### PR TITLE
feat- decept spec bonus

### DIFF
--- a/Source/ACE.Server/WorldObjects/Creature_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Combat.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Data.Common;
 using System.Linq;
 using ACE.Common;
 using ACE.Entity;
@@ -898,26 +899,6 @@ namespace ACE.Server.WorldObjects
                 behind = Math.Abs(angle) > 45.0f;
             }
 
-            // SPEC BONUS - Deception: Up to 50% chance to sneak attack from the front. Both chance and damage bonus scaled for skill.
-            var deception = GetCreatureSkill(Skill.Deception);
-            if (deception.AdvancementClass == SkillAdvancementClass.Specialized)
-            {
-                var attackSkill = GetCreatureSkill(GetCurrentAttackSkill());
-                var skillChance = (float)deception.Current / (float)attackSkill.Current;
-                var chance = skillChance > 1f ? 0.5f : skillChance * 0.5f;
-
-                if (chance >= ThreadSafeRandom.Next(0f, 1f))
-                {
-                    if (deception.Current < attackSkill.Current)
-                    {
-                        var bonusPenalty = (float)(deception.Current / attackSkill.Current);
-                        return 1.2f * bonusPenalty;
-                    }
-                    else
-                        return 1.2f;
-                }
-            }
-
             if (behind)
             {
                 var targetPlayer = target as Player;
@@ -935,8 +916,33 @@ namespace ACE.Server.WorldObjects
                 return 1.2f; // 20% bonus
             }
             else
-                return 1.0f;
-            
+            {
+                // SPEC BONUS - Deception: Up to 50% chance to sneak attack from the front. Both chance and damage bonus scaled for skill.
+                var deception = GetCreatureSkill(Skill.Deception);
+                if (deception.AdvancementClass == SkillAdvancementClass.Specialized)
+                {
+                    var attackSkill = GetCreatureSkill(GetCurrentAttackSkill());
+                    var skillChance = (float)deception.Current / (float)attackSkill.Current;
+                    var chance = skillChance > 1f ? 0.5f : skillChance * 0.5f;
+
+                    if (chance >= ThreadSafeRandom.Next(0f, 1f))
+                    {
+                        if (deception.Current < attackSkill.Current)
+                        {
+                            var bonusPenalty = (float)deception.Current / (float)attackSkill.Current;
+                            return 1.2f * bonusPenalty;
+                        }
+                        else
+                            return 1.2f;
+                    }
+                    else
+                        return 1.0f;
+                }
+                else
+                    return 1.0f;
+
+            }
+
         }
 
         public void FightDirty(WorldObject target, WorldObject weapon)

--- a/Source/ACE.Server/WorldObjects/Creature_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Combat.cs
@@ -903,7 +903,7 @@ namespace ACE.Server.WorldObjects
             if (deception.AdvancementClass == SkillAdvancementClass.Specialized)
             {
                 var attackSkill = GetCreatureSkill(GetCurrentAttackSkill());
-                var skillChance = (float)(deception.Current / attackSkill.Current);
+                var skillChance = (float)deception.Current / (float)attackSkill.Current;
                 var chance = skillChance > 1f ? 0.5f : skillChance * 0.5f;
 
                 if (chance >= ThreadSafeRandom.Next(0f, 1f))

--- a/Source/ACE.Server/WorldObjects/Creature_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Combat.cs
@@ -904,7 +904,7 @@ namespace ACE.Server.WorldObjects
             {
                 var attackSkill = GetCreatureSkill(GetCurrentAttackSkill());
                 var skillChance = (float)(deception.Current / attackSkill.Current);
-                var chance = skillChance > 1f ? 1f : skillChance * 0.5f;
+                var chance = skillChance > 1f ? 0.5f : skillChance * 0.5f;
 
                 if (chance >= ThreadSafeRandom.Next(0f, 1f))
                 {

--- a/Source/ACE.Server/WorldObjects/Creature_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Combat.cs
@@ -898,6 +898,26 @@ namespace ACE.Server.WorldObjects
                 behind = Math.Abs(angle) > 45.0f;
             }
 
+            // SPEC BONUS - Deception: Up to 50% chance to sneak attack from the front. Both chance and damage bonus scaled for skill.
+            var deception = GetCreatureSkill(Skill.Deception);
+            if (deception.AdvancementClass == SkillAdvancementClass.Specialized)
+            {
+                var attackSkill = GetCreatureSkill(GetCurrentAttackSkill());
+                var skillChance = (float)(deception.Current / attackSkill.Current);
+                var chance = skillChance > 1f ? 1f : skillChance * 0.5f;
+
+                if (chance >= ThreadSafeRandom.Next(0f, 1f))
+                {
+                    if (deception.Current < attackSkill.Current)
+                    {
+                        var bonusPenalty = (float)(deception.Current / attackSkill.Current);
+                        return 1.2f * bonusPenalty;
+                    }
+                    else
+                        return 1.2f;
+                }
+            }
+
             if (behind)
             {
                 var targetPlayer = target as Player;


### PR DESCRIPTION
- adds up to 50% chance to sneak from the front with spec deception
- chance and damage bonus scale, depending on ratio of deception skill to attack skill