### PR TITLE
fix: locked doors

### DIFF
--- a/Source/ACE.Server/WorldObjects/Door.cs
+++ b/Source/ACE.Server/WorldObjects/Door.cs
@@ -90,7 +90,7 @@ namespace ACE.Server.WorldObjects
             var player = worldObject as Player;
             var behind = player != null && player.GetRelativeDir(this).HasFlag(Quadrant.Back);
 
-            if (!IsLocked || behind)
+            if (!IsLocked)
             {
                 if (!IsOpen)
                     Open(worldObject.Guid);


### PR DESCRIPTION
- removes the ability to open locked doors from behind (I assume this was retail behavior that was maintained for the sake of fidelity, but it just encourages cheese).