### PR TITLE
update- trade skill untraining

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Skills.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Skills.cs
@@ -291,14 +291,25 @@ namespace ACE.Server.WorldObjects
                     creatureSkill.AdvancementClass = SkillAdvancementClass.Untrained;
                     creatureSkill.InitLevel = 0;
 
-                    if(IsTradeSkill(skill))
-                        creditsSpent = 0;
-
                     AvailableSkillCredits += creditsSpent;
                 }
 
                 creatureSkill.Ranks = 0;
                 creatureSkill.ExperienceSpent = 0;
+
+                // CUSTOM - Trade Skills - Handle Quest Stamps on Untrain
+                if (IsTradeSkill(skill))
+                {
+                   if (QuestManager.HasQuest("TradeSkill"))
+                    {
+                        var solves = QuestManager.GetCurrentSolves("TradeSkill");
+                        if (solves == 1)
+                            QuestManager.Erase("TradeSkill");
+                        else
+                            QuestManager.Decrement("TradeSkill");
+                    }
+
+                }
             }
 
             return true;
@@ -953,9 +964,6 @@ namespace ACE.Server.WorldObjects
                 creatureSkill.InitLevel = 0;
                 AvailableSkillCredits += skillBase.TrainedCost;
             }
-
-            // CRAFTING - Untraining: Gain no gained crafting experience back (it is not included in max amount)
-            refund = !IsTradeSkill(skill); 
 
             if (refund)
                 RefundXP(creatureSkill.ExperienceSpent);

--- a/Source/ACE.Server/WorldObjects/SkillAlterationDevice.cs
+++ b/Source/ACE.Server/WorldObjects/SkillAlterationDevice.cs
@@ -219,6 +219,18 @@ namespace ACE.Server.WorldObjects
                     {
                         var untrainable = Player.IsSkillUntrainable(skill.Skill, (HeritageGroup)player.Heritage);
 
+                       if (player.IsTradeSkill(skill.Skill))
+                        {
+                            if (player.UntrainSkill(skill.Skill, 0))
+                            {
+                                var updateSkill = new GameMessagePrivateUpdateSkill(player, skill);
+                                var msg = untrainable ? WeenieErrorWithString.YouHaveSucceededUntraining_Skill : WeenieErrorWithString.CannotUntrain_SkillButRecoveredXP;
+                                var message = new GameEventWeenieErrorWithString(player.Session, msg, newSkill.ToSentence());
+
+                                player.Session.Network.EnqueueSend(updateSkill, message);
+                                player.TryConsumeFromInventoryWithNetworking(this, 1);
+                            }
+                        } 
                         if (player.UntrainSkill(skill.Skill, skillBase.TrainedCost))
                         {
                             var updateSkill = new GameMessagePrivateUpdateSkill(player, skill);


### PR DESCRIPTION
- adds a separate code path to deal with trade skill untraining that refunds no credits (preivous check in player skills did not work)

- handles TradeSkill limiting quest stamps (the issue with just using an emote on the forgetfulness gem is that it fires off at the start of the code sequence regardless of whether you confirm to untrain the skill, so you could get your quest stamps removed and get multiple skills, and a purely weenie based approach did not seem to work with a contained gem (though it does with a remote-used object)