### PR TITLE
update: capstone landblock selection

### DIFF
--- a/Source/ACE.DatLoader/DatManager.cs
+++ b/Source/ACE.DatLoader/DatManager.cs
@@ -11,7 +11,7 @@ namespace ACE.DatLoader
 
         private static int count;
 
-        private static int ITERATION_CELL = 30000;
+        private static int ITERATION_CELL = 30002;
         private static int ITERATION_PORTAL = 30013;
         private static int ITERATION_HIRES = 497;
         private static int ITERATION_LANGUAGE = 30005;

--- a/Source/ACE.Entity/Enum/EmoteType.cs
+++ b/Source/ACE.Entity/Enum/EmoteType.cs
@@ -145,5 +145,6 @@ namespace ACE.Entity.Enum
         SetMyFloatStat                = 10007,
         AwardSkillRanks               = 10008,
         CapstoneCacheReward           = 10009,
+        AssignCapstoneDungeon         = 10010,
     }
 }

--- a/Source/ACE.Entity/Enum/Properties/PropertyBool.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyBool.cs
@@ -184,6 +184,7 @@ namespace ACE.Entity.Enum.Properties
         AffectsOnlyAis                   = 141,
         ExamineItemsSilently             = 142, // allows for no/custom message upon NPC Emote Refuse examination of items
         TakeItemsSilently                = 143, // allows for no/custom messages for NPC TakeItems emote
+        DungeonLockout                   = 144, // if object is on landblock, no new players will be added to permitted list
 
         /* custom */
         [ServerOnly]

--- a/Source/ACE.Entity/Enum/Properties/PropertyString.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyString.cs
@@ -102,12 +102,7 @@ namespace ACE.Entity.Enum.Properties
         VendorBroadcastAppend = 9009,
         JewelSocket1 = 9010,
         JewelSocket2 = 9011,
-        JewelSocket3 = 9012,
-        JewelSocket4 = 9013,
-        JewelSocket5 = 9014,
-        JewelSocket6 = 9015,
-        JewelSocket7 = 9016,
-        JewelSocket8 = 9017
+        CacheLog     = 9012,
     }
 
     public static class PropertyStringExtensions

--- a/Source/ACE.Server/Entity/Fellowship.cs
+++ b/Source/ACE.Server/Entity/Fellowship.cs
@@ -43,6 +43,8 @@ namespace ACE.Server.Entity
 
         public QuestManager QuestManager;
 
+        public LandblockId? CapstoneDungeon;
+
         /// <summary>
         /// Called when a player first creates a Fellowship
         /// </summary>

--- a/Source/ACE.Server/Entity/GeneratorProfile.cs
+++ b/Source/ACE.Server/Entity/GeneratorProfile.cs
@@ -12,6 +12,7 @@ using ACE.Server.Managers;
 using ACE.Server.Physics.Common;
 using ACE.Server.WorldObjects;
 using Serilog;
+using Quaternion = System.Numerics.Quaternion;
 
 namespace ACE.Server.Entity
 {
@@ -321,8 +322,20 @@ namespace ACE.Server.Entity
         {
             // specific position
             if ((Biota.ObjCellId ?? 0) > 0)
-                obj.Location = new ACE.Entity.Position(Biota.ObjCellId ?? 0, Biota.OriginX ?? 0, Biota.OriginY ?? 0, Biota.OriginZ ?? 0, Biota.AnglesX ?? 0, Biota.AnglesY ?? 0, Biota.AnglesZ ?? 0, Biota.AnglesW ?? 0);
+            {
+                var loc = Biota.ObjCellId;
+                // allow generator slots to use whichever lb the generator is on, while keeping the cellId
+                if (Biota.ObjCellId != Generator.Location.LandblockId.Raw)
+                {
+                    var originalCellId = ((int)Biota.ObjCellId).ToString("X8");
+                    var generatorLandblockId = ((int)Generator.Location.LandblockId.Raw).ToString("X8");
+                    
+                    var modifiedCellId = generatorLandblockId.Substring(0, 4) + originalCellId.Substring(4);
 
+                    loc = uint.Parse(modifiedCellId, System.Globalization.NumberStyles.HexNumber);
+                }
+                obj.Location = new ACE.Entity.Position(loc ?? 0, Biota.OriginX ?? 0, Biota.OriginY ?? 0, Biota.OriginZ ?? 0, Biota.AnglesX ?? 0, Biota.AnglesY ?? 0, Biota.AnglesZ ?? 0, Biota.AnglesW ?? 0);
+            }
             // offset from generator location
             else
             {

--- a/Source/ACE.Server/Managers/WorldManager.cs
+++ b/Source/ACE.Server/Managers/WorldManager.cs
@@ -156,6 +156,8 @@ namespace ACE.Server.Managers
 
             session.SetPlayer(player);
 
+            Player.HandleCapstoneLandblockLogin(session, player);
+
             if (stripAdminProperties) // continue stripping properties
             {
                 player.CloakStatus = CloakStatus.Undef;

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -44,6 +44,9 @@ namespace ACE.Server.WorldObjects
         public bool LastContact = true;
 
         public Player P_PetOwner;
+
+        public LandblockId? CapstoneDungeon;
+
         public bool IsJumping
         {
             get

--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -1634,8 +1634,11 @@ namespace ACE.Server.WorldObjects
                         AdjustDungeon(teleportDest);
 
                         targetPlayer.Teleport(teleportDest);
+
+                        portal.EmoteManager.OnPortal(player);
                     });
                     portalRecall.EnqueueChain();
+
                 }
             }
         }

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -3440,43 +3440,6 @@ namespace ACE.Server.WorldObjects
             get => GetProperty(PropertyString.JewelSocket2);
             set { if (value == null) RemoveProperty(PropertyString.JewelSocket2); else SetProperty(PropertyString.JewelSocket2, value); }
         }
-
-        public string JewelSocket3
-        {
-            get => GetProperty(PropertyString.JewelSocket3);
-            set { if (value == null) RemoveProperty(PropertyString.JewelSocket3); else SetProperty(PropertyString.JewelSocket3, value); }
-        }
-
-        public string JewelSocket4
-        {
-            get => GetProperty(PropertyString.JewelSocket4);
-            set { if (value == null) RemoveProperty(PropertyString.JewelSocket4); else SetProperty(PropertyString.JewelSocket4, value); }
-        }
-
-        public string JewelSocket5
-        {
-            get => GetProperty(PropertyString.JewelSocket5);
-            set { if (value == null) RemoveProperty(PropertyString.JewelSocket5); else SetProperty(PropertyString.JewelSocket5, value); }
-        }
-
-        public string JewelSocket6
-        {
-            get => GetProperty(PropertyString.JewelSocket6);
-            set { if (value == null) RemoveProperty(PropertyString.JewelSocket6); else SetProperty(PropertyString.JewelSocket6, value); }
-        }
-
-        public string JewelSocket7
-        {
-            get => GetProperty(PropertyString.JewelSocket7);
-            set { if (value == null) RemoveProperty(PropertyString.JewelSocket7); else SetProperty(PropertyString.JewelSocket7, value); }
-        }
-
-        public string JewelSocket8
-        {
-            get => GetProperty(PropertyString.JewelSocket8);
-            set { if (value == null) RemoveProperty(PropertyString.JewelSocket8); else SetProperty(PropertyString.JewelSocket8, value); }
-        }
-
         public int? JewelSockets
         {
             get => GetProperty(PropertyInt.JewelSockets);
@@ -3959,7 +3922,7 @@ namespace ACE.Server.WorldObjects
 
         public bool? Ivoryable
         {
-            get => GetProperty(PropertyBool.Ivoryable) ?? true;
+            get => GetProperty(PropertyBool.Ivoryable);
             set { if (!value.HasValue) RemoveProperty(PropertyBool.Ivoryable); else SetProperty(PropertyBool.Ivoryable, value.Value); }
         }
 
@@ -3973,6 +3936,18 @@ namespace ACE.Server.WorldObjects
         {
             get => GetProperty(PropertyString.CraftsmanName);
             set { if (value == null) RemoveProperty(PropertyString.CraftsmanName); else SetProperty(PropertyString.CraftsmanName, value); }
+        }
+
+        public bool? DungeonLockout
+        {
+            get => GetProperty(PropertyBool.DungeonLockout);
+            set { if (!value.HasValue) RemoveProperty(PropertyBool.DungeonLockout); else SetProperty(PropertyBool.DungeonLockout, value.Value); }
+        }
+
+        public string CacheLog
+        {
+            get => GetProperty(PropertyString.CacheLog);
+            set { if (value == null) RemoveProperty(PropertyString.CacheLog); else SetProperty(PropertyString.CacheLog, value); }
         }
     }
 }


### PR DESCRIPTION
-adds capstone instancing, details follow.
- also includes support to enable relative generation to work on any landblock with no changes to the weenies

Players and Fellowships now have a CapstoneDungeon property, which is a uint copy of a landblock Id.
Landblocks now have:
	- CapstoneMax - max number of players on a capstone landblock
	- CapstonePlayers - a dictionary of Player / double (for timers). By default the timer is set to 0, but timer starts when player leaves a dungeon or are added to the list when a fellow member enters the dungeon.
	- CapstoneSeatHolder - 10 minutes (in seconds), serving as a timer for above
	- CapstoneLockout - On LB heartbeat, it checks for any object with DungeonLockout bool and if so, lb sets this to true.  If true, no new players can be added to the CapstonePlayers list.  End boss caches are being given this property, in order to prevent players from being placed in a dungeon that is already completed, and to prevent players joining right at the end to grab a reward.

ON ENTERING A CAPSTONE PORTAL:
	Portal emote fires off AssignCapstoneDungeon emote, which includes the dungeon name. A list of landblock IDs associated with that name is generated.
FELLOWSHIP?:
	IF HAS CAPSTONE FLAG:
	- Check if fellow has a Capstone flag, and if so, does it match one of the dungeons on the list
	- If it does, check to see if that individual player is on the list of permitted players associated with that landblock
	- If so, port them 
	- If not, check to see if that instance has open slots
	- If so port them in, if not send them a broadcast explanation
	IF NO FLAG:
	If fellow has no capstone flag, or one that is not on this list, find an open instance for them, checking each landblock in the list of IDs generated at the start for any that can contain them.
	- If it finds one, stamp the fellow with that Capstone ID, add all members to the permitted players list, start a cooldown timer for them to get there, and send message to alert them.
	- Teleport the initiating player into the dungeon ahead of his fellow.
** Checking Capstone Timers **
	- On landblock heartbeats, we check the CapstonePlayers list versus the players physically present on the landblock. If any aren't on the landblock, we start a timer for them.
	- Then we check for any active timers. CapstoneSeatHolder value is set to 10 minutes currently, and once that much has elapsed the player is removed from the CapstonePlayers list, which opens a slot for other people to join if the dungeon was full.  Active timers are reset to 0 upon entering the dungeon.

IF NO FELLOW:
	Does player have a CapstoneDungeon flag? And does it match one in this list?
	If not, check for an open instance for them.
	If so, are they still on the player list for that specific instance?  If so, TP them.  If not, check for open slots. If any, TP them, if not, try to find open instance.
	FindOpenInstance:
	- Cycles through the landblocks on the list checking for room, and if finding TPs and breaks, if none sends explanation.
	
CAPSTONE PORTALS:
	Capstone portals include the portal emote, which redirects the player to one of the dungeons.
	- Added a Portal Emote check to recall spells so dungeon selection process will still fire off on recalls. 
	The surface portals inside the dungeons remain quest restricted, and players will only be flagged by physically visiting the portal location for the first time (with watchdog). This way players can still join friends in capstones via summoned portals but can't use them as a shortcut without having visited once themselves.

LOGGING OFF ON CAPSTONE LANDBLOCKS:  
	When players log in a capstone landblock, if they are still on the permitted players list they are left at whatever position they were previously in.
	If they ARENT on the players list (10 mins has elapsed since they logged out, or landblock has reset) we check to see if the landblock is not locked (cache active) and if it has room for them--if so, we send them to the start of this dungeon (prevents logout cheese)
	Otherwise, we send them to their lifestone. Wanted to just send them through the FindOpenInstance method again but there was no quick reference to the list of dungeon Ids, so player can just recall to the dungeon to get sent through this method again if they want to.


@Capstone command
	- type @capstone to receive a list of capstones with active instances
	- type @capstone [dungeon name] to get more detailed information on instances of that dungeon, including players currently inside, players permitted (and timers until they lose their position, if any),  landblock uptime, dormant status.
