### PR TITLE
feat: adjust lootgen material system

### DIFF
--- a/Source/ACE.Server/Factories/LootGenerationFactory.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory.cs
@@ -852,8 +852,6 @@ namespace ACE.Server.Factories
             var materialCloth = LootTables.DefaultMaterial[4];
             var materialLeather = LootTables.DefaultMaterial[5];
 
-            var random = ThreadSafeRandom.Next(0, 1);
-
             WeenieType weenieType = wo.WeenieType;
             switch (weenieType)
             {
@@ -867,7 +865,7 @@ namespace ACE.Server.Factories
                         }
                         else
                         {
-                            if (random == 0)
+                            if (ThreadSafeRandom.Next(0, 1) == 0)
                             {
                                 int roll = ThreadSafeRandom.Next(0, materialWoods.Length - 1);
                                 material = (MaterialType)materialWoods[roll];

--- a/Source/ACE.Server/Factories/LootGenerationFactory.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Drawing.Text;
 using System.Linq;
 using System.Threading;
 using ACE.Common;
@@ -14,7 +15,6 @@ using ACE.Server.Factories.Tables;
 using ACE.Server.Factories.Tables.Wcids;
 using ACE.Server.Managers;
 using ACE.Server.WorldObjects;
-using Pomelo.EntityFrameworkCore.MySql.Query.ExpressionVisitors.Internal;
 using Serilog;
 using WeenieClassName = ACE.Server.Factories.Enum.WeenieClassName;
 
@@ -786,6 +786,8 @@ namespace ACE.Server.Factories
         /// </summary>
         private static MaterialType GetMaterialType(WorldObject wo, int tier)
         {
+            return GetDefaultMaterialType(wo);
+
             if (wo.TsysMutationData == null)
             {
                 _log.Warning($"[LOOT] Missing PropertyInt.TsysMutationData on loot item {wo.WeenieClassId} - {wo.Name}");
@@ -842,32 +844,94 @@ namespace ACE.Server.Factories
                 return MaterialType.Unknown;
 
             MaterialType material = MaterialType.Unknown;
-            int defaultMaterialEntry = ThreadSafeRandom.Next(0, 4);
+
+            var materialWoods = LootTables.DefaultMaterial[0];
+            var materialMetals = LootTables.DefaultMaterial[1];
+            var materialGems = LootTables.DefaultMaterial[2];
+            var materialStones = LootTables.DefaultMaterial[3];
+            var materialCloth = LootTables.DefaultMaterial[4];
+            var materialLeather = LootTables.DefaultMaterial[5];
+
+            var random = ThreadSafeRandom.Next(0, 1);
 
             WeenieType weenieType = wo.WeenieType;
             switch (weenieType)
             {
                 case WeenieType.Caster:
-                    material = (MaterialType)LootTables.DefaultMaterial[3][defaultMaterialEntry];
+                    {
+                        uint[] orbs = { 2366, 1050101, 1050102, 1050103, 1050104, 1050105, 1050106, 1050107 };
+                        if (orbs.Contains(wo.WeenieClassId))
+                        {
+                            int roll = ThreadSafeRandom.Next(0, materialGems.Length - 1);
+                            material = (MaterialType)materialGems[roll];
+                        }
+                        else
+                        {
+                            if (random == 0)
+                            {
+                                int roll = ThreadSafeRandom.Next(0, materialWoods.Length - 1);
+                                material = (MaterialType)materialWoods[roll];
+                            }
+                            else
+                            {
+                                int roll = ThreadSafeRandom.Next(0, materialMetals.Length - 1);
+                                material = (MaterialType)materialMetals[roll];
+                            }
+                        }
+                    }
                     break;
                 case WeenieType.Clothing:
-                    if (wo.ItemType == ItemType.Armor)
-                        material = (MaterialType)LootTables.DefaultMaterial[0][defaultMaterialEntry];
-                    if (wo.ItemType == ItemType.Clothing)
-                        material = (MaterialType)LootTables.DefaultMaterial[5][defaultMaterialEntry];
+                    {
+                        if (wo.ArmorWeightClass == (int)ArmorWeightClass.Cloth)
+                        {
+                            int roll = ThreadSafeRandom.Next(0, materialCloth.Length - 1);
+                            material = (MaterialType)materialCloth[roll];
+                        }
+                        else if (wo.ArmorWeightClass == (int)ArmorWeightClass.Light)
+                        {
+                            int roll = ThreadSafeRandom.Next(0, materialLeather.Length - 1);
+                            material = (MaterialType)materialLeather[roll];
+                        }
+                        else if (wo.ArmorWeightClass == (int)ArmorWeightClass.Heavy)
+                        {
+                            int roll = ThreadSafeRandom.Next(0, materialMetals.Length - 1);
+                            material = (MaterialType)materialMetals[roll];
+                        }
+                    }
                     break;
                 case WeenieType.MissileLauncher:
                 case WeenieType.Missile:
-                    material = (MaterialType)LootTables.DefaultMaterial[1][defaultMaterialEntry];
+                    {
+                        uint[] metalThrownWeapons = { };
+                        if (metalThrownWeapons.Contains(wo.WeenieClassId))
+                        {
+                            int roll = ThreadSafeRandom.Next(0, materialMetals.Length - 1);
+                            material = (MaterialType)materialMetals[roll];
+                        }
+                        else
+                        {
+                            int roll = ThreadSafeRandom.Next(0, materialWoods.Length - 1);
+                            material = (MaterialType)materialWoods[roll];
+                        }
+                    }
                     break;
                 case WeenieType.MeleeWeapon:
-                    material = (MaterialType)LootTables.DefaultMaterial[2][defaultMaterialEntry];
+                    {
+                        uint[] woodMeleeWeapons = { 309, 3766, 3767, 3768, 3769, 7768, 7787, 7788, 7789, 7790 };  
+                        if(wo.WeaponSkill == Skill.Staff || wo.WeaponSkill == Skill.Spear || woodMeleeWeapons.Contains(wo.WeenieClassId))
+                        {
+                            int roll = ThreadSafeRandom.Next(0, materialWoods.Length - 1);
+                            material = (MaterialType)materialWoods[roll];
+                        }
+                        else
+                        {
+                            int roll = ThreadSafeRandom.Next(0, materialMetals.Length - 1);
+                            material = (MaterialType)materialMetals[roll];
+                        }
+                    }
                     break;
                 case WeenieType.Generic:
-                    if (wo.ItemType == ItemType.Jewelry)
-                        material = (MaterialType)LootTables.DefaultMaterial[3][defaultMaterialEntry];
-                    if (wo.ItemType == ItemType.MissileWeapon)
-                        material = (MaterialType)LootTables.DefaultMaterial[4][defaultMaterialEntry];
+                    material = MaterialType.Unknown;
                     break;
                 default:
                     material = MaterialType.Unknown;

--- a/Source/ACE.Server/Factories/LootTables.cs
+++ b/Source/ACE.Server/Factories/LootTables.cs
@@ -1985,12 +1985,23 @@ namespace ACE.Server.Factories
 
         public static readonly int[][] DefaultMaterial =
         {
-            new int[] { (int)MaterialType.Copper, (int)MaterialType.Bronze, (int)MaterialType.Iron, (int)MaterialType.Steel, (int)MaterialType.Silver },            // Armor
-            new int[] { (int)MaterialType.Oak, (int)MaterialType.Teak, (int)MaterialType.Mahogany, (int)MaterialType.Pine, (int)MaterialType.Ebony },               // Missile
-            new int[] { (int)MaterialType.Brass, (int)MaterialType.Ivory, (int)MaterialType.Gold, (int)MaterialType.Steel, (int)MaterialType.Diamond },             // Melee
-            new int[] { (int)MaterialType.RedGarnet, (int)MaterialType.Jet, (int)MaterialType.BlackOpal, (int)MaterialType.FireOpal, (int)MaterialType.Emerald },   // Caster
-            new int[] { (int)MaterialType.Granite, (int)MaterialType.Ceramic, (int)MaterialType.Porcelain, (int)MaterialType.Alabaster, (int)MaterialType.Marble }, // Dinnerware
-            new int[] { (int)MaterialType.Linen, (int)MaterialType.Wool, (int)MaterialType.Velvet, (int)MaterialType.Satin, (int)MaterialType.Silk }                // Clothes
+            // Wood
+            new int[] { (int)MaterialType.Oak, (int)MaterialType.Teak, (int)MaterialType.Mahogany, (int)MaterialType.Pine, (int)MaterialType.Ebony },               
+
+            // Metal 
+            new int[] { (int)MaterialType.Iron, (int)MaterialType.Steel, (int)MaterialType.Copper, (int)MaterialType.Bronze, (int)MaterialType.Brass, (int)MaterialType.Pyreal, },             
+
+            // Common Gems
+            new int[] { (int)MaterialType.Amethyst, (int)MaterialType.GreenGarnet, (int)MaterialType.LavenderJade, (int)MaterialType.Malachite, (int)MaterialType.Opal, (int)MaterialType.RoseQuartz },   
+
+            // Stone
+            new int[] { (int)MaterialType.Granite, (int)MaterialType.Ceramic, (int)MaterialType.Porcelain, (int)MaterialType.Alabaster, (int)MaterialType.Marble, (int)MaterialType.Sandstone, (int)MaterialType.Ivory }, 
+
+            // Cloth
+            new int[] { (int)MaterialType.Linen, (int)MaterialType.Wool, (int)MaterialType.Velvet, (int)MaterialType.Satin, (int)MaterialType.Silk },               
+
+            // Leather
+            new int[] { (int)MaterialType.Leather, (int)MaterialType.ArmoredilloHide, (int)MaterialType.GromnieHide, (int)MaterialType.ReedSharkHide },             
         };
 
         public enum ArmorType


### PR DESCRIPTION
* Greatly simplified and no longer references the db.
* Less random material combinations. More logical now.
* Only some gemtypes added (to Orb drops). Imbue gems only available from actual gems atm.

TODO
* Need to add WCIDs for metal thrown weapons.
* Make Koujia chest/leggings use metal instead of leather.
* Possibly add more gemtypes.
* Check for other specific loot types that need adjusting.