### PR TITLE
Spell damage balancing

### DIFF
--- a/Source/ACE.DatLoader/DatManager.cs
+++ b/Source/ACE.DatLoader/DatManager.cs
@@ -12,9 +12,9 @@ namespace ACE.DatLoader
         private static int count;
 
         private static int ITERATION_CELL = 30000;
-        private static int ITERATION_PORTAL = 30011;
+        private static int ITERATION_PORTAL = 30012;
         private static int ITERATION_HIRES = 497;
-        private static int ITERATION_LANGUAGE = 30003;
+        private static int ITERATION_LANGUAGE = 30004;
         public static CellDatDatabase CellDat { get; private set; }
 
         public static PortalDatDatabase PortalDat { get; private set; }

--- a/Source/ACE.Server/Entity/DamageEvent.cs
+++ b/Source/ACE.Server/Entity/DamageEvent.cs
@@ -237,7 +237,7 @@ namespace ACE.Server.Entity
             // ---- DAMAGE RATING ----
             PowerMod = attacker.GetPowerMod(Weapon);
             
-            AttributeMod = attacker.GetAttributeMod(Weapon);
+            AttributeMod = attacker.GetAttributeMod(Weapon, false);
 
             SlayerMod = WorldObject.GetWeaponCreatureSlayerModifier(Weapon, attacker, defender);
 

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Caster.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Caster.cs
@@ -108,19 +108,16 @@ namespace ACE.Server.Factories
             wo.Tier = GetTierValue(profile);
 
             // Determine caster type: 0 = Orb, 1 = Scepter, 2 = Wand/Baton, 3 = Staff
+            int ORB = 0, SCEPTER = 1, WAND = 2, STAFF = 3;
             var subType = GetCasterSubType(wo);
 
             // Add element/material to low tier orb/wand/scepter/staff
             if (wo.WeenieClassId == 2366 || wo.WeenieClassId == 2547 || wo.WeenieClassId == 2548 || wo.WeenieClassId == 2472)
-            {
                 RollCasterElement(profile, wo);
-            }
-            else
-            {
-                var materialType = GetMaterialType(wo, profile.Tier);
-                if (materialType > 0)
-                    wo.MaterialType = materialType;
-            }
+
+            var materialType = GetMaterialType(wo, profile.Tier);
+            if (materialType > 0)
+                wo.MaterialType = materialType;
 
             // item color
             if (wo.WeenieClassId == 2548)
@@ -132,9 +129,7 @@ namespace ACE.Server.Factories
                 MutateColor(wo);
             }
 
-            // Bonus Resto/Elemental %
-            var damagePercentile = 0.0;
-            if (wo.W_DamageType == DamageType.Undef)
+            if (ThreadSafeRandom.Next(0, 1) == 0)
                 wo.WieldSkillType2 = (int)Skill.LifeMagic;
             else
                 wo.WieldSkillType2 = (int)Skill.WarMagic;
@@ -148,37 +143,26 @@ namespace ACE.Server.Factories
             wo.WieldDifficulty2 = 1;
 
             // Roll Elemental Damage Mod
-            TryMutateCasterWeaponDamage(wo, roll, profile, out damagePercentile);
+            TryMutateCasterWeaponDamage(wo, profile, out var damagePercentile);
 
-            // T1 casters have damage penalty
+            // T0 casters have damage penalty
             if (profile.Tier == 1)
             {
-                // Orb and Staff receive harsher penalties
-                if (subType == 0 || subType == 3)
-                {
-                    wo.GearDamage = ThreadSafeRandom.Next(-30, -20);
-                    wo.DamageRating = ThreadSafeRandom.Next(-30, -20);
-                }
-                else
-                {
-                    wo.GearDamage = ThreadSafeRandom.Next(-20, -10);
-                    wo.DamageRating = ThreadSafeRandom.Next(-20, -10);
-                }
+                var damagePenaltyRoll = ThreadSafeRandom.Next(0, 25);
+                var finalRating = -25 + (int)(damagePenaltyRoll * GetDiminishingRoll(profile));
+                wo.GearDamage = finalRating;
+                wo.DamageRating = finalRating;
             }
 
             // Roll Weapon Mods
             TryMutateWeaponMods(wo, profile, out var modsPercentile, true);
 
-            // Bonus Crit Chance for Scepters
-            if (subType == 1)
-            {
+            if (subType == ORB)
+                RollBonusAegisCleaving(profile, wo);
+            else if (subType == SCEPTER)
                 RollBonusCritDamage(profile, wo);
-            }
-            // Bonus Crit Damage for Wands/Batons
-            else if (subType == 2)
-            {
+            else if (subType == WAND)
                 RollBonusCritChance(profile, wo);
-            }
 
 
             // gem count / gem material
@@ -381,63 +365,56 @@ namespace ACE.Server.Factories
         /// </summary>
         private static void RollCasterElement(TreasureDeath profile, WorldObject wo)
         {
-            var noElement = ThreadSafeRandom.Next(0, 3) == 0 ? true : false;
             var elementType = 0;
-            var materialType = 0;
             var uiEffect = 0;
-
-            if (noElement)
-            {
-                var material = GetMaterialType(wo, profile.Tier);
-                if (material > 0)
-                    wo.MaterialType = material;
-                wo.UiEffects = UiEffects.BoostHealth;
-
-                return;
-            }
 
             var roll = ThreadSafeRandom.Next(1, 7);
             switch (roll)
             {
                 case 1:
                     elementType = 0x1; // slash
-                    materialType = 0x0000001A; // imperial topaz
                     uiEffect = 0x0400;
                     break; 
                 case 2:
                     elementType = 0x2; // pierce
-                    materialType = 0x0000000F; // black garnet
                     uiEffect = 0x0800; 
                     break; 
                 case 3:
                     elementType = 0x4; // bludge
-                    materialType = 0x0000002F; // white saphhire
                     uiEffect = 0x0200; 
                     break;
                 case 4:
                     elementType = 0x8; // cold
-                    materialType = 0x0000000D; // aquamarine
                     uiEffect = 0x0080;
                     break;
                 case 5:
                     elementType = 0x10; // fire
-                    materialType = 0x00000023; // red garnet
                     uiEffect = 0x0020; 
                     break;
                 case 6:
                     elementType = 0x20; // acid
-                    materialType = 0x00000015; // emerald
                     uiEffect = 0x0100; 
                     break;
                 case 7:
                     elementType = 0x40; // electric
-                    materialType = 0x0000001B; // jet
                     uiEffect = 0x0040; 
                     break;
             }
             wo.W_DamageType = (DamageType)elementType;
-            wo.MaterialType = (MaterialType)materialType;
             wo.UiEffects = (UiEffects)uiEffect;
+        }
+
+        /// <summary>
+        /// Rolls Bonus Aegis Cleaving for Orbs
+        /// </summary>
+        private static void RollBonusAegisCleaving(TreasureDeath treasureDeath, WorldObject wo)
+        {
+            float[] minMod = { 0.10f, 0.11f, 0.12f, 0.13f, 0.14f, 0.15f, 0.175f, 0.2f };
+
+            var tier = Math.Clamp(treasureDeath.Tier - 1, 0, minMod.Length);
+            var aegisCleavingMod = minMod[tier] + 0.1f * GetDiminishingRoll(treasureDeath);
+
+            wo.SetProperty(PropertyFloat.IgnoreAegis, aegisCleavingMod);
         }
 
         /// <summary>
@@ -445,11 +422,10 @@ namespace ACE.Server.Factories
         /// </summary>
         private static void RollBonusCritChance(TreasureDeath treasureDeath, WorldObject wo)
         {
-            var lootQualityMod = treasureDeath.LootQualityMod * 100;
-            var roll = ThreadSafeRandom.Next((int)lootQualityMod, 100);
-            var tier = treasureDeath.Tier;
+            float[] minMod = { 0.05f, 0.055f, 0.06f, 0.065f, 0.07f, 0.075f, 0.0875f, 0.1f };
 
-            var critChanceMod = 0.1f * GetDiminishingRoll(treasureDeath);
+            var tier = Math.Clamp(treasureDeath.Tier - 1, 0, minMod.Length);
+            var critChanceMod = minMod[tier] + 0.05f * GetDiminishingRoll(treasureDeath);
 
             wo.SetProperty(PropertyFloat.CriticalFrequency, 0.1f + critChanceMod);
         }
@@ -458,12 +434,11 @@ namespace ACE.Server.Factories
         /// Rolls Bonus Crit Chance for Batons
         /// </summary>
         private static void RollBonusCritDamage(TreasureDeath treasureDeath, WorldObject wo)
-        {;
-            var lootQualityMod = treasureDeath.LootQualityMod * 100;
-            var roll = ThreadSafeRandom.Next((int)lootQualityMod, 100);
-            var tier = treasureDeath.Tier;
+        {
+            float[] minMod = { 0.5f, 0.55f, 0.6f, 0.65f, 0.7f, 0.75f, 0.875f, 1.0f };
 
-            var critDamageMod = 1.0f * GetDiminishingRoll(treasureDeath);
+            var tier = Math.Clamp(treasureDeath.Tier - 1, 0, minMod.Length);
+            var critDamageMod = minMod[tier] + 0.5f * GetDiminishingRoll(treasureDeath);
 
             if (wo.GetProperty(PropertyFloat.CriticalMultiplier) != null)
             {
@@ -479,15 +454,11 @@ namespace ACE.Server.Factories
         }
 
         /// <summary>
-        /// Rolls Bonus Defense Mods for Orbs (magic) and Staffs (melee)
+        /// Rolls Bonus Defense Mods for Staffs
         /// </summary>
         private static float BonusDefenseMod(TreasureDeath treasureDeath, WorldObject wo)
         {
-            var lootQualityMod = treasureDeath.LootQualityMod * 100;
-            var roll = ThreadSafeRandom.Next((int)lootQualityMod, 100);
-            var tier = treasureDeath.Tier;
-
-            var defenseMod = 0.1f + 0.1f * GetDiminishingRoll(treasureDeath);
+            var defenseMod = 0.1f * GetDiminishingRoll(treasureDeath);
 
             return defenseMod;
         }
@@ -685,43 +656,46 @@ namespace ACE.Server.Factories
             }
         }
 
-        private static void TryMutateCasterWeaponDamage(WorldObject wo, TreasureRoll roll, TreasureDeath profile, out double damagePercentile)
+        private static void TryMutateCasterWeaponDamage(WorldObject wo, TreasureDeath profile, out double damagePercentile)
         {
-            // If Staff or Orb reduce damage by 50%
-            var defensiveCasterMultiplier = GetCasterSubType(wo) == 0 || GetCasterSubType(wo) == 3 ? 0.5f : 1.0f;
+            damagePercentile = 0;
 
-            // Calculate Max, Min, and Roll
-            var maxDamageMod = GetCasterMaxDamageMod(wo)[profile.Tier - 1] * defensiveCasterMultiplier / 100;
-            var minDamageMod = (profile.Tier > 1 ? (float)(GetCasterMaxDamageMod(wo)[profile.Tier - 2] - 5) : 1) / 100 * defensiveCasterMultiplier;
-            var diminishedDamageModRoll = (maxDamageMod - minDamageMod) * GetDiminishingRoll(profile);
-
-            var maxPossibleDamage = GetCasterMaxDamageMod(wo)[7] * defensiveCasterMultiplier / 100;
-
-            // Elemental or Resto?
-            if (wo.W_DamageType != DamageType.Undef)
+            var tier = Math.Clamp(profile.Tier - 1, 0, 7);
+            if (tier > 0)
             {
-                wo.ElementalDamageMod = minDamageMod + diminishedDamageModRoll + 1;
-                damagePercentile = ((double)wo.ElementalDamageMod - 1) / maxPossibleDamage;
-            }
-            else
-            {
-                wo.WeaponRestorationSpellsMod = minDamageMod + diminishedDamageModRoll + 1;
-                damagePercentile = ((double)wo.WeaponRestorationSpellsMod - 1) / maxPossibleDamage;
+                float damageRoll;
+
+                // Calculate Max, Min, and Roll
+                var maxDamageMod = GetCasterMaxDamageMod()[tier];
+                var minDamageMod = GetCasterMinDamageMod()[tier];
+                var diminishedDamageModRoll = (maxDamageMod - minDamageMod) * GetDiminishingRoll(profile);
+                
+                if (wo.WieldSkillType2 == (int)Skill.WarMagic)
+                {
+                    damageRoll = minDamageMod + diminishedDamageModRoll;
+
+                    wo.ElementalDamageMod = damageRoll;
+                    wo.WeaponRestorationSpellsMod = damageRoll / 2 + 0.5f;
+                }
+                else
+                {
+                    damageRoll = minDamageMod + diminishedDamageModRoll;
+
+                    wo.WeaponRestorationSpellsMod = minDamageMod + diminishedDamageModRoll;
+                    wo.ElementalDamageMod = damageRoll / 2 + 0.5f;
+                }
+
+                var maxPossibleDamage = GetCasterMaxDamageMod()[7];
+                damagePercentile = ((double)damageRoll - 1) / (maxPossibleDamage - 1);
             }
         }
 
         private static int GetCasterWorkmanship(WorldObject wo, double damagePercentile, double modsPercentile)
         {
-            var divisor = 0;
-
-            // Damage
-            divisor++;
-
-            // Weapon Mods
-            divisor++;
+            var divisor = 3; // Damage x2 + Mods
 
             // Average Percentile
-            var finalPercentile = (damagePercentile + modsPercentile) / divisor;
+            var finalPercentile = (damagePercentile * 2 + modsPercentile) / divisor;
 
             //Console.WriteLine($"{wo.Name}\n -Mods %: {modsPercentile}\n" + $" -Damage %: {damagePercentile}\n" + $" -Divisor: {divisor}\n" +
             //    $" --FINAL: {finalPercentile}\n\n");

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Chance.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Chance.cs
@@ -27,7 +27,7 @@ namespace ACE.Server.Factories
                         case 5: wield = 200; break;
                         case 6: wield = 220; break;
                         case 7: wield = 240; break;
-                        case 8: wield = 360; break;
+                        case 8: wield = 260; break;
                     }
                     break;
 
@@ -42,7 +42,7 @@ namespace ACE.Server.Factories
                         case 5: wield = 200; break;
                         case 6: wield = 220; break;
                         case 7: wield = 240; break;
-                        case 8: wield = 360; break;
+                        case 8: wield = 260; break;
                     }
                     break;
 
@@ -57,7 +57,7 @@ namespace ACE.Server.Factories
                         case 5: wield = 200; break;
                         case 6: wield = 220; break;
                         case 7: wield = 240; break;
-                        case 8: wield = 360; break;
+                        case 8: wield = 260; break;
                     }
                     break;
             }

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Clothing.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Clothing.cs
@@ -1109,41 +1109,17 @@ namespace ACE.Server.Factories
         private static List<int> GetRolledTypes(List<int> potentialTypes, float qualityMod)
         {
             List<int> rolledTypes = new List<int>();
-            var numTypes = potentialTypes.Count;
-            var threshold = 50;
+            var numPotentialTypes = potentialTypes.Count;
+            var numTypes = ThreadSafeRandom.Next(1, numPotentialTypes);
 
             for (int i = 0; i < numTypes; i++)
             {
-                var rng = GetRollForArmorMod(qualityMod);
-
-                if (rng > threshold)
-                {
-                    var type = potentialTypes[ThreadSafeRandom.Next(0, potentialTypes.Count - 1)];
-                    potentialTypes.Remove(type);
-                    rolledTypes.Add(type);
-
-                    threshold += GetThresholdAdjustment(threshold, true);
-                }
-                else
-                    threshold -= GetThresholdAdjustment(threshold, false);
-
-                
+                var type = potentialTypes[ThreadSafeRandom.Next(0, potentialTypes.Count - 1)];
+                potentialTypes.Remove(type);
+                rolledTypes.Add(type);
             }
 
             return rolledTypes;
-        }
-
-        /// <summary>
-        /// Gets the adjusted success chance of rolling the next mod
-        /// </summary>
-        /// <returns>Returns 50% of the difference between 100 and the current threshold if adding,
-        /// or 50% of the current threshold if subtracting</returns>
-        private static int GetThresholdAdjustment(int threshold, bool add)
-        {
-            var difference = add == true ? 100 - threshold : threshold;
-            var adjustment = difference * 0.5f;
-
-            return (int)adjustment;
         }
 
         private static void SetWieldLevelReq(WorldObject wo, int level)

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Melee.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Melee.cs
@@ -148,12 +148,12 @@ namespace ACE.Server.Factories
             wo.DamageVariance = baseVariance + ThreadSafeRandom.Next(-0.1f, 0.1f);
 
             // Damage Percentile (for workmanship)
-            var lowerMaxPossibleDamage = maxPossibleDamage * (1 - (baseVariance - 0.1f));
-            var averageMaxPossibleDamage = (maxPossibleDamage + lowerMaxPossibleDamage) / 2;
-            var weaponAverageDamage = ((wo.Damage * (1 - wo.DamageVariance)) + wo.Damage) / 2;
-            var damagePercentile = (float)(weaponAverageDamage / averageMaxPossibleDamage);
+            //var lowerMaxPossibleDamage = maxPossibleDamage * (1 - (baseVariance - 0.1f));
+            //var averageMaxPossibleDamage = (maxPossibleDamage + lowerMaxPossibleDamage) / 2;
+            //var weaponAverageDamage = ((wo.Damage * (1 - wo.DamageVariance)) + wo.Damage) / 2;
+            var damagePercentile = ((float)wo.Damage / maxPossibleDamage);
 
-            //Console.WriteLine($"lower: {lowerMaxPossibleDamage} upper: {maxPossibleDamage} average: {averageMaxPossibleDamage} weaponAvg: {weaponAverageDamage} percentile: {damagePercentile}");
+            //Console.WriteLine($"{wo.NameWithMaterialAndElement}  lower: {lowerMaxPossibleDamage} upper: {maxPossibleDamage} average: {averageMaxPossibleDamage} weaponAvg: {weaponAverageDamage} percentile: {damagePercentile}");
 
             // weapon speed
             if (wo.WeaponTime != null)
@@ -1369,8 +1369,8 @@ namespace ACE.Server.Factories
                 targetBaseDps *= 0.6f;
 
             targetAverageHitDamage = targetBaseDps / effectiveAttacksPerSecond;
-            averageBaseMaxDamage = (targetAverageHitDamage * 2) / (1.0 + (1 - weaponVariance));
-            maximumBaseMaxDamage = (averageBaseMaxDamage * 2) / (1.0 + damageRangePerTier);
+            averageBaseMaxDamage = targetAverageHitDamage / ((((1 - weaponVariance) + 1) / 2 * 0.9) + 0.2);
+            maximumBaseMaxDamage = (averageBaseMaxDamage * 2) / (1.0 + (1 - damageRangePerTier));
             maxPossibleDamage = (int)maximumBaseMaxDamage;
         }
     }

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Missile.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Missile.cs
@@ -107,11 +107,7 @@ namespace ACE.Server.Factories
             wo.WieldSkillType2 = GetWeaponWieldSkill(wo.WeaponSkill);
 
             // Damage
-            TryMutateMissileWeaponDamage(wo, roll, profile, out var maxPossibleDamageMod);
-
-            // Damage Percentile, for workmanship
-            var damageModPercentile = (wo.DamageMod - 1) / maxPossibleDamageMod;
-            //Console.WriteLine($"damMod: {wo.DamageMod - 1} maxDamMod: {maxPossibleDamageMod} damModPercentile: {damageModPercentile}");
+            TryMutateMissileWeaponDamage(wo, roll, profile, out var damageModPercentile);
 
             // weapon speed
             if (wo.WeaponTime != null)
@@ -124,8 +120,6 @@ namespace ACE.Server.Factories
             var totalModsPercentile = 0.0f;
 
             TryMutateWeaponMods(wo, profile, out totalModsPercentile);
-
-            // Weapon Mods Percentile, for workmanship
 
             //RollCrushingBlow(profile, wo);
             //RollBitingStrike(profile, wo);
@@ -375,9 +369,9 @@ namespace ACE.Server.Factories
             return LootTables.NonElementalMissileWeaponsMatrix[missileType][subType];
         }
 
-        private static void TryMutateMissileWeaponDamage(WorldObject wo, TreasureRoll roll, TreasureDeath profile, out double maxPossibleDamageMod)
+        private static void TryMutateMissileWeaponDamage(WorldObject wo, TreasureRoll roll, TreasureDeath profile, out double damageModPercentile)
         {
-            maxPossibleDamageMod = 0;
+            damageModPercentile = 0;
 
             if (wo.WeaponTime == null)
             {
@@ -447,12 +441,14 @@ namespace ACE.Server.Factories
             // max possible damage (for workmanship)
             targetBaseDps = GetWeaponBaseDps(8);
             ammoMaxDamage = GetAmmoBaseMaxDamage(wo.WeaponSkill, 8);
-            ammoMinDamage = ammoMaxDamage * weaponVariance;
+            ammoMinDamage = ammoMaxDamage * (1 - weaponVariance);
             ammoAverageDamage = (ammoMaxDamage + ammoMinDamage) / 2;
             targetAvgHitDamage = targetBaseDps / effectiveAttacksPerSecond;
-            averageBaseDamageMod = targetAvgHitDamage / ammoAverageDamage;
-            maximumBaseMaxDamageMod = (averageBaseDamageMod * 2) / (1.0 + damageRangePerTier);
-            maxPossibleDamageMod = (int)maximumBaseMaxDamageMod;
+            averageBaseDamageMod = targetAvgHitDamage / ((ammoAverageDamage * 0.9) + (ammoMaxDamage * 0.2));
+            maximumBaseMaxDamageMod = (averageBaseDamageMod * 2) / (1.0 + (1 - damageRangePerTier));
+
+            damageModPercentile = (finalMaxDamageMod - 1) / (maximumBaseMaxDamageMod - 1);
+            //Console.WriteLine($"damMod: {wo.DamageMod - 1} maxDamMod: {maxPossibleDamageMod} damModPercentile: {damageModPercentile}");
         }
 
         /// <summary>

--- a/Source/ACE.Server/Factories/LootTables.cs
+++ b/Source/ACE.Server/Factories/LootTables.cs
@@ -568,8 +568,11 @@ namespace ACE.Server.Factories
                 { 5, 10, 20, 30, 40, 50, 75, 100 };
 
         // Caster
-        public static readonly int[] CasterMaxDamageMod =
-                { 5, 10, 20, 30, 40, 50, 75, 100  };
+        public static readonly float[] CasterMaxDamageMod =
+                { 1.0f, 1.3f, 1.6f, 2.1f, 2.75f, 3.75f, 4.75f, 6.00f  };
+
+        public static readonly float[] CasterMinDamageMod =
+                { 0.75f, 1.0f, 1.2f, 1.4f, 1.9f, 2.5f, 3.5f, 4.5f  };
 
 
         public static readonly int[][] CasterWeaponsMatrix =
@@ -583,10 +586,10 @@ namespace ACE.Server.Factories
         public static readonly int[][] TimelineCasterWeaponsMatrix =
         {
             new int[] { 2366, 2548, 2472, 2547 }, // Orb, Wand, Scepter, Staff
-            new int[] { 1050100, 1050101, 1050102, 1050103, 1050104, 1050105, 1050106, 1050107 }, // Orb: Life, Slashing, Piercing, Blunt, Frost, Fire, Acid, Electric
-            new int[] { 1050108, 29265, 29264, 29260, 29263, 29262, 29259, 29261 }, // Sceptre: Life, Slashing, Piercing, Blunt, Frost, Fire, Acid, Electric
-            new int[] { 1050110, 31819, 31825, 31821, 31824, 31823, 31820, 31822 }, // Wand/Baton: Life, Slashing, Piercing, Blunt, Frost, Fire, Acid, Electric
-            new int[] { 1050109, 37223, 37222, 37225, 37221, 37220, 37224, 37219 }  // Staff: Life, Slashing, Piercing, Blunt, Frost, Fire, Acid, Electric
+            new int[] { 1050101, 1050102, 1050103, 1050104, 1050105, 1050106, 1050107 }, // Orb: Slashing, Piercing, Blunt, Frost, Fire, Acid, Electric
+            new int[] { 29265, 29264, 29260, 29263, 29262, 29259, 29261 }, // Sceptre: Slashing, Piercing, Blunt, Frost, Fire, Acid, Electric
+            new int[] { 31819, 31825, 31821, 31824, 31823, 31820, 31822 }, // Wand/Baton: Slashing, Piercing, Blunt, Frost, Fire, Acid, Electric
+            new int[] { 37223, 37222, 37225, 37221, 37220, 37224, 37219 }  // Staff: Slashing, Piercing, Blunt, Frost, Fire, Acid, Electric
         };
 
         public static readonly float[][] MissileDamageMod =

--- a/Source/ACE.Server/Factories/Tables/Wcids/Weapons/CasterWcids.cs
+++ b/Source/ACE.Server/Factories/Tables/Wcids/Weapons/CasterWcids.cs
@@ -16,13 +16,6 @@ namespace ACE.Server.Factories.Tables.Wcids
 
         private static ChanceTable<WeenieClassName> T6_T7_T8_Chances = new ChanceTable<WeenieClassName>(ChanceTableType.Weight)
         {
-            // Life only
-            ( WeenieClassName.orblife,                     3.0f ),
-            ( WeenieClassName.scepterlife,                 3.0f ),
-            ( WeenieClassName.stafflife,                   3.0f ),
-            ( WeenieClassName.batonlife,                   3.0f ),
-
-            //War only
             ( WeenieClassName.orbslash,               1.0f ),
             ( WeenieClassName.orbpierce,              1.0f ),
             ( WeenieClassName.orbblunt,               1.0f ),

--- a/Source/ACE.Server/Network/Structure/AppraiseInfo.cs
+++ b/Source/ACE.Server/Network/Structure/AppraiseInfo.cs
@@ -548,15 +548,86 @@ namespace ACE.Server.Network.Structure
                 hasExtraPropertiesText = true;
             }
 
+            // -------- WEAPON PROPERTIES --------
+            // Aegis Rending
+            if (PropertiesInt.TryGetValue(PropertyInt.ImbuedEffect, out var imbuedEffect) && imbuedEffect == 0x8000)
+            {
+                extraPropertiesText += $"Additional Properties: Aegis Rending\n";
+
+                hasExtraPropertiesText = true;
+            }
+            // Ignore Armor
+            if (PropertiesFloat.TryGetValue(PropertyFloat.IgnoreArmor, out var ignoreArmor) && ignoreArmor != 0)
+            {
+                var wielder = (Creature)wo.Wielder;
+                extraPropertiesText += $"+{Math.Round((ignoreArmor * 100), 0)} Ignored Armor%\n";
+
+                hasExtraPropertiesText = true;
+            }
+            // Aegis Cleaving
+            if (PropertiesFloat.TryGetValue(PropertyFloat.IgnoreAegis, out var ignoreAegis) && ignoreAegis != 0)
+            {
+                var wielder = (Creature)wo.Wielder;
+                extraPropertiesText += $"+{Math.Round((ignoreAegis * 100), 0)}% Ignored Aegis\n";
+
+                hasExtraPropertiesText = true;
+            }
+            // Crit Multiplier
+            if (PropertiesFloat.TryGetValue(PropertyFloat.CriticalMultiplier, out var critMultiplier) && critMultiplier > 1)
+            {
+                var wielder = (Creature)wo.Wielder;
+
+                extraPropertiesText += $"+{Math.Round((critMultiplier - 1) * 100, 0)}% Critical Damage\n";
+
+                hasExtraPropertiesText = true;
+            }
+            // Crit Chance
+            if (PropertiesFloat.TryGetValue(PropertyFloat.CriticalFrequency, out var critFrequency) && critFrequency > 0.0f)
+            {
+                var wielder = (Creature)wo.Wielder;
+
+                extraPropertiesText += $"+{Math.Round((critFrequency - 0.1) * 100, 1)}% Critical Chance\n";
+
+                hasExtraPropertiesText = true;
+            }
+            // Spell Proc Rate
+            if (PropertiesFloat.TryGetValue(PropertyFloat.ProcSpellRate, out var procSpellRate) && procSpellRate > 0.0f)
+            {
+                var wielder = (Creature)wo.Wielder;
+
+                extraPropertiesText += $"Cast on strike chance: {Math.Round(procSpellRate * 100, 1)}%\n";
+
+                hasExtraPropertiesText = true;
+            }
+
             // -------- WEAPON ATTACK/DEFENSE MODS --------
+            extraPropertiesText += "\n";
             // Attack Mod for Bows
             if (PropertiesFloat.TryGetValue(PropertyFloat.WeaponOffense, out var weaponOffense) && weaponOffense > 1.001)
             {
                 var weaponMod = (weaponOffense - 1) * 100;
-                if (wo.WeaponSkill == Skill.Bow || wo.WeaponSkill == Skill.Crossbow)
+                if (wo.WeaponSkill == Skill.Bow || wo.WeaponSkill == Skill.Crossbow || wo.WeaponSkill == Skill.MissileWeapons)
                 {
                     extraPropertiesText += $"Bonus to Attack Skill: +{Math.Round(weaponMod, 1)}%\n";
                 }
+
+                hasExtraPropertiesText = true;
+            }
+            // Weapon Mod - War Magic
+            if (PropertiesFloat.TryGetValue(PropertyFloat.WeaponWarMagicMod, out var weaponWarMagicMod) && weaponWarMagicMod >= 0.001)
+            {
+                var wielder = (Creature)wo.Wielder;
+
+                extraPropertiesText += $"Bonus to War Magic Skill: +{Math.Round((weaponWarMagicMod) * 100, 1)}%\n";
+
+                hasExtraPropertiesText = true;
+            }
+            // Weapon Mod - Life Magic
+            if (PropertiesFloat.TryGetValue(PropertyFloat.WeaponLifeMagicMod, out var weaponLifeMagicMod) && weaponLifeMagicMod >= 0.001)
+            {
+                var wielder = (Creature)wo.Wielder;
+
+                extraPropertiesText += $"Bonus to Life Magic Skill: +{Math.Round((weaponLifeMagicMod) * 100, 1)}%\n";
 
                 hasExtraPropertiesText = true;
             }
@@ -577,81 +648,12 @@ namespace ACE.Server.Network.Structure
                 hasExtraPropertiesText = true;
             }
 
-            // -------- ARMOR MODS --------
-            // Weapon Mod - War Magic
-            if (PropertiesFloat.TryGetValue(PropertyFloat.WeaponWarMagicMod, out var weaponWarMagicMod) && weaponWarMagicMod >= 0.001)
-            {
-                var wielder = (Creature)wo.Wielder;
-
-                extraPropertiesText += $"\nBonus to War Magic Skill: +{Math.Round((weaponWarMagicMod) * 100, 1)}%\n";
-
-                hasExtraPropertiesText = true;
-            }
-            // Weapon Mod - Life Magic
-            if (PropertiesFloat.TryGetValue(PropertyFloat.WeaponLifeMagicMod, out var weaponLifeMagicMod) && weaponLifeMagicMod >= 0.001)
-            {
-                var wielder = (Creature)wo.Wielder;
-
-                extraPropertiesText += $"Bonus to Life Magic Skill: +{Math.Round((weaponLifeMagicMod) * 100, 1)}%\n";
-
-                hasExtraPropertiesText = true;
-            }
-            // Weapon Mod - Restoration Spell Magic
+            // Weapon Mod - Life Spell Restoration Mod
             if (PropertiesFloat.TryGetValue(PropertyFloat.WeaponRestorationSpellsMod, out var weaponLifeMagicVitalMod) && weaponLifeMagicVitalMod >= 1.001)
             {
                 var wielder = (Creature)wo.Wielder;
 
-                extraPropertiesText += $"Bonus to Restoration Spells: +{Math.Round((weaponLifeMagicVitalMod - 1) * 100, 1)}%\n";
-
-                hasExtraPropertiesText = true;
-            }
-            // Aegis Rending
-            if (PropertiesInt.TryGetValue(PropertyInt.ImbuedEffect, out var imbuedEffect) && imbuedEffect == 0x8000)
-            {
-                extraPropertiesText += $"Additional Properties: Aegis Rending\n";
-
-                hasExtraPropertiesText = true;
-            }
-            // Aegis Penetration
-            if (PropertiesFloat.TryGetValue(PropertyFloat.IgnoreAegis, out var ignoreAegis) && ignoreAegis != 0)
-            {
-                var wielder = (Creature)wo.Wielder;
-                extraPropertiesText += $"Aegis Penetration: {Math.Round(100.0f - (ignoreAegis * 100), 0)}%\n";
-
-                hasExtraPropertiesText = true;
-            }
-            // Ignore Armor
-            if (PropertiesFloat.TryGetValue(PropertyFloat.IgnoreArmor, out var ignoreArmor) && ignoreArmor != 0)
-            {
-                var wielder = (Creature)wo.Wielder;
-                extraPropertiesText += $"Armor Penetration: +{Math.Round(100.0f - (ignoreArmor * 100), 0)}%\n";
-
-                hasExtraPropertiesText = true;
-            }
-            // Crit Multiplier
-            if (PropertiesFloat.TryGetValue(PropertyFloat.CriticalMultiplier, out var critMultiplier) && critMultiplier > 1)
-            {
-                var wielder = (Creature)wo.Wielder;
-
-                extraPropertiesText += $"Crit Damage: +{Math.Round(critMultiplier * 100, 0)}%\n";
-
-                hasExtraPropertiesText = true;
-            }
-            // Crit Chance
-            if (PropertiesFloat.TryGetValue(PropertyFloat.CriticalFrequency, out var critFrequency) && critFrequency > 0.0f)
-            {
-                var wielder = (Creature)wo.Wielder;
-
-                extraPropertiesText += $"Crit Chance: +{Math.Round(critFrequency * 100, 1)}%\n";
-
-                hasExtraPropertiesText = true;
-            }
-            // Spell Proc Rate
-            if (PropertiesFloat.TryGetValue(PropertyFloat.ProcSpellRate, out var procSpellRate) && procSpellRate > 0.0f)
-            {
-                var wielder = (Creature)wo.Wielder;
-
-                extraPropertiesText += $"Cast on strike chance: {Math.Round(procSpellRate * 100, 1)}%\n";
+                extraPropertiesText += $"Healing Bonus for Restoration Spells: +{Math.Round((weaponLifeMagicVitalMod - 1) * 100, 1)}%\n";
 
                 hasExtraPropertiesText = true;
             }

--- a/Source/ACE.Server/WorldObjects/Creature_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Combat.cs
@@ -475,19 +475,44 @@ namespace ACE.Server.WorldObjects
         }
 
         /// <summary>
-        /// Returns the attribute damage bonus for a physical attack
+        /// Returns the attribute damage bonus for a physical and magical attacks
         /// </summary>
         /// <param name="attackType">Uses strength for melee, coordination for missile</param>
-        public float GetAttributeMod(WorldObject weapon)
+        public float GetAttributeMod(WorldObject weapon, bool isSpell)
         {
             Entity.CreatureAttribute attribute;
 
-            Skill[] coordinationSkills = { Skill.Dagger, Skill.Staff, Skill.UnarmedCombat, Skill.Bow, Skill.Crossbow };
-            attribute = coordinationSkills.Contains(weapon.WeaponSkill) ? Coordination : Strength;
+            if (weapon == null)
+                attribute = isSpell ? Self : Coordination;
+            else
+            {
+                switch(weapon.WeaponSkill)
+                {
+                    default:
+                    case Skill.Bow:
+                    case Skill.Crossbow:
+                    case Skill.Dagger:
+                    case Skill.Staff:
+                    case Skill.MissileWeapons:
+                    case Skill.UnarmedCombat:
+                        attribute = Coordination;
+                        break;
+                    case Skill.Axe:
+                    case Skill.HeavyWeapons:
+                    case Skill.Mace:
+                    case Skill.Spear:
+                    case Skill.Sword:
+                    case Skill.ThrownWeapon:
+                        attribute = Strength;
+                        break;
+                    case Skill.LifeMagic:
+                    case Skill.WarMagic:
+                        attribute = Self;
+                        break;
+                }
+            }
 
             Skill skill = GetCurrentWeaponSkill();
-            if (skill == Skill.UnarmedCombat && !IsHumanoid)
-                skill = Skill.None; // Non humanoids(creatures that aren't able to wield weapons) use unarmed combat but still have the regular weapon factor.
 
             return SkillFormula.GetAttributeMod((int)attribute.Current, skill);
         }

--- a/Source/ACE.Server/WorldObjects/Creature_Vitals.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Vitals.cs
@@ -136,13 +136,13 @@ namespace ACE.Server.WorldObjects
             // Player Regeneration is now based on Maximum Vitals
             // Health = 10% per 5 seconds
             // Stamina = 20% per 5 seconds
-            // Mana = 10% per 5 seconds
+            // Mana = 20% per 5 seconds
             double currentTick = 0.0;
 
             float maxVital = vital.MaxValue;
             float diminishedMaxVital = maxVital * (1000 / (1000 + maxVital));
 
-            var vitalTypeBaseMod = vital == Stamina ? 5 : 10;
+            var vitalTypeBaseMod = vital == Health ? 10 : 5;
 
             var vitalTypeArmorMod = 1.0;
             if (vital == Health)

--- a/Source/ACE.Server/WorldObjects/Managers/EnchantmentManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EnchantmentManager.cs
@@ -1064,8 +1064,8 @@ namespace ACE.Server.WorldObjects.Managers
                 return elementalDamageAuraMod;
             else
                 return elementalDamageMod;*/
-
-            return elementalDamageAuraMod + elementalDamageMod;
+            
+            return elementalDamageAuraMod + elementalDamageMod - 2;
         }
 
         /// <summary>


### PR DESCRIPTION
* feat: update spell damage calculations
   - Spell damage scales of primary attribute instead of magic skill.
   - Spell crit damage works like other weapons now (max spell damage x2).
   - Bonus magic defense implicit mod moved from Orb to Staff. (Staff has magic and physical d bonuses)
   - Orb now has Aegis Cleaving implicit.
   - Weapon mod rolls adjusted (attack skill and defenses).
   - Casters can now roll with +magic skill mod (equivalent to +attack skill mods).
   - Removed "Life" casters. All casters roll with an element AND restoration bonus mod, but Life req casters have higher resto bonus and War req caster have higher elemental damage bonus.
   - Adjusted appraise info ordering of item mods.
   - Mana regens as fast as Stamina (10% per 5 seconds, Health is still 5%).
   - Fixed elemental damage mod buffed state.

* feat: update portal.dat (30012) and lang.dat (30004)
   - update War spell damage text and mana costs (bolts, arcs, streaks, volleys, blasts, rings, walls).
   - update Bow skill description to include Atlatls.

* feat: update rolled mods function
   - when rolling mods for gear/weapons, there is an equal chance to roll each potential number of mods. (used to be weighted towards and average number)

* fix: update damage roll calculation for workmanship