### PR TITLE
update: empowered scarab cast on strike support

### DIFF
--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -337,7 +337,13 @@ namespace ACE.Server.WorldObjects
                 // TODO: instead of ProjectileLauncher is Caster, perhaps a SpellProjectile.CanProc bool that defaults to true,
                 // but is set to false if the source of a spell is from a proc, to prevent multi procs?
 
-                if (sourceCreature != null && ProjectileTarget != null && !FromProc)
+                // EMPOWERED SCARAB - Detonation Check for Cast-On-Strike
+                if (player != null && FromProc)
+                {
+                    player.CheckForEmpoweredScarabOnCastEffects(target, Spell, true, creatureTarget);
+                }
+
+                if (sourceCreature != null && ProjectileTarget != null && !FromProc) // From proc prevents detonation
                 {
                     // TODO figure out why cross-landblock group operations are happening here. We shouldn't need this code Mag-nus 2021-02-09
                     bool threadSafe = true;
@@ -357,6 +363,8 @@ namespace ACE.Server.WorldObjects
                         // EMPOWERED SCARAB - Detonate
                         if (player != null)
                             player.CheckForEmpoweredScarabOnCastEffects(target, Spell, false, creatureTarget);
+
+                     
                     }
                     else
                     {

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -343,7 +343,7 @@ namespace ACE.Server.WorldObjects
                     player.CheckForEmpoweredScarabOnCastEffects(target, Spell, true, creatureTarget);
                 }
 
-                if (sourceCreature != null && ProjectileTarget != null && !FromProc) // From proc prevents detonation
+                if (sourceCreature != null && ProjectileTarget != null && !FromProc)
                 {
                     // TODO figure out why cross-landblock group operations are happening here. We shouldn't need this code Mag-nus 2021-02-09
                     bool threadSafe = true;
@@ -363,8 +363,6 @@ namespace ACE.Server.WorldObjects
                         // EMPOWERED SCARAB - Detonate
                         if (player != null)
                             player.CheckForEmpoweredScarabOnCastEffects(target, Spell, false, creatureTarget);
-
-                     
                     }
                     else
                     {

--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -56,7 +56,7 @@ namespace ACE.Server.WorldObjects
                 foreach (var fellow in fellows.Values)
                     TryCastSpell_Inner(spell, fellow, itemCaster, weapon, isWeaponSpell, fromProc, tryResist, showMsg);
             }
-            else
+ 
                 TryCastSpell_Inner(spell, target, itemCaster, weapon, isWeaponSpell, fromProc, tryResist, showMsg);
         }
 
@@ -349,6 +349,16 @@ namespace ACE.Server.WorldObjects
                 }
             }
 
+            // Empowered Scarabs
+
+            if (this is Player)
+            {
+                if (targetCreature != null)
+                {
+                    var player = this as Player;
+                    player.CheckForEmpoweredScarabOnCastEffects(targetCreature, spell, true, null, false);
+                }
+            }
             switch (spell.MetaSpellType)
             {
                 case SpellType.Enchantment:

--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -56,7 +56,7 @@ namespace ACE.Server.WorldObjects
                 foreach (var fellow in fellows.Values)
                     TryCastSpell_Inner(spell, fellow, itemCaster, weapon, isWeaponSpell, fromProc, tryResist, showMsg);
             }
- 
+            else
                 TryCastSpell_Inner(spell, target, itemCaster, weapon, isWeaponSpell, fromProc, tryResist, showMsg);
         }
 

--- a/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
@@ -1005,10 +1005,11 @@ namespace ACE.Server.WorldObjects
             {
                 if (playerAttacker != null)
                 {
+                    var scarabReduction = playerAttacker.GetEmpoweredScarabManaReductionMod();
                     if (playerAttacker.Mana.Current < spell.BaseMana)
                         return;
 
-                    playerAttacker.UpdateVitalDelta(playerAttacker.Mana, (int)(spell.BaseMana * -1));
+                     playerAttacker.UpdateVitalDelta(playerAttacker.Mana, (int)(spell.BaseMana * (scarabReduction * -1)));
                 }
 
                 attacker.TryCastSpell(spell, target, itemCaster, itemCaster, true, true);


### PR DESCRIPTION
- Empowered scarabs now proc appropriately with cast-on-strike weapons
- does not fix surge of crushing/protection visual errors
- ManaLowering category for Growth and Vuln procs is for the ManaDrain Spell which players don't have access to. Drain Mana is a Mana transfer to category, but since Stamina to Mana etc. are as well I didn't fiddle with this for now.  Growth proc on enemies seems a bit weak atm anyway so it may be worth a bit of a redo anyway.