### PR TITLE
fix: increase vis range

### DIFF
--- a/Source/ACE.Server/WorldObjects/Monster_Awareness.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Awareness.cs
@@ -638,6 +638,9 @@ namespace ACE.Server.WorldObjects
                 {
                     var visualAwarenessRange = (float)((VisualAwarenessRange ?? VisualAwarenessRange_Default) * PropertyManager.GetDouble("mob_awareness_range").Item);
 
+                    if (!Location.Indoors && visualAwarenessRange < 45f && Level > 10)
+                        visualAwarenessRange = 45f;
+
                     _visualAwarenessRangeSq = visualAwarenessRange * visualAwarenessRange;
                 }
 


### PR DESCRIPTION
- increases visual awareness range for all outdoors monsters > level 10 to a min of 45