### PR TITLE
feat: perception spec bonus

### DIFF
--- a/Source/ACE.Server/Entity/DamageEvent.cs
+++ b/Source/ACE.Server/Entity/DamageEvent.cs
@@ -1,21 +1,14 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection.Metadata.Ecma335;
 using ACE.Common;
-using ACE.DatLoader.Entity;
-using ACE.Database.Models.Auth;
 using ACE.DatLoader.Entity.AnimationHooks;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
 using ACE.Entity.Models;
-using ACE.Server.Factories;
-using ACE.Server.Factories.Entity;
 using ACE.Server.Managers;
 using ACE.Server.Network.GameMessages.Messages;
 using ACE.Server.WorldObjects;
-using Google.Protobuf.WellKnownTypes;
-using Org.BouncyCastle.Asn1.X509;
 using Serilog;
 using Time = ACE.Common.Time;
 
@@ -463,7 +456,25 @@ namespace ACE.Server.Entity
                         CriticalDefended = true;
                 }
 
-                if (!CriticalDefended)
+                var perceptionDefended = false;
+                // SPEC BONUS: Perception - 50% chance to defend against a critical hit
+                if (playerDefender != null)
+                {
+                    var perception = playerDefender.GetCreatureSkill(Skill.AssessCreature);
+                    if (perception.AdvancementClass == SkillAdvancementClass.Specialized)
+                    {
+                        var skillCheck = (float)perception.Current / (float)attackSkill.Current;
+                        var criticalDefenseChance = skillCheck > 1f ? 0.5f : skillCheck * 0.5f;
+
+                        if (criticalDefenseChance > ThreadSafeRandom.Next(0f, 1f))
+                        {
+                            perceptionDefended = true;
+                            playerDefender.Session.Network.EnqueueSend(new GameMessageSystemChat($"Your perception skill allowed you to prevent a critical strike!", ChatMessageType.CombatEnemy));
+                        }
+                    }
+                }
+
+                if (!CriticalDefended && perceptionDefended == false)
                 {
                     IsCritical = true;
 
@@ -490,8 +501,6 @@ namespace ACE.Server.Entity
                     {
                         CriticalDamageMod += playerAttacker.GetAccuracyCritDamageMod(Weapon);
                     }
-
-                   
 
                     if (playerAttacker != null)
                     {   // JEWEL - White Sapphire: Ramping Bludgeon Crit Damage Bonus

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -511,11 +511,25 @@ namespace ACE.Server.WorldObjects
                         critDefended = true;
                 }
 
-                if (!critDefended)
-                    criticalHit = true;
+                // SPEC BONUS: Perception - 50% chance to prevent a critical hit
+                var perceptionDefended = false;
+                var perception = targetPlayer.GetCreatureSkill(Skill.AssessCreature);
+                if (perception.AdvancementClass == SkillAdvancementClass.Specialized)
+                {
+                    var skillCheck = (float)perception.Current / (float)attackSkill.Current;
+                    var criticalDefenseChance = skillCheck > 1f ? 0.5f : skillCheck * 0.5f;
+
+                    if (criticalDefenseChance > ThreadSafeRandom.Next(0f, 1f))
+                    {
+                        perceptionDefended = true;
+                        targetPlayer.Session.Network.EnqueueSend(new GameMessageSystemChat($"Your perception skill allowed you to prevent a critical strike!", ChatMessageType.Magic));
+                    }
+                }
+
+                if (!critDefended && perceptionDefended == false)
+                criticalHit = true;
 
                 // Jewelcrafting Reprisal-- Chance to resist an incoming critical
-
                 if (criticalHit)
                 {
                     if (targetPlayer != null && sourceCreature != null)


### PR DESCRIPTION
- adds 50% chance to avoid a critical strike with perception spec, scaling with skill
- also removes unnecessary usings from damage event