### PR TITLE
feat: heatseeking blasts

### DIFF
--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -3948,6 +3948,7 @@ namespace ACE.Server.WorldObjects
         {
             get => GetProperty(PropertyString.CacheLog);
             set { if (value == null) RemoveProperty(PropertyString.CacheLog); else SetProperty(PropertyString.CacheLog, value); }
+        }
 
         public int? ItemSpellId
         {


### PR DESCRIPTION
- adds heatseeking blast code

- if spelltype isn't blast, we just create projectiles as usual, otherwise we create a list of targets near our main target, filter them for 2 additional valid ones, then create projectiles for those + main target.

- damage is scaled by 75% if 2 targets, by 2/3 if 3 targets.