### PR TITLE
feat: update attack stamina costs

### DIFF
--- a/Source/ACE.Server/WorldObjects/Creature_Vitals.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Vitals.cs
@@ -140,7 +140,7 @@ namespace ACE.Server.WorldObjects
             double currentTick = 0.0;
 
             float maxVital = vital.MaxValue;
-            float diminishedMaxVital = maxVital * (500 / (500 + maxVital));
+            float diminishedMaxVital = maxVital * (1000 / (1000 + maxVital));
 
             var vitalTypeBaseMod = vital == Stamina ? 5 : 10;
 

--- a/Source/ACE.Server/WorldObjects/Player_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Combat.cs
@@ -885,7 +885,7 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Calculates the amount of stamina required to perform this attack
         /// </summary>
-        public int GetAttackStamina(PowerAccuracy powerAccuracy)
+        public int GetAttackStamina(PowerAccuracy powerAccuracy, float attackAnimLength, bool dualWieldStaminaBonus = false)
         {
             // Stamina cost for melee and missile attacks is based on the total burden of what you are holding
             // in your hands (main hand and offhand), and your power/accuracy bar.
@@ -922,7 +922,7 @@ namespace ACE.Server.WorldObjects
 
             var weightClassPenalty = (float)(1 + GetArmorResourcePenalty());
             
-            var baseCost = StaminaTable.GetStaminaCost(weaponTier, powerAccuracyLevel, weaponSpeed, weightClassPenalty);
+            var baseCost = StaminaTable.GetStaminaCost(weaponTier, dualWieldStaminaBonus, attackAnimLength, powerAccuracyLevel, weaponSpeed, weightClassPenalty);
 
             // COMBAT ABILITY - Power Shot
             if (combatAbility == CombatAbility.Powershot && AccuracyLevel == 1.0f)

--- a/Source/ACE.Server/WorldObjects/Player_Missile.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Missile.cs
@@ -243,7 +243,8 @@ namespace ACE.Server.WorldObjects
                 // stamina usage
                 // TODO: ensure enough stamina for attack
                 // TODO: verify formulas - double/triple cost for bow/xbow?
-                var staminaCost = GetAttackStamina(GetAccuracyRange());
+                var missileLauncherAnimLength = 2.93f;
+                var staminaCost = GetAttackStamina(GetAccuracyRange(), missileLauncherAnimLength);
                 UpdateVitalDelta(Stamina, -staminaCost);
 
                 var combatAbility = CombatAbility.None;


### PR DESCRIPTION
- Incorporate weapon animation base length into the cost formula, scaling down costs with faster weapons.
- Increase the base stamina cost of an attack from '20 per tier' -> '20 per tier + 20'.
- Reduce diminishing return of vital regeneration (increasing regen rates slightly).
- Reduce cost of dual wield attacks if Dual Wield is specialized.