### PR TITLE
feat: add implicit bonuses to weapons that match their spec bonuses

### DIFF
--- a/Source/ACE.Entity/Enum/Properties/PropertyFloat.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyFloat.cs
@@ -217,6 +217,7 @@ namespace ACE.Entity.Enum.Properties
         WeaponMagicalDefense           = 188,
         Damage                         = 189,
         WeaponAuraDamage               = 190,
+        StaminaCostReductionMod        = 191,
 
         [ServerOnly]
         PCAPRecordedWorkmanship        = 8004,

--- a/Source/ACE.Server/Entity/DamageEvent.cs
+++ b/Source/ACE.Server/Entity/DamageEvent.cs
@@ -3,9 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection.Metadata.Ecma335;
 using ACE.Common;
+using ACE.DatLoader.Entity;
 using ACE.DatLoader.Entity.AnimationHooks;
 using ACE.Entity.Enum;
 using ACE.Entity.Models;
+using ACE.Server.Factories;
 using ACE.Server.Managers;
 using ACE.Server.Network.GameMessages.Messages;
 using ACE.Server.WorldObjects;
@@ -316,16 +318,16 @@ namespace ACE.Server.Entity
                     if (playerDefender == null)
                         SneakAttackMod = 3.0f;
                 }
-
-                // SPEC BONUS: Martial Weapons (Axe) - +10% crit chance (additively)
                 if (playerAttacker.GetEquippedWeapon() != null)
+                {
+                    // SPEC BONUS - Martial Weapons (Axe): +5% crit chance (additively)
                     if (playerAttacker.GetEquippedWeapon().WeaponSkill == Skill.Axe && playerAttacker.GetCreatureSkill(Skill.HeavyWeapons).AdvancementClass == SkillAdvancementClass.Specialized)
-                        CriticalChance += 0.1f;
+                        CriticalChance += 0.05f;
 
-                // SPEC BONUS: Dagger - +10% crit chance (additively)
-                if (playerAttacker.GetEquippedWeapon() != null)
+                    // SPEC BONUS - Dagger: +5% crit chance (additively)
                     if (playerAttacker.GetEquippedWeapon().WeaponSkill == Skill.Dagger && playerAttacker.GetCreatureSkill(Skill.Dagger).AdvancementClass == SkillAdvancementClass.Specialized)
-                        CriticalChance += 0.1f;
+                        CriticalChance += 0.05f;
+                }
             }
 
             // https://asheron.fandom.com/wiki/Announcements_-_2002/08_-_Atonement
@@ -364,13 +366,13 @@ namespace ACE.Server.Entity
 
                     if (playerAttacker != null && playerAttacker.GetEquippedWeapon() != null)
                     {
-                        // SPEC BONUS: Martial Weapons (Mace) - +100% crit damage (additively)
+                        // SPEC BONUS - Martial Weapons (Mace): +50% crit damage (additively)
                         if (playerAttacker.GetEquippedWeapon().WeaponSkill == Skill.Mace && playerAttacker.GetCreatureSkill(Skill.HeavyWeapons).AdvancementClass == SkillAdvancementClass.Specialized)
-                            CriticalDamageMod += 1.0f;
+                            CriticalDamageMod += 0.5f;
 
-                        // SPEC BONUS: Staff - +100% crit damage (additively)
+                        // SPEC BONUS - Staff: +50% crit damage (additively)
                         if (playerAttacker.GetEquippedWeapon().WeaponSkill == Skill.Staff && playerAttacker.GetCreatureSkill(Skill.Staff).AdvancementClass == SkillAdvancementClass.Specialized)
-                            CriticalDamageMod += 1.0f;
+                            CriticalDamageMod += 0.5f;
                     }
 
                     if (CombatType == CombatType.Missile && playerAttacker != null)
@@ -402,11 +404,11 @@ namespace ACE.Server.Entity
 
             if (playerAttacker != null && playerAttacker.GetEquippedWeapon() != null)
             {
-                // SPEC BONUS: Two-handed combat (Spear) - +10% armor penetration (additively)
+                // SPEC BONUS - Two-handed combat (Spear): +10% armor penetration (additively)
                 if (playerAttacker.GetEquippedWeapon().W_WeaponType == WeaponType.TwoHanded && Weapon.WeaponSkill == Skill.Spear && playerAttacker.GetCreatureSkill(Skill.TwoHandedCombat).AdvancementClass == SkillAdvancementClass.Specialized)
                     ignoreArmorMod -= 0.1f;
 
-                // SPEC BONUS: Martial Weapons (Spear) - +10% armor penetration (additively)
+                // SPEC BONUS - Martial Weapons (Spear): +10% armor penetration (additively)
                 if (playerAttacker.GetEquippedWeapon().WeaponSkill == Skill.Spear && playerAttacker.GetCreatureSkill(Skill.HeavyWeapons).AdvancementClass == SkillAdvancementClass.Specialized)
                     ignoreArmorMod -= 0.1f;
             }
@@ -469,7 +471,7 @@ namespace ACE.Server.Entity
                 DamageResistanceRatingMod = Creature.AdditiveCombine(DamageResistanceRatingMod, PkDamageResistanceMod);
             }
 
-            // SPEC BONUS: Physical Defense
+            // SPEC BONUS - Physical Defense
             var specDefenseMod = 1.0f;
             if(playerDefender != null && playerDefender.GetCreatureSkill(Skill.MeleeDefense).AdvancementClass == SkillAdvancementClass.Specialized)
             {

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Clothing.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Clothing.cs
@@ -1395,21 +1395,7 @@ namespace ACE.Server.Factories
             //    $" --FINAL: {finalPercentile}\n\n");
 
             // Workmanship Calculation
-            return (int)Math.Max(Math.Round(finalPercentile * 10, 0), 1);
-
-            //switch (finalPercentile)
-            //{
-            //    case < 0.1f: return 1;
-            //    case < 0.2f: return 2;
-            //    case < 0.3f: return 3;
-            //    case < 0.4f: return 4;
-            //    case < 0.5f: return 5;
-            //    case < 0.6f: return 6;
-            //    case < 0.7f: return 7;
-            //    case < 0.8f: return 8;
-            //    case < 0.9f: return 9;
-            //    default: return 10;
-            //}
+            return (int)Math.Clamp(Math.Round(finalPercentile * 10, 0), 1, 10);
         }
 
         private static int GetMaxArmorLevel(WorldObject wo)
@@ -1421,7 +1407,7 @@ namespace ACE.Server.Factories
             switch (weightClass)
             {
                 case ArmorWeightClass.Cloth:
-                    maxArmorLevel = 0;
+                    maxArmorLevel = 350;
                     break;
                 case ArmorWeightClass.Light:
                     maxArmorLevel = 525;

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Melee.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Melee.cs
@@ -138,8 +138,6 @@ namespace ACE.Server.Factories
             wo.WieldDifficulty2 = 1;
             wo.WieldSkillType2 = GetWeaponWieldSkill(wo.WeaponSkill);
 
-            //Console.WriteLine($"{wo.Name} WieldDiff: {wo.WieldDifficulty} WieldReq: {wo.WieldRequirements} WieldSkill: { wo.WieldSkillType}");
-
             // Max damage
             TryMutateMeleeWeaponDamage(wo, roll, profile, out var maxPossibleDamage);
 
@@ -147,13 +145,7 @@ namespace ACE.Server.Factories
             var baseVariance = wo.DamageVariance ?? 1.0f;
             wo.DamageVariance = baseVariance + ThreadSafeRandom.Next(-0.1f, 0.1f);
 
-            // Damage Percentile (for workmanship)
-            //var lowerMaxPossibleDamage = maxPossibleDamage * (1 - (baseVariance - 0.1f));
-            //var averageMaxPossibleDamage = (maxPossibleDamage + lowerMaxPossibleDamage) / 2;
-            //var weaponAverageDamage = ((wo.Damage * (1 - wo.DamageVariance)) + wo.Damage) / 2;
             var damagePercentile = ((float)wo.Damage / maxPossibleDamage);
-
-            //Console.WriteLine($"{wo.NameWithMaterialAndElement}  lower: {lowerMaxPossibleDamage} upper: {maxPossibleDamage} average: {averageMaxPossibleDamage} weaponAvg: {weaponAverageDamage} percentile: {damagePercentile}");
 
             // weapon speed
             if (wo.WeaponTime != null)
@@ -166,16 +158,9 @@ namespace ACE.Server.Factories
             }
 
             // weapon mods
-            var modsPercentile = 0.0f;
-            TryMutateWeaponMods(wo, profile, out modsPercentile);
+            TryMutateWeaponMods(wo, profile, out var modsPercentile);
 
-            //RollCrushingBlow(profile, wo);
-            //RollBitingStrike(profile, wo);
-            //RollHollow(profile, wo);
-            //RollArmorCleaving(profile, wo);
-            //RollResistanceCleaving(profile, wo);
-            //RollShieldCleaving(profile, wo);
-            //RollSlayer(profile, wo);
+            TryMutateWeaponSubtypeBonuses(wo, profile, out var subtypeBonusesPercentile);
 
             // material type
             var materialType = GetMaterialType(wo, profile.Tier);
@@ -218,7 +203,7 @@ namespace ACE.Server.Factories
             wo.LongDesc = GetLongDesc(wo);
 
             // workmanship
-            wo.ItemWorkmanship = GetWeaponWorkmanship(wo, damagePercentile, modsPercentile);
+            wo.ItemWorkmanship = GetWeaponWorkmanship(wo, damagePercentile, modsPercentile, subtypeBonusesPercentile);
 
             return true;
         }

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Missile.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Missile.cs
@@ -116,18 +116,12 @@ namespace ACE.Server.Factories
                 wo.WeaponTime = (int)(wo.WeaponTime * weaponSpeedMod);
             }
 
-            // weapon mods
-            var totalModsPercentile = 0.0f;
-
+            // weapon mods and subtype bonuses
+            float totalModsPercentile;
             TryMutateWeaponMods(wo, profile, out totalModsPercentile);
 
-            //RollCrushingBlow(profile, wo);
-            //RollBitingStrike(profile, wo);
-            //RollHollow(profile, wo);
-            //RollArmorCleaving(profile, wo);
-            //RollResistanceCleaving(profile, wo);
-            //RollShieldCleaving(profile, wo);
-            //RollSlayer(profile, wo);
+            float subtypeBonusesPercentile;
+            TryMutateWeaponSubtypeBonuses(wo, profile, out subtypeBonusesPercentile);
 
             // item color
             MutateColor(wo);
@@ -141,7 +135,7 @@ namespace ACE.Server.Factories
             wo.GemType = RollGemType(profile.Tier);
 
             // workmanship
-            wo.ItemWorkmanship = GetWeaponWorkmanship(wo, (float)damageModPercentile, totalModsPercentile);
+            wo.ItemWorkmanship = GetWeaponWorkmanship(wo, (float)damageModPercentile, totalModsPercentile, subtypeBonusesPercentile);
 
             // burden
             MutateBurden(wo, profile, true);

--- a/Source/ACE.Server/Network/Structure/AppraiseInfo.cs
+++ b/Source/ACE.Server/Network/Structure/AppraiseInfo.cs
@@ -560,7 +560,7 @@ namespace ACE.Server.Network.Structure
             if (PropertiesFloat.TryGetValue(PropertyFloat.IgnoreArmor, out var ignoreArmor) && ignoreArmor != 0)
             {
                 var wielder = (Creature)wo.Wielder;
-                extraPropertiesText += $"+{Math.Round((ignoreArmor * 100), 0)} Ignored Armor%\n";
+                extraPropertiesText += $"+{Math.Round((ignoreArmor * 100), 0)}% Armor Cleaving\n";
 
                 hasExtraPropertiesText = true;
             }
@@ -568,7 +568,7 @@ namespace ACE.Server.Network.Structure
             if (PropertiesFloat.TryGetValue(PropertyFloat.IgnoreAegis, out var ignoreAegis) && ignoreAegis != 0)
             {
                 var wielder = (Creature)wo.Wielder;
-                extraPropertiesText += $"+{Math.Round((ignoreAegis * 100), 0)}% Ignored Aegis\n";
+                extraPropertiesText += $"+{Math.Round((ignoreAegis * 100), 0)}% Aegis Cleaving\n";
 
                 hasExtraPropertiesText = true;
             }
@@ -587,6 +587,15 @@ namespace ACE.Server.Network.Structure
                 var wielder = (Creature)wo.Wielder;
 
                 extraPropertiesText += $"+{Math.Round((critFrequency - 0.1) * 100, 1)}% Critical Chance\n";
+
+                hasExtraPropertiesText = true;
+            }
+            // Stamina Reduction Mod
+            if (PropertiesFloat.TryGetValue(PropertyFloat.StaminaCostReductionMod, out var staminaCostReductionMod) && staminaCostReductionMod > 0.001f)
+            {
+                var wielder = (Creature)wo.Wielder;
+
+                extraPropertiesText += $"{Math.Round((staminaCostReductionMod - 0.1) * 100, 1)}% Stamina Cost Reduction\n";
 
                 hasExtraPropertiesText = true;
             }

--- a/Source/ACE.Server/WorldObjects/Player_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Combat.cs
@@ -930,7 +930,7 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Calculates the amount of stamina required to perform this attack
         /// </summary>
-        public int GetAttackStamina(PowerAccuracy powerAccuracy, float attackAnimLength, bool dualWieldStaminaBonus = false)
+        public int GetAttackStamina(PowerAccuracy powerAccuracy, float attackAnimLength, WorldObject weapon, bool dualWieldStaminaBonus = false)
         {
             // Stamina cost for melee and missile attacks is based on the total burden of what you are holding
             // in your hands (main hand and offhand), and your power/accuracy bar.
@@ -973,13 +973,21 @@ namespace ACE.Server.WorldObjects
             if (combatAbility == CombatAbility.Powershot && AccuracyLevel == 1.0f)
                 baseCost *= 2;
 
-            // SPEC BONUS: UA - Stamina costs for melee attacks reduced by 20%
-            if(GetCurrentWeaponSkill() == Skill.UnarmedCombat && GetCreatureSkill(Skill.UnarmedCombat).AdvancementClass == SkillAdvancementClass.Specialized)
-                baseCost *= 0.8f;
+            var staminaCostReductionMod = 1.0f;
 
-            // SPEC BONUS: Martial Weapons (Sword) - Stamina costs for melee attacks reduced by 20%
+            // Sword/UA implicit rolled bonuses
+            if (weapon.StaminaCostReductionMod != null)
+                staminaCostReductionMod -= (float)weapon.StaminaCostReductionMod;
+
+            // SPEC BONUS - UA: Stamina costs for melee attacks reduced by 10%
+            if (GetCurrentWeaponSkill() == Skill.UnarmedCombat && GetCreatureSkill(Skill.UnarmedCombat).AdvancementClass == SkillAdvancementClass.Specialized)
+                staminaCostReductionMod -= 0.1f;
+
+            // SPEC BONUS - Martial Weapons (Sword): Stamina costs for melee attacks reduced by 10%
             if (GetCurrentWeaponSkill() == Skill.Sword && GetCreatureSkill(Skill.HeavyWeapons).AdvancementClass == SkillAdvancementClass.Specialized)
-                baseCost *= 0.8f;
+                staminaCostReductionMod -= 0.1f;
+
+            baseCost *= staminaCostReductionMod;
 
             var staminaCost = Math.Max(baseCost, 1);
 

--- a/Source/ACE.Server/WorldObjects/Player_Melee.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Melee.cs
@@ -308,7 +308,7 @@ namespace ACE.Server.WorldObjects
 
             // stamina usage
             // TODO: ensure enough stamina for attack
-            var staminaCost = GetAttackStamina(GetPowerRange(), (float)LastAttackAnimationLength, dualWieldStaminaBonus);
+            var staminaCost = GetAttackStamina(GetPowerRange(), (float)LastAttackAnimationLength, weapon, dualWieldStaminaBonus);
             UpdateVitalDelta(Stamina, -staminaCost);
 
             var combatAbility = CombatAbility.None;

--- a/Source/ACE.Server/WorldObjects/Player_Missile.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Missile.cs
@@ -272,7 +272,7 @@ namespace ACE.Server.WorldObjects
             LastAttackAnimationLength = launchTime + reloadTime + linkTime;
             //Console.WriteLine($"LaunchTime: {launchTime}, Reload: {reloadTime} (BaseReload: {reloadTime*animSpeed}), Link: {linkTime}");
 
-            var staminaCost = GetAttackStamina(GetAccuracyRange(), (float)LastAttackAnimationLength);
+            var staminaCost = GetAttackStamina(GetAccuracyRange(), (float)LastAttackAnimationLength, weapon);
             UpdateVitalDelta(Stamina, -staminaCost);
 
             var combatAbility = CombatAbility.None;

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -1987,6 +1987,12 @@ namespace ACE.Server.WorldObjects
             set { if (!value.HasValue) RemoveProperty(PropertyFloat.ArmorResourcePenalty); else SetProperty(PropertyFloat.ArmorResourcePenalty, value.Value); }
         }
 
+        public double? StaminaCostReductionMod
+        {
+            get => GetProperty(PropertyFloat.StaminaCostReductionMod);
+            set { if (!value.HasValue) RemoveProperty(PropertyFloat.StaminaCostReductionMod); else SetProperty(PropertyFloat.StaminaCostReductionMod, value.Value); }
+        }
+
         public uint? CombatTableDID
         {
             get => GetProperty(PropertyDataId.CombatTable);

--- a/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
@@ -3,6 +3,7 @@ using ACE.Common;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
 using ACE.Server.Entity;
+using ACE.Server.Factories;
 using ACE.Server.Network.GameMessages.Messages;
 using ACE.Server.WorldObjects.Entity;
 
@@ -764,6 +765,13 @@ namespace ACE.Server.WorldObjects
             var creatureMod = IgnoreAegis ?? 0.0f;
             var weaponMod = weapon.IgnoreAegis ?? 0.0f;
 
+            var player = weapon.Wielder as Player;
+
+            // SPEC BONUS - War Magic (Orb): +10% aegis penetration (additively)
+            if (player != null)
+                if (weapon.WeaponSkill == Skill.WarMagic && player.GetCreatureSkill(Skill.WarMagic).AdvancementClass == SkillAdvancementClass.Specialized && LootGenerationFactory.GetCasterSubType(weapon) == 0)
+                    creatureMod -= 0.1f;
+
             var finalMod = 1.0f - (float)Math.Max(creatureMod, weaponMod);
             //Console.WriteLine($"FinalMod = {finalMod}"); 
 
@@ -772,7 +780,7 @@ namespace ACE.Server.WorldObjects
 
         public bool HasIgnoreAegis()
         {
-            return IgnoreAegis != null ? true : false; ;
+            return IgnoreAegis != null ? true : false;
         }
 
         public static int GetBaseSkillImbued(CreatureSkill skill)


### PR DESCRIPTION
- Halve all current weapon spec bonuses (and add War spec bonuses)
   - Axe/Dagger/Bow/Scepter: +5% crit chance
   - Mace/Staff/Atlatl/Wand: +50% crit damage
   - Spear/Crossbow/Orb: +10% ignore armor/aegis
   - Sword/UA: +10% Stamina Cost Reduction
- Add implicit bonuses to weapons that match the spec bonus
   - Axe/Dagger/Bow/Scepter: +0-10% crit chance
   - Mace/Staff/Atlatl/Wand: +0-100% crit damage
   - Spear/Crossbow/Orb: +0-20% ignore armor/aegis
   - Sword/UA: +0-20% Stamina Cost Reduction
   - Staff (caster): +0-10% defense mods
- New stat: Stamina Cost Reduction
- Add implicit bonuses to workmanship calculation
   - (Damage x2 + Mods + Implicit) / 4
- Adjust Aegis/Armor Cleaving text on appraisal