### PR TITLE
fix: hotspots

### DIFF
--- a/Source/ACE.Server/WorldObjects/Hotspot.cs
+++ b/Source/ACE.Server/WorldObjects/Hotspot.cs
@@ -182,6 +182,10 @@ namespace ACE.Server.WorldObjects
         {
             if (!IsHot) return;
 
+            if (!(creature is Player))
+                if (!AffectsAis && !AffectsOnlyAis)
+                    return;
+
             var amount = DamageNext;
             var iAmount = (int)Math.Round(amount);
 


### PR DESCRIPTION
- ensures hotspots only hit monsters when either AffectsAis or AffectsOnlyAis is set to true.