### PR TITLE
fix-recipe wield check

### DIFF
--- a/Source/ACE.Entity/Enum/WeenieType.cs
+++ b/Source/ACE.Entity/Enum/WeenieType.cs
@@ -77,9 +77,9 @@ namespace ACE.Entity.Enum
         EmpoweredScarab,
         CombatFocus,
         ArmorPatch,
-        TailoringKit,
         Jewel,
         Salvage,
         SpellTransference,
+        TailoringKit,
     }
 }

--- a/Source/ACE.Server/Managers/RecipeManager.cs
+++ b/Source/ACE.Server/Managers/RecipeManager.cs
@@ -62,6 +62,13 @@ namespace ACE.Server.Managers
                 return;
             }
 
+            if (target.Wielder != null)
+            {
+                player.Session.Network.EnqueueSend(new GameMessageSystemChat($"You cannot use the {source.NameWithMaterial} on a wielded item.", ChatMessageType.Craft));
+                player.SendUseDoneEvent();
+                return;
+            }
+
             var recipe = GetRecipe(player, source, target);
 
             if (recipe == null)


### PR DESCRIPTION
- adds a not-wielded requirement to recipemanager by default (yes I know about blockWielded) to prevent issues with equipped item ratings with jewel unsocketing and tinkering/untinkering.
- also resorted WeenieTypes so existing weenies have the proper numbers