### PR TITLE
feat: jump spec bonus

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -1008,6 +1008,13 @@ namespace ACE.Server.WorldObjects
 
             if (MagicState.IsCasting && RecordCast.Enabled)
                 RecordCast.OnJump(jump);
+
+            //SPEC BONUS - Jump: Gain a buff that doubles Jump skill for 10 seconds after jumping.
+            if (GetCreatureSkill(Skill.Jump).AdvancementClass == SkillAdvancementClass.Specialized)
+            {
+                var jumpSpell = new Spell(SpellId.JumpMasteryRare);
+                TryCastSpell(jumpSpell, this);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
* Cast a buff spell on self when jumping.
   * Does not improve the first jump. Player must do a brief jump to gain the buff first.
   * Current spell is a placeholder (RareJump). Will eventually be a custom spell that doubles skill.
   * This is in addition to the half-fall damage bonus that is already implemented.