### PR TITLE
feat: improve stealth detection system

### DIFF
--- a/Source/ACE.Entity/Enum/Properties/PropertyBool.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyBool.cs
@@ -185,6 +185,7 @@ namespace ACE.Entity.Enum.Properties
         ExamineItemsSilently             = 142, // allows for no/custom message upon NPC Emote Refuse examination of items
         TakeItemsSilently                = 143, // allows for no/custom messages for NPC TakeItems emote
         DungeonLockout                   = 144, // if object is on landblock, no new players will be added to permitted list
+        CannotBreakStealth               = 145,
 
         /* custom */
         [ServerOnly]

--- a/Source/ACE.Server/WorldObjects/Monster_Tick.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Tick.cs
@@ -1,4 +1,7 @@
+using ACE.Common;
 using ACE.Entity.Enum;
+using ACE.Server.Managers;
+using System;
 
 namespace ACE.Server.WorldObjects
 {
@@ -78,7 +81,7 @@ namespace ACE.Server.WorldObjects
             if (playerTarget != null && playerTarget.IsStealthed)
             {
                 if (IsDirectVisible(playerTarget))
-                    playerTarget.EndStealth($"{Name} can still see you! You stop sneaking!");
+                    playerTarget.TestStealth(this, $"{Name} detects you! You lose stealth.");
             }
 
             if (creatureTarget != null && (creatureTarget.IsDead || (combatPet == null && !IsVisibleTarget(creatureTarget))) || (playerTarget != null && playerTarget.IsStealthed))

--- a/Source/ACE.Server/WorldObjects/Player_Monster.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Monster.cs
@@ -27,7 +27,7 @@ namespace ACE.Server.WorldObjects
                 var distSq = PhysicsObj.get_distance_sq_to_object(monster.PhysicsObj, true);
                 //var distSq = Location.SquaredDistanceTo(monster.Location);
 
-                if (distSq <= monster.VisualAwarenessRangeSq &&!TestStealth(monster, distSq, $"{monster.Name} sees you! You lose stealth."))
+                if (distSq <= monster.VisualAwarenessRangeSq &&!TestStealth(monster, distSq, $"{monster.Name} detects you! You lose stealth."))
                     AlertMonster(monster);
             }
         }

--- a/Source/ACE.Server/WorldObjects/WorldObject.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject.cs
@@ -1195,5 +1195,11 @@ namespace ACE.Server.WorldObjects
             get => GetProperty(PropertyBool.OverrideArchetypeSkills);
             set { if (!value.HasValue) RemoveProperty(PropertyBool.OverrideArchetypeSkills); else SetProperty(PropertyBool.OverrideArchetypeSkills, value.Value); }
         }
+
+        public bool? CannotBreakStealth
+        {
+            get => GetProperty(PropertyBool.CannotBreakStealth);
+            set { if (!value.HasValue) RemoveProperty(PropertyBool.CannotBreakStealth); else SetProperty(PropertyBool.CannotBreakStealth, value.Value); }
+        }
     }
 }


### PR DESCRIPTION
* Add bool for special creatures that shouldn't be able to break player stealth (watchers, etc).
* Adjust detection rules:
   * Monster can gain up to x2 Perception skill depending on how close the player is to them.
   * Monster can gain up to x2 Perception skill depending on what side of the monster the player is standing (x2 directly in front, x0 directly behind)
   * Each monster can only attempt to detect a nearby stealth player once every 3 seconds. (previously they were making 10+ attempts per second)