### PR TITLE
feat: simple ai health recovery

### DIFF
--- a/Source/ACE.Server/WorldObjects/Monster_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Magic.cs
@@ -86,6 +86,17 @@ namespace ACE.Server.WorldObjects
 
                 var rng = ThreadSafeRandom.Next(0.0f, 1.0f);
 
+                // Simplified Ai-Acquire Health - place heals/drains at top of Spellbook with probability of 2, as health decreases prob of casting increases.
+
+                if (spell.Value == 2.0f)
+                {
+                    var maxHealth = (float)this.Health.MaxValue;
+                    var currentHealth = (float)this.Health.Current;
+
+                    probability = ((maxHealth - currentHealth) / maxHealth) / 3;
+
+                }
+
                 if (rng < probability)
                 {
                     CurrentSpell = new Spell(spell.Key);

--- a/Source/ACE.Server/WorldObjects/Monster_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Magic.cs
@@ -93,7 +93,10 @@ namespace ACE.Server.WorldObjects
                     var maxHealth = (float)this.Health.MaxValue;
                     var currentHealth = (float)this.Health.Current;
 
-                    probability = ((maxHealth - currentHealth) / maxHealth) / 3;
+                    var maxProbability = 0.33f;
+                    var reciprocal = 1 / maxProbability;
+
+                    probability = ((maxHealth - currentHealth) / maxHealth) / reciprocal;
 
                 }
 


### PR DESCRIPTION
- adds a bit of logic to monster spellcasting to weight the likelihood of casting any with values set to 2.0

- most likely will be used with drain/heal self but could increase risk by adding more dangerous damage spells this way

- todo: increase healing effectiveness on monsters to account for their higher base health