### PR TITLE
feat: allow vendors to sell items with shared cooldowns

### DIFF
--- a/Source/ACE.Entity/Enum/Properties/PropertyInt.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyInt.cs
@@ -645,6 +645,7 @@ namespace ACE.Entity.Enum.Properties
         BaseAegis                               = 453,
         BaseWeaponTime                          = 454,
         BaseMaxMana                             = 455,
+        VendorItemSharedCooldown                = 456,
 
 
         [ServerOnly]

--- a/Source/ACE.Entity/Enum/SpellId.cs
+++ b/Source/ACE.Entity/Enum/SpellId.cs
@@ -6385,8 +6385,7 @@ namespace ACE.Entity.Enum
 
         HealingKitCooldown                  = 0x8000 | 10003,   // varies
 
-        FocusedTaunt                        = 0x8000 | 10050,   // 15 second cooldown
-        AreaTaunt                           = 0x8000 | 10050,   // 15 second cooldown
+        Taunts                              = 0x8000 | 10050,   // 15 second cooldown (Focus Taunt and Area Taunt)
         FeignWeakness                       = 0x8000 | 10051,   // 15 second cooldown
         Vanish                              = 0x8000 | 10052,   // 60 second cooldown
         ExposeWeakness                      = 0x8000 | 10053,   // 15 second cooldown

--- a/Source/ACE.Server/WorldObjects/Container.cs
+++ b/Source/ACE.Server/WorldObjects/Container.cs
@@ -590,6 +590,10 @@ namespace ACE.Server.WorldObjects
                 worldObject.WieldSkillType3 = worldObject.WieldSkillType3.HasValue ? (int)worldObject.ConvertToMoASkill((Skill)worldObject.WieldSkillType3) : null;
                 worldObject.WieldSkillType4 = worldObject.WieldSkillType4.HasValue ? (int)worldObject.ConvertToMoASkill((Skill)worldObject.WieldSkillType4) : null;
             }
+            
+            // If item has a TempSharedCooldown, set SharedCooldown to the same value
+            if (worldObject.VendorItemSharedCooldown != null)
+                worldObject.CooldownId = worldObject.VendorItemSharedCooldown;
 
             OnAddItem();
 

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -1665,6 +1665,12 @@ namespace ACE.Server.WorldObjects
             set { if (!value.HasValue) RemoveProperty(PropertyInt.SharedCooldown); else SetProperty(PropertyInt.SharedCooldown, value.Value); }
         }
 
+        public int? VendorItemSharedCooldown
+        {
+            get => GetProperty(PropertyInt.VendorItemSharedCooldown);
+            set { if (!value.HasValue) RemoveProperty(PropertyInt.VendorItemSharedCooldown); else SetProperty(PropertyInt.VendorItemSharedCooldown, value.Value); }
+        }
+
         public double? CooldownDuration
         {
             get => GetProperty(PropertyFloat.CooldownDuration);


### PR DESCRIPTION
* Items must use a different Int to set a shared cooldown on the sql file (Int 456 - VendorItemSharedCooldown).
* SharedCooldown gets copied over after an item is purchased.