### PR TITLE
feat: adjust portal magic rules

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Magic.cs
@@ -537,6 +537,10 @@ namespace ACE.Server.WorldObjects
                     castingPreCheckStatus = CastingPreCheckStatus.Success;
             }
 
+            // portal spells never fizzle
+            if (spell.School == MagicSchool.PortalMagic)
+                castingPreCheckStatus = CastingPreCheckStatus.Success;
+
             // build-in spells never fizzle
             if (isWeaponSpell)
                 castingPreCheckStatus = CastingPreCheckStatus.Success;

--- a/Source/ACE.Server/WorldObjects/Player_Skills.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Skills.cs
@@ -74,8 +74,9 @@ namespace ACE.Server.WorldObjects
                 var cannotRaiseMsg = $"You cannot raise your {creatureSkill.Skill.ToSentence()} skill directly.";
                 switch (creatureSkill.Skill)
                 {
-                    case Skill.Leadership: Session.Network.EnqueueSend(new GameMessageSystemChat(cannotRaiseMsg + " It raises automatically overtime if you have active vassals.", ChatMessageType.Advancement)); return false;
-                    case Skill.Loyalty: Session.Network.EnqueueSend(new GameMessageSystemChat(cannotRaiseMsg + " It raises automatically overtime while you are active and have a patron.", ChatMessageType.Advancement)); return false;
+                    case Skill.PortalMagic: Session.Network.EnqueueSend(new GameMessageSystemChat(cannotRaiseMsg + " You gain experience towards it when you attune yourself to a new portal magic attunement device.", ChatMessageType.Advancement)); return false;
+                    case Skill.Leadership: Session.Network.EnqueueSend(new GameMessageSystemChat(cannotRaiseMsg + " You gain experience towards it when your vassals earn experience for you.", ChatMessageType.Advancement)); return false;
+                    case Skill.Loyalty: Session.Network.EnqueueSend(new GameMessageSystemChat(cannotRaiseMsg + " You gain experience towards it when you earn experience for your patron.", ChatMessageType.Advancement)); return false;
                     case Skill.Alchemy: Session.Network.EnqueueSend(new GameMessageSystemChat(cannotRaiseMsg + " You gain experience towards it when performing Alchemy recipes. You may also purchase training from an Alchemist.", ChatMessageType.Advancement)); return false;
                     case Skill.Cooking: Session.Network.EnqueueSend(new GameMessageSystemChat(cannotRaiseMsg + " You gain experience towards it when performing Cooking recipes. You may also purchase training from a Chef or Provisioner.", ChatMessageType.Advancement)); return false;
                     case Skill.WeaponTinkering: Session.Network.EnqueueSend(new GameMessageSystemChat(cannotRaiseMsg + " You gain experience towards it when performing Blacksmithing recipes. You may also purchase training from a Blacksmith, Weaponsmith, or Armorer.", ChatMessageType.Advancement)); return false;


### PR DESCRIPTION
* portal magic spells never fizzle.
* prevent using unassigned xp to raise portal magic.