### PR TITLE
feat: award skill ranks

### DIFF
--- a/Source/ACE.Entity/Enum/EmoteType.cs
+++ b/Source/ACE.Entity/Enum/EmoteType.cs
@@ -143,5 +143,6 @@ namespace ACE.Entity.Enum
         SetMyIntStat                  = 10005,
         SetMyBoolStat                 = 10006,
         SetMyFloatStat                = 10007,
+        AwardSkillRanks               = 10008,
     }
 }

--- a/Source/ACE.Server/Entity/Proficiency.cs
+++ b/Source/ACE.Server/Entity/Proficiency.cs
@@ -105,7 +105,7 @@ namespace ACE.Server.Entity
                 // send PP to player as skill XP, which gets spent from the CP sent
                 if (pp > 0)
                 {
-                    player.HandleActionRaiseSkill(skill.Skill, pp, false);
+                    player.HandleActionRaiseSkill(skill.Skill, pp);
                 }
             }
         }
@@ -118,19 +118,6 @@ namespace ACE.Server.Entity
                 return;
             }
             OnSuccessUse(player, skill, (uint)difficulty);
-        }
-
-        // CRAFTING - Proficiency XP: Gain 10% xp (1% for failure) directly into skill, max cap set at recipe difficulty.
-        public static void OnCraftingSuccessUse(Player player, CreatureSkill skill, uint difficulty, bool success, Skill playerSkill)
-        {
-            var percent = success ? .2 : 0.05;
-            long min = 0;
-            var max = player.GetXPBetweenSkillLevels(skill.AdvancementClass, (int)difficulty, (int)difficulty + 1);
-
-            if (percent <= 0 || !max.HasValue)
-                return;
-
-            player.GrantLevelProportionalSkillXP(playerSkill, percent, min, (long)max);
         }
     }
 }

--- a/Source/ACE.Server/Managers/RecipeManager.cs
+++ b/Source/ACE.Server/Managers/RecipeManager.cs
@@ -386,12 +386,17 @@ namespace ACE.Server.Managers
                 if (modified.Contains(target.Guid.Full))
                     UpdateObj(player, target);
             }
-            // regardless of success, grant proficiency xp
-            if (recipe.Skill > 0 && recipe.Difficulty > 0)
+            // CUSTOM CRAFTING - Ranking Up - On success, grant a 20% chance to rank up the skill, up to 10 higher than difficulty
+            if (recipe.Skill > 0 && recipe.Difficulty > 0 && success)
             {
                 var skill = player.GetCreatureSkill((Skill)recipe.Skill);
                 var playerSkill = (Skill)recipe.Skill;
-                Proficiency.OnCraftingSuccessUse(player, skill, recipe.Difficulty, success, playerSkill);
+                if (skill.Ranks < recipe.Difficulty + 10)
+                {
+                    var chance = ThreadSafeRandom.Next(1, 5);
+                    if (chance == 5)
+                        player.GrantSkillRanks(playerSkill, 1);
+                }
             }
         }
 

--- a/Source/ACE.Server/Network/GameAction/Actions/GameActionRaiseSkill.cs
+++ b/Source/ACE.Server/Network/GameAction/Actions/GameActionRaiseSkill.cs
@@ -10,7 +10,7 @@ namespace ACE.Server.Network.GameAction.Actions
             var skill = (Skill)message.Payload.ReadUInt32();
             var xpSpent = message.Payload.ReadUInt32();
 
-            session.Player.HandleActionRaiseSkill(skill, xpSpent, false);
+            session.Player.HandleActionRaiseSkill(skill, xpSpent);
         }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
@@ -128,6 +128,11 @@ namespace ACE.Server.WorldObjects.Managers
                         player.GrantLevelProportionalXp(emote.Percent ?? 0, min, max);
                     break;
 
+                case EmoteType.AwardSkillRanks:
+                    if (player != null)
+                        player.GrantSkillRanks((Skill)emote.Stat, (int)emote.Amount);
+
+                   break;
                 case EmoteType.AwardLuminance:
 
                     if (player != null)


### PR DESCRIPTION
- provides support for simple ranking up of portal magic and trade skills without fiddling around with granting xp that doesn't count towards total etc.

- crafting leveling now handled with a chance to rank up on recipe use, rather than granting proficiency xp

- essentially these skills will function as though experience didn't exist--cannot spend xp into them, or gain any through any means, and of course get none back on untraining