### PR TITLE
feat: monster stat setting emotes

### DIFF
--- a/Source/ACE.Entity/Enum/EmoteType.cs
+++ b/Source/ACE.Entity/Enum/EmoteType.cs
@@ -140,5 +140,8 @@ namespace ACE.Entity.Enum
         EraseFellowQuest              = 10002,
         SetLBEnviron                  = 10003,
         RelieveVitaePenalty           = 10004,
+        SetMyIntStat                  = 10005,
+        SetMyBoolStat                 = 10006,
+        SetMyFloatStat                = 10007,
     }
 }

--- a/Source/ACE.Server/WorldObjects/Creature_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Properties.cs
@@ -2,6 +2,7 @@ using System;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
 using ACE.Server.Managers;
+using ACE.Server.Network.GameMessages.Messages;
 
 namespace ACE.Server.WorldObjects
 {
@@ -804,5 +805,37 @@ namespace ACE.Server.WorldObjects
         }
 
         public FactionBits Society => Faction1Bits ?? FactionBits.None;
+
+        public void UpdateProperty(WorldObject obj, PropertyInt prop, int? value, bool broadcast = false)
+        {
+            if (value != null)
+                obj.SetProperty(prop, value.Value);
+            else
+                obj.RemoveProperty(prop);
+
+            var msg = new GameMessagePublicUpdatePropertyInt(obj, prop, value ?? 0);
+        }
+
+        public void UpdateProperty(WorldObject obj, PropertyBool prop, bool? value, bool broadcast = false)
+        {
+            if (value != null)
+                obj.SetProperty(prop, value.Value);
+            else
+                obj.RemoveProperty(prop);
+
+            var msg = new GameMessagePublicUpdatePropertyBool(obj, prop, value ?? false);
+
+        }
+
+        public void UpdateProperty(WorldObject obj, PropertyFloat prop, double? value, bool broadcast = false)
+        {
+            if (value != null)
+                obj.SetProperty(prop, value.Value);
+            else
+                obj.RemoveProperty(prop);
+
+            var msg = new GameMessagePublicUpdatePropertyFloat(obj, prop, value ?? 0.0);
+
+        }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
@@ -1285,6 +1285,27 @@ namespace ACE.Server.WorldObjects.Managers
                     //if (creature != null)
                     //    creature.NoseTextureDID = (uint)emote.Display;
                     break;
+                case EmoteType.SetMyIntStat:
+
+                    if (creature != null)
+                    {
+                        creature.UpdateProperty(creature, (PropertyInt)emote.Stat, emote.Amount);
+                    }
+                    break;
+                case EmoteType.SetMyFloatStat:
+
+                    if (creature != null)
+                    {
+                        creature.UpdateProperty(creature, (PropertyFloat)emote.Stat, emote.Percent);
+                    }
+                    break;
+                case EmoteType.SetMyBoolStat:
+
+                    if (creature != null)
+                    {
+                        creature.UpdateProperty(creature, (PropertyBool)emote.Stat, emote.Amount == 0 ? false : true);
+                    }
+                    break;
 
                 case EmoteType.SetMyQuestBitsOff:
                 case EmoteType.SetQuestBitsOff:


### PR DESCRIPTION
- allows monsters to set some of their own properties
- spells can only change a handful of things and the decreased duration of debuffs/buffs limits that further