### PR TITLE
feat: balance stamina costs, missile animation changes

### DIFF
--- a/Source/ACE.Server/Entity/StaminaTable.cs
+++ b/Source/ACE.Server/Entity/StaminaTable.cs
@@ -46,38 +46,28 @@ namespace ACE.Server.Entity
 
         public static float GetStaminaCost(int weaponTier, bool dualWieldStaminaBonus, float animLength = 3.0f, float powerAccuracyLevel = 0.0f, int weaponSpeed = 0, float? weightClassPenalty = null)
         {
-            // Weapon tier mod
+            // Weapon tier and base cost
             weaponTier = Math.Clamp(weaponTier - 1, 0, 7);
-
-            // Tier Cost
-            var baseCost = (weaponTier + 1) * 20;
+            var baseCost = weaponTier * 20 + 20;
 
             // PowerLevel mod reduces stamina cost exponentially: i.e.  100% = 100% Cost,  75% = 56% Cost,  50% = 25% Cost,  25% = 6.25% Cost,  0% = 0% Cost (min 1)
             var powerLevelMod = (float)Math.Pow(powerAccuracyLevel, 2);
 
             // WeaponAnimationLength mod
             var maxAnimLength = 3.0f;
-            var animLengthMod = animLength / maxAnimLength;
-
-            // WeaponSpeed mod can range from 66.66% to 100%, depending on weapon speed (0-100)
-            var minSpeedMod = 200.0f / 3;  
-            var speedModRange = 100.0f / 3;
-            var weaponSpeedMod = minSpeedMod + (float)weaponSpeed / 100 * speedModRange;
-            weaponSpeedMod *= 0.01f;
+            var animLengthMod = (animLength + powerAccuracyLevel) / maxAnimLength;
 
             // Weight class resource penalty mod
             var weightClassPenaltyMod = weightClassPenalty ?? 1.0f;
 
-            // Dual wield spec mod
-            var dualWieldSpecMod = dualWieldStaminaBonus ? 0.75f : 1.0f;
-
             // Final calculation
-            var finalCost = baseCost * powerLevelMod * weaponSpeedMod * animLengthMod * weightClassPenaltyMod * dualWieldSpecMod;
+            var finalCost = baseCost * powerLevelMod * animLengthMod * weightClassPenaltyMod;
 
             //Console.WriteLine($"GetStaminaCost - Final Cost: {finalCost}\n" +
-            //    $" -WeaponTier: {weaponTier} WeightClassPenalty: {weightClassPenalty}\n" +
+            //    $" -Base Cost: {baseCost}\n" +
+            //    $" -WeaponTier: {weaponTier}\n" +
+            //    $" -WeightClassPenalty: {weightClassPenalty}\n" +
             //    $" -PowerLevel: {powerAccuracyLevel} PowerLevelMod: {powerLevelMod}\n" +
-            //    $" -WeaponSpeed: {weaponSpeed} WeaponSpeedMod: {weaponSpeedMod}\n" +
             //    $" -WeaponAnim: {animLength} AnimLengthMod: {animLengthMod}\n" +
             //    $" -DualWield: {dualWieldSpecMod}");
 

--- a/Source/ACE.Server/Managers/PropertyManager.cs
+++ b/Source/ACE.Server/Managers/PropertyManager.cs
@@ -604,7 +604,7 @@ namespace ACE.Server.Managers
                 ("require_spell_comps", new Property<bool>(true, "if FALSE, spell components are no longer required to be in inventory to cast spells. defaults to enabled, as in retail")),
                 ("safe_spell_comps", new Property<bool>(false, "if TRUE, disables spell component burning for everyone")),
                 ("salvage_handle_overages", new Property<bool>(false, "in retail, if 2 salvage bags were combined beyond 100 structure, the overages would be lost")),
-                ("show_ammo_buff", new Property<bool>(false, "shows active enchantments such as blood drinker on equipped missile ammo during appraisal")),
+                ("show_ammo_buff", new Property<bool>(true, "shows active enchantments such as blood drinker on equipped missile ammo during appraisal")),
                 ("show_aura_buff", new Property<bool>(false, "shows active aura enchantments on wielded items during appraisal")),
                 ("show_dat_warning", new Property<bool>(false, "if TRUE, will alert player (dat_warning_msg) when client attempts to download from server and boot them from game, disabled by default")),
                 ("show_dot_messages", new Property<bool>(false, "enabled, shows combat messages for DoT damage ticks. defaults to disabled, as in retail")),

--- a/Source/ACE.Server/Physics/Animation/MotionTable.cs
+++ b/Source/ACE.Server/Physics/Animation/MotionTable.cs
@@ -474,11 +474,6 @@ namespace ACE.Server.Physics.Animation
 
             var motionTable = DatManager.PortalDat.ReadFromDat<DatLoader.FileTypes.MotionTable>(motionTableId);
 
-            //Normalize Bow and Atlatl Reload Animations to Crossbow's
-            if (motion == MotionCommand.Reload && (stance == MotionStance.BowCombat || stance == MotionStance.AtlatlCombat))
-                return 0.26190478f / speed;
-
-            //Console.WriteLine($"AnimLength without speedMod({speed}): {stance} {motion} {motionTable.GetAnimationLength(stance, motion, null)}");
             return motionTable.GetAnimationLength(stance, motion, null) / speed;
         }
 
@@ -495,18 +490,7 @@ namespace ACE.Server.Physics.Animation
                 currentMotion = MotionCommand.Ready;
             }
 
-            // Normalize Bow/Crossbow/Atlatl link time animation length
-            {
-                animLength += motionTable.GetAnimationLength(stance, motion, currentMotion) / speed;
-
-                var crossbowLinkTime = 1.2619047f;
-                //Console.WriteLine($"GetAnimationLength: {stance} {motion} BaseAnimLength: {animLength + crossbowLinkTime}");
-
-                if (stance == MotionStance.AtlatlCombat || stance == MotionStance.BowCombat || stance == MotionStance.CrossbowCombat)
-                {
-                    animLength += crossbowLinkTime / speed;
-                }
-            }
+            animLength += motionTable.GetAnimationLength(stance, motion, currentMotion) / speed;
 
             return animLength;
         }

--- a/Source/ACE.Server/WorldObjects/Player_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Combat.cs
@@ -882,6 +882,8 @@ namespace ACE.Server.WorldObjects
             return weaponTier;
         }
 
+        //private double TimeSinceLastStaminaUse = 0;
+
         /// <summary>
         /// Calculates the amount of stamina required to perform this attack
         /// </summary>
@@ -939,6 +941,12 @@ namespace ACE.Server.WorldObjects
             var staminaCost = Math.Max(baseCost, 1);
 
             //Console.WriteLine($"GetAttackStamina({powerAccuracy}) - burden: {burden}, baseCost: {baseCost}, staminaMod: {staminaMod}, staminaCost: {staminaCost}");
+
+            //var currentTime = Time.GetUnixTime();
+            //var difference = currentTime - TimeSinceLastStaminaUse;
+            //TimeSinceLastStaminaUse = currentTime;
+            //var staminaPerTime = baseCost / difference;
+            //Console.WriteLine($"StaminaUsed: {Math.Round(baseCost, 2)}, TimeBetweenAttacks: {Math.Round(difference, 2)},  StaminaPerTime: {Math.Round(staminaPerTime, 2)}");
 
             return (int)Math.Round(staminaCost);
         }

--- a/Source/ACE.Server/WorldObjects/Player_Melee.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Melee.cs
@@ -308,7 +308,7 @@ namespace ACE.Server.WorldObjects
 
             // stamina usage
             // TODO: ensure enough stamina for attack
-            var staminaCost = GetAttackStamina(GetPowerRange(), MotionTable.GetAnimationLength(MotionTableId, CurrentMotionState.Stance, GetSwingMotion()), dualWieldStaminaBonus);
+            var staminaCost = GetAttackStamina(GetPowerRange(), animLength, dualWieldStaminaBonus);
             UpdateVitalDelta(Stamina, -staminaCost);
 
             var combatAbility = CombatAbility.None;

--- a/Source/ACE.Server/WorldObjects/Player_Missile.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Missile.cs
@@ -1,11 +1,12 @@
 using System;
 using System.Numerics;
-using ACE.Common;
+
 using ACE.Entity.Enum;
 using ACE.Server.Entity.Actions;
 using ACE.Server.Network.GameEvent.Events;
 using ACE.Server.Network.GameMessages.Messages;
 using ACE.Server.Physics.Animation;
+using Serilog;
 
 namespace ACE.Server.WorldObjects
 {
@@ -192,8 +193,6 @@ namespace ACE.Server.WorldObjects
             // point of no return beyond this point -- cannot be cancelled
             actionChain.AddAction(this, () => Attacking = true);
 
-            EndStealth();
-
             if (subsequent)
             {
                 // client shows hourglass, until attack done is received
@@ -225,11 +224,17 @@ namespace ACE.Server.WorldObjects
                 OnAttackDone();
                 return;
             }
-            //Console.WriteLine("\n\n -- ANIMATION TEST START --");
-            var animSpeed = GetAnimSpeed();
+
             var launchTime = EnqueueMotionPersist(actionChain, aimLevel);
-            //Console.WriteLine("LaunchTime");
-            //Console.WriteLine($" -AddDelaySeconds({launchTime})");
+
+            // reload animation
+            var animSpeed = GetAnimSpeed();
+            var reloadTime = EnqueueMotionPersist(actionChain, stance, MotionCommand.Reload, animSpeed);
+
+            // reset for next projectile
+            EnqueueMotionPersist(actionChain, stance, MotionCommand.Ready);
+            var linkTime = MotionTable.GetAnimationLength(MotionTableId, stance, MotionCommand.Reload, MotionCommand.Ready);
+            //var cycleTime = MotionTable.GetCycleLength(MotionTableId, CurrentMotionState.Stance, MotionCommand.Ready);
 
             // launch projectile
             actionChain.AddAction(this, () =>
@@ -243,7 +248,7 @@ namespace ACE.Server.WorldObjects
                 // stamina usage
                 // TODO: ensure enough stamina for attack
                 // TODO: verify formulas - double/triple cost for bow/xbow?
-                var missileLauncherAnimLength = 2.93f;
+                var missileLauncherAnimLength = reloadTime + linkTime;
                 var staminaCost = GetAttackStamina(GetAccuracyRange(), missileLauncherAnimLength);
                 UpdateVitalDelta(Stamina, -staminaCost);
 
@@ -275,35 +280,12 @@ namespace ACE.Server.WorldObjects
                 return;
             }
 
-            // reload animation
-            //Console.WriteLine("Reload Animation");
-            var reloadTime = EnqueueMotionPersist(actionChain, stance, MotionCommand.Reload, animSpeed);
-            //Console.WriteLine($" -Missile Anim Speed: {animSpeed} Reload Time: {reloadTime}");
-
-            // reset for next projectile
-            //Console.WriteLine("Reset for next projectile");
-            EnqueueMotionPersist(actionChain, stance, MotionCommand.Ready);
-
-            //Console.WriteLine($"Link Time");
-            var linkTime = MotionTable.GetAnimationLength(MotionTableId, stance, MotionCommand.Reload, MotionCommand.Ready, animSpeed);
-
-            // Missile Weapon normalizing
-                var linkTimeBuffer = 0.5f;
-                var atlatlLaunchTime = 0.377777779f;
-                var crossbowLaunchTime = 0.06666667f;
-
-                if (stance == MotionStance.BowCombat || stance == MotionStance.CrossbowCombat)
-                    linkTime = MotionTable.GetAnimationLength(MotionTableId, stance, MotionCommand.Reload, MotionCommand.Ready, animSpeed) + linkTimeBuffer + (atlatlLaunchTime - crossbowLaunchTime);
-                else if (stance == MotionStance.AtlatlCombat)
-                    linkTime = MotionTable.GetAnimationLength(MotionTableId, stance, MotionCommand.Reload, MotionCommand.Ready, animSpeed) + linkTimeBuffer;
-
             actionChain.AddAction(this, () =>
             {
                 if (CombatMode == CombatMode.Missile)
                     EnqueueBroadcast(new GameMessageParentEvent(this, ammo, ACE.Entity.Enum.ParentLocation.RightHand, ACE.Entity.Enum.Placement.RightHandCombat));
             });
-            //Console.WriteLine($" -AddDelaySeconds({linkTime})\n");
-            //Console.WriteLine($"TOTAL TIME: {launchTime+reloadTime+linkTime}\n\n");
+
             actionChain.AddDelaySeconds(linkTime);
 
             actionChain.AddAction(this, () =>
@@ -323,7 +305,6 @@ namespace ACE.Server.WorldObjects
 
                     NextRefillTime = DateTime.UtcNow.AddSeconds(nextRefillTime);
                     nextAttack.AddDelaySeconds(nextRefillTime);
-                    //Console.WriteLine($"NextAttack: {nextRefillTime}");
 
                     // perform next attack
                     nextAttack.AddAction(this, () => { LaunchMissile(target, attackSequence, stance, true); });


### PR DESCRIPTION
-Stamina cost formula includes the final 'attacks per second' of an attack. Faster weapons cost proportionally less stamina. This also scales with all gains to weapons speed, including quickness and swift killer buffs. Attacking with faster weapons faster will never lead to more stamina use overtime.

-Reverted missile animation shenanigans back to retail state.