### PR TITLE
feat: automatic ivorying

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -1089,6 +1089,14 @@ namespace ACE.Server.WorldObjects
                                 item.EmoteManager.OnPickup(this);
                                 item.NotifyOfEvent(RegenerationType.PickUp);
 
+                                // CUSTOM - Automatic Ivorying
+                                if (item.Attuned == AttunedStatus.Attuned && item.Ivoryable == true)
+                                {
+                                    item.Attuned = AttunedStatus.Normal;
+                                    item.AllowedWielder = this.Guid.Full;
+                                    item.CraftsmanName = this.Name;
+                                }
+
                                 if (questSolve)
                                     item.EmoteManager.OnQuest(this);
 

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -3956,5 +3956,23 @@ namespace ACE.Server.WorldObjects
             get => (int?)GetProperty(PropertyInt.BaseWeaponTime);
             set { if (!value.HasValue) RemoveProperty(PropertyInt.BaseWeaponTime); else SetProperty(PropertyInt.BaseWeaponTime, value.Value); }
         }
+
+        public bool Ivoryable
+        {
+            get => GetProperty(PropertyBool.Ivoryable) ?? true;
+            set { if (value) RemoveProperty(PropertyBool.Ivoryable); else SetProperty(PropertyBool.Ivoryable, value); }
+        }
+
+        public uint? AllowedWielder
+        {
+            get => GetProperty(PropertyInstanceId.AllowedWielder);
+            set { if (!value.HasValue) RemoveProperty(PropertyInstanceId.AllowedWielder); else SetProperty(PropertyInstanceId.AllowedWielder, value.Value); }
+        }
+
+        public string CraftsmanName
+        {
+            get => GetProperty(PropertyString.CraftsmanName);
+            set { if (value == null) RemoveProperty(PropertyString.CraftsmanName); else SetProperty(PropertyString.CraftsmanName, value); }
+        }
     }
 }


### PR DESCRIPTION
- attuned but ivoryable items now immediately become unattuned + wielder linked on pickup
- restricting quest item use to one player only was the goal of attunement, and ivory was a workaround to allow players to mule said quest items. But it is an unnecessary extra step