### PR TITLE
feat: update wield reqs

### DIFF
--- a/Source/ACE.Server/Entity/DamageEvent.cs
+++ b/Source/ACE.Server/Entity/DamageEvent.cs
@@ -387,7 +387,7 @@ namespace ACE.Server.Entity
                     if (pkBattle)
                         DamageRatingMod = Creature.AdditiveCombine(DamageRatingMod, PkDamageMod);
 
-                    DamageBeforeMitigation = BaseDamageMod.MaxDamage * AttributeMod * PowerMod * SlayerMod * DamageRatingMod * CriticalDamageMod;
+                    DamageBeforeMitigation = BaseDamageMod.MaxDamage * AttributeMod * PowerMod * SlayerMod * DamageRatingMod * CriticalDamageMod * powershotMod * dualWieldDamageMod * twohandedCombatDamageMod;
                 }
             }
 
@@ -1087,6 +1087,7 @@ namespace ACE.Server.Entity
 
         private void DpsLogging(Player playerAttacker)
         {
+            Console.WriteLine($"\n---- {Weapon.Name} ----");
             var currentTime = Time.GetUnixTime();
             var timeSinceLastAttack = currentTime - playerAttacker.LastAttackedCreatureTime;
             Console.WriteLine($"\nCurrentTime: {currentTime}, LastAttackTime: {playerAttacker.LastAttackedCreatureTime} TimeBetweenAttacks: {timeSinceLastAttack}");

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Caster.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Caster.cs
@@ -132,17 +132,20 @@ namespace ACE.Server.Factories
                 MutateColor(wo);
             }
 
-            // Wield Reqs
-            wo.WieldRequirements = WieldRequirement.RawSkill;
-            var wieldDiff = RollWieldDifficulty(profile.Tier, TreasureWeaponType.Caster);
-            wo.WieldDifficulty = wieldDiff > 0 ? wieldDiff : null;
-
             // Bonus Resto/Elemental %
             var damagePercentile = 0.0;
             if (wo.W_DamageType == DamageType.Undef)
-                wo.WieldSkillType = (int)Skill.LifeMagic;
+                wo.WieldSkillType2 = (int)Skill.LifeMagic;
             else
-                wo.WieldSkillType = (int)Skill.WarMagic;
+                wo.WieldSkillType2 = (int)Skill.WarMagic;
+
+            // Wield Reqs
+            wo.WieldRequirements = WieldRequirement.RawAttrib;
+            wo.WieldDifficulty = RollWieldDifficulty(profile.Tier, TreasureWeaponType.MeleeWeapon);
+            wo.WieldSkillType = GetWeaponPrimaryAttribute((Skill)wo.WieldSkillType2);
+
+            wo.WieldRequirements2 = WieldRequirement.Training;
+            wo.WieldDifficulty2 = 1;
 
             // Roll Elemental Damage Mod
             TryMutateCasterWeaponDamage(wo, roll, profile, out damagePercentile);

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Chance.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Chance.cs
@@ -23,11 +23,11 @@ namespace ACE.Server.Factories
                         case 1: wield = 50; break;
                         case 2: wield = 100; break;
                         case 3: wield = 150; break;
-                        case 4: wield = 200; break;
-                        case 5: wield = 225; break;
-                        case 6: wield = 250; break;
-                        case 7: wield = 275; break;
-                        case 8: wield = 300; break;
+                        case 4: wield = 175; break;
+                        case 5: wield = 200; break;
+                        case 6: wield = 220; break;
+                        case 7: wield = 240; break;
+                        case 8: wield = 360; break;
                     }
                     break;
 
@@ -38,11 +38,11 @@ namespace ACE.Server.Factories
                         case 1: wield = 50; break;
                         case 2: wield = 100; break;
                         case 3: wield = 150; break;
-                        case 4: wield = 200; break;
-                        case 5: wield = 225; break;
-                        case 6: wield = 250; break;
-                        case 7: wield = 275; break;
-                        case 8: wield = 300; break;
+                        case 4: wield = 175; break;
+                        case 5: wield = 200; break;
+                        case 6: wield = 220; break;
+                        case 7: wield = 240; break;
+                        case 8: wield = 360; break;
                     }
                     break;
 
@@ -53,11 +53,11 @@ namespace ACE.Server.Factories
                         case 1: wield = 50; break;
                         case 2: wield = 100; break;
                         case 3: wield = 150; break;
-                        case 4: wield = 200; break;
-                        case 5: wield = 225; break;
-                        case 6: wield = 250; break;
-                        case 7: wield = 275; break;
-                        case 8: wield = 300; break;
+                        case 4: wield = 175; break;
+                        case 5: wield = 200; break;
+                        case 6: wield = 220; break;
+                        case 7: wield = 240; break;
+                        case 8: wield = 360; break;
                     }
                     break;
             }

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Clothing.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Clothing.cs
@@ -156,7 +156,7 @@ namespace ACE.Server.Factories
             var armorWeightClass = GetArmorWeightClass(wo.WeenieClassId);
             wo.ArmorWeightClass = (int)armorWeightClass;
 
-            // wield requirements (attibute, type, amount)
+            // wield requirements (attribute, type, amount)
             wo.WieldSkillType = 0;
 
             if (profile.Tier > 0)
@@ -167,15 +167,13 @@ namespace ACE.Server.Factories
                     wo.WieldRequirements = WieldRequirement.Level;
                     wo.WieldDifficulty = GetArmorLevelReq(profile.Tier);
                 }
-                // armor uses a custom "weight class requirement", so we disable the standard wield reqs
+                // armor req based on weight class
                 else
                 {
-                    wo.WieldRequirements = WieldRequirement.Invalid;
-                    wo.WieldDifficulty = null;
-                }    
-
-                // Set WeightClassRequirement
-                wo.WeightClassReqAmount = GetWieldDifficultyPerTier(profile.Tier);
+                    wo.WieldRequirements = WieldRequirement.RawAttrib;
+                    wo.WieldSkillType = GetWeightClassAttributeReq((ArmorWeightClass)wo.ArmorWeightClass);
+                    wo.WieldDifficulty = GetWieldDifficultyPerTier(profile.Tier);
+                }
             }
 
             AssignArmorLevel(wo, profile.Tier, armorType);
@@ -1564,6 +1562,17 @@ namespace ACE.Server.Factories
                 return true;
 
             return false;
+        }
+
+        private static int GetWeightClassAttributeReq(ArmorWeightClass weightClass)
+        {
+            switch (weightClass)
+            {
+                default:
+                case ArmorWeightClass.Heavy: return 1; // Strength
+                case ArmorWeightClass.Light: return 4; // Coordination
+                case ArmorWeightClass.Cloth: return 6; // Self
+            }
         }
     }
 }

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Melee.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Melee.cs
@@ -130,9 +130,13 @@ namespace ACE.Server.Factories
             }
 
             // Wield Difficulty
+            wo.WieldRequirements = WieldRequirement.RawAttrib;
             wo.WieldDifficulty = RollWieldDifficulty(profile.Tier, TreasureWeaponType.MeleeWeapon);
-            wo.WieldRequirements = WieldRequirement.RawSkill;
-            wo.WieldSkillType = (int)wo.WeaponSkill;
+            wo.WieldSkillType = GetWeaponPrimaryAttribute(wo.WeaponSkill);
+
+            wo.WieldRequirements2 = WieldRequirement.Training;
+            wo.WieldDifficulty2 = 1;
+            wo.WieldSkillType2 = GetWeaponWieldSkill(wo.WeaponSkill);
 
             //Console.WriteLine($"{wo.Name} WieldDiff: {wo.WieldDifficulty} WieldReq: {wo.WieldRequirements} WieldSkill: { wo.WieldSkillType}");
 

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Missile.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Missile.cs
@@ -98,12 +98,13 @@ namespace ACE.Server.Factories
             }
 
             // Wield Difficulty
+            wo.WieldRequirements = WieldRequirement.RawAttrib;
             wo.WieldDifficulty = RollWieldDifficulty(profile.Tier, TreasureWeaponType.MissileWeapon);
-            if (wo.WieldDifficulty > 0)
-            {
-                wo.WieldRequirements = WieldRequirement.RawSkill;
-                wo.WieldSkillType = (int)wo.WeaponSkill;
-            }
+            wo.WieldSkillType = GetWeaponPrimaryAttribute(wo.WeaponSkill);
+
+            wo.WieldRequirements2 = WieldRequirement.Training;
+            wo.WieldDifficulty2 = 1;
+            wo.WieldSkillType2 = GetWeaponWieldSkill(wo.WeaponSkill);
 
             // Damage
             TryMutateMissileWeaponDamage(wo, roll, profile, out var maxPossibleDamageMod);

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Spells.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Spells.cs
@@ -87,14 +87,14 @@ namespace ACE.Server.Factories
         {
             SpellId procSpellId = SpellId.Undef;
 
-            wo.WieldRequirements2 = WieldRequirement.Training;
-            wo.WieldDifficulty2 = 1;
+            wo.WieldRequirements3 = WieldRequirement.Training;
+            wo.WieldDifficulty3 = 1;
 
             var warSpell = ThreadSafeRandom.Next(0, 1) == 0 ? true : false;
             if (warSpell)
-                wo.WieldSkillType2 = (int)Skill.WarMagic;
+                wo.WieldSkillType3 = (int)Skill.WarMagic;
             else
-                wo.WieldSkillType2 = (int)Skill.LifeMagic;
+                wo.WieldSkillType3 = (int)Skill.LifeMagic;
 
             if (roll.IsMeleeWeapon)
                 procSpellId = MeleeSpells.RollProc(wo, profile, warSpell);

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Weapon.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Weapon.cs
@@ -361,6 +361,60 @@ namespace ACE.Server.Factories
                 case 8: return 110.0f;
             }
         }
+
+        private static int GetWeaponPrimaryAttribute(Skill weaponSkill)
+        {
+            switch(weaponSkill)
+            {
+                default:
+                case Skill.Sword:
+                case Skill.Axe:
+                case Skill.Mace:
+                case Skill.Spear:
+                case Skill.TwoHandedCombat:
+                case Skill.ThrownWeapon:
+                    return 1;
+                case Skill.Bow:
+                case Skill.Crossbow:
+                case Skill.MissileWeapons:
+                case Skill.Dagger:
+                case Skill.Staff:
+                case Skill.UnarmedCombat:
+                    return 4;
+                case Skill.WarMagic:
+                case Skill.LifeMagic:
+                    return 6;
+            }
+        }
+
+        private static int GetWeaponWieldSkill(Skill weaponSkill)
+        {
+            switch (weaponSkill)
+            {
+                default:
+                case Skill.Sword:
+                case Skill.Axe:
+                case Skill.Mace:
+                case Skill.Spear:
+                    return (int)Skill.HeavyWeapons;
+                case Skill.ThrownWeapon:
+                    return (int)Skill.ThrownWeapon;
+                case Skill.Bow:
+                case Skill.Crossbow:
+                case Skill.MissileWeapons:
+                    return (int)Skill.Bow;
+                case Skill.Dagger:
+                    return (int)Skill.Dagger;
+                case Skill.Staff:
+                    return (int)Skill.Staff;
+                case Skill.UnarmedCombat:
+                    return (int)Skill.UnarmedCombat;
+                case Skill.WarMagic:
+                    return (int)Skill.WarMagic;
+                case Skill.LifeMagic:
+                    return (int)Skill.LifeMagic;
+            }
+        }
     }
 }
 

--- a/Source/ACE.Server/Network/Structure/AppraiseInfo.cs
+++ b/Source/ACE.Server/Network/Structure/AppraiseInfo.cs
@@ -658,35 +658,42 @@ namespace ACE.Server.Network.Structure
 
             // -- ARMOR --
 
+            // Aegis Level
+            if (PropertiesInt.TryGetValue(PropertyInt.AegisLevel, out var aegisLevel) && aegisLevel != 0)
+            {
+                var wielder = (Creature)wo.Wielder;
+                if (wielder != null)
+                {
+                    var totalAegisLevel = wielder.GetAegisLevel();
+                    extraPropertiesText += $"Aegis Level: {aegisLevel}  ({totalAegisLevel})\n";
+                }
+                else
+                    extraPropertiesText += $"Aegis Level: {aegisLevel}\n\n";
+
+                hasExtraPropertiesText = true;
+            }
+
             // Armor Weight Class
             if (PropertiesInt.TryGetValue(PropertyInt.ArmorWeightClass, out var armorWieghtClass) && armorWieghtClass > 0)
             {
-                if (PropertiesInt.TryGetValue(PropertyInt.WeightClassReqAmount, out var weightClassReqAmount) && weightClassReqAmount > 0)
+                var weightClassText = "";
+
+                if (wo.ArmorWeightClass == (int)ArmorWeightClass.Cloth)
                 {
-                    var weightClassText = "";
-                    var wieldAttributeText = "";
-
-                    if (wo.ArmorWeightClass == (int)ArmorWeightClass.Cloth)
-                    {
-                        weightClassText = "Cloth";
-                        wieldAttributeText = "base Focus or base Self";
-                    }
-                    else if (wo.ArmorWeightClass == (int)ArmorWeightClass.Light)
-                    {
-                        weightClassText = "Light";
-                        wieldAttributeText = "base Coordination or base Quickness";
-                    }
-                    else if (wo.ArmorWeightClass == (int)ArmorWeightClass.Heavy)
-                    {
-                        weightClassText = "Heavy";
-                        wieldAttributeText = "base Strength or base Endurance";
-                    }
-
-                    extraPropertiesText += $"Weight Class: {weightClassText}\n" +
-                        $"Wield requires {wieldAttributeText}: {weightClassReqAmount}\n";
-
-                    hasExtraPropertiesText = true;
+                    weightClassText = "Cloth";
                 }
+                else if (wo.ArmorWeightClass == (int)ArmorWeightClass.Light)
+                {
+                    weightClassText = "Light";
+                }
+                else if (wo.ArmorWeightClass == (int)ArmorWeightClass.Heavy)
+                {
+                    weightClassText = "Heavy";
+                }
+
+                extraPropertiesText += $"Weight Class: {weightClassText}\n";
+
+                hasExtraPropertiesText = true;
             }
 
             // Armor Penalty - Attack Resource
@@ -700,22 +707,7 @@ namespace ACE.Server.Network.Structure
                     extraPropertiesText += $"Penalty to Stamina/Mana usage: {Math.Round((armoResourcePenalty) * 100, 1)}%  ({Math.Round((double)(totalArmorResourcePenalty * 100), 2)}%)\n";
                 }
                 else
-                    extraPropertiesText += $"Penalty to Stamina/Mana usage: {Math.Round((armoResourcePenalty) * 100, 1)}%\n\n";
-
-                hasExtraPropertiesText = true;
-            }
-
-            // Aegis Level
-            if (PropertiesInt.TryGetValue(PropertyInt.AegisLevel, out var aegisLevel) && aegisLevel != 0)
-            {
-                var wielder = (Creature)wo.Wielder;
-                if (wielder != null)
-                {
-                    var totalAegisLevel = wielder.GetAegisLevel();
-                    extraPropertiesText += $"Aegis Level: {aegisLevel}  ({totalAegisLevel})\n";
-                }
-                else
-                    extraPropertiesText += $"Aegis Level: {aegisLevel}\n";
+                    extraPropertiesText += $"Penalty to Stamina/Mana usage: {Math.Round((armoResourcePenalty) * 100, 1)}%\n";
 
                 hasExtraPropertiesText = true;
             }


### PR DESCRIPTION
* Weapons now use base attributes and trained weapon skill for wield reqs.
   * **Martial Weapons:** Strength and trained Martial Weapons.
   * **Thrown Weapons:** Strength and trained Thrown Weapons.
   * **Bows:** Coordination and trained Bows.
   * **Dagger:** Coordination and trained Daggers. 
   * **Staff:** Coordination and trained Staff.
   * **Unarmed:** Coordination and trained Unarmed Combat.
   * **War Magic:** Self and trained War Magic.
   * **Life Magic:** Self and trained Life Magic.
* Armor now only uses one attribute type for it's wield req.
   * **Heavy:** Strength.
   * **Light:** Coordination.
   * **Cloth:** Self.