### PR TITLE
feat: strikethrough volleys

### DIFF
--- a/Source/ACE.Server/Physics/PhysicsObj.cs
+++ b/Source/ACE.Server/Physics/PhysicsObj.cs
@@ -6,6 +6,7 @@ using ACE.Common;
 using ACE.Entity;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
+using ACE.Server.Entity;
 using ACE.Server.Entity.Actions;
 using ACE.Server.Managers;
 using ACE.Server.Physics.Animation;
@@ -16,6 +17,7 @@ using ACE.Server.Physics.Hooks;
 using ACE.Server.Physics.Managers;
 using ACE.Server.WorldObjects;
 using Serilog;
+using Landblock = ACE.Server.Physics.Common.Landblock;
 using Plane = System.Numerics.Plane;
 using Position = ACE.Server.Physics.Common.Position;
 
@@ -392,6 +394,13 @@ namespace ACE.Server.Physics
                     return TransitionState.OK;
                 ethereal = true;
             }
+            // CUSTOM - Strikethrough: permits strikethrough projectiles to travel cleanly through monsters, even if they're not ethereal
+            if (WeenieObj.WorldObject != null && WeenieObj.WorldObject.Attackable == true)
+            {
+                if (transition.ObjectInfo.Object.WeenieObj.WorldObject != null && transition.ObjectInfo.Object.WeenieObj.WorldObject is SpellProjectile)
+                    ethereal = true;
+            }
+
             transition.SpherePath.ObstructionEthereal = ethereal;
 
             var state = transition.ObjectInfo.State;
@@ -2674,9 +2683,22 @@ namespace ACE.Server.Physics
                     retval = true;
             }
 
+            // CUSTOM - Strikethrough: Allow volley projectiles to continue traveling until they hit 3 targets
+            var spellProjectile = WeenieObj.WorldObject is SpellProjectile ? WeenieObj.WorldObject as SpellProjectile : null;
+            var spellType = spellProjectile != null ? SpellProjectile.GetProjectileSpellType(spellProjectile.Spell.Id) : ProjectileSpellType.Undef;
+
+            var strikethrough = false;
+
+            if (spellProjectile != null && spellType == ProjectileSpellType.Volley)
+            { 
+                strikethrough = true;
+                if (spellProjectile.Strikethrough >= 3)
+                    strikethrough = false;
+            }
+
             if (collisions.FramesStationaryFall <= 1)
             {
-                if (apply_bounce && collisions.CollisionNormalValid)
+                if (apply_bounce && collisions.CollisionNormalValid && !strikethrough)
                 {
                     if (State.HasFlag(PhysicsState.Inelastic))
                     {
@@ -2705,6 +2727,7 @@ namespace ACE.Server.Physics
                     return retval;
                 }
             }
+
 
             if (collisions.FramesStationaryFall == 0)
                 TransientState &= ~TransientStateFlags.StationaryComplete;

--- a/Source/ACE.Server/Physics/PhysicsObj.cs
+++ b/Source/ACE.Server/Physics/PhysicsObj.cs
@@ -2690,9 +2690,10 @@ namespace ACE.Server.Physics
             var strikethrough = false;
 
             if (spellProjectile != null && spellType == ProjectileSpellType.Volley)
-            { 
+            {
                 strikethrough = true;
-                if (spellProjectile.Strikethrough >= 3)
+
+                if (spellProjectile.Strikethrough >= spellProjectile.StrikethroughLimit)
                     strikethrough = false;
             }
 

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -30,7 +30,8 @@ namespace ACE.Server.WorldObjects
 
         public PartialEvasion PartialEvasion;
 
-        public double Strikethrough = 0;
+        public int Strikethrough = 0;
+        public int StrikethroughLimit = 3;
 
         public List<uint> StrikethroughTargets = new List<uint>();
 
@@ -286,8 +287,8 @@ namespace ACE.Server.WorldObjects
 
             var spellType = GetProjectileSpellType(Spell.Id);
             if (spellType != ProjectileSpellType.Volley)
-                 ProjectileImpact();
-            if (spellType == ProjectileSpellType.Volley && Strikethrough == 3)
+                ProjectileImpact();
+            if (spellType == ProjectileSpellType.Volley && Strikethrough == StrikethroughLimit || ThreadSafeRandom.Next(0, 1) == 0)
                 ProjectileImpact();
 
             // ensure valid creature target
@@ -834,10 +835,7 @@ namespace ACE.Server.WorldObjects
                         jewelLastStand += Jewel.GetJewelLastStand(sourcePlayer, target);
                 }
 
-                var strikethroughMod = 1f;
-                if (Strikethrough == 1) strikethroughMod = 0.5f;
-                if (Strikethrough == 2) strikethroughMod = 0.33f;
-                if (Strikethrough >= 3) strikethroughMod = 0.1f;
+                var strikethroughMod = 1f / (Strikethrough + 1);
 
                 // ----- FINAL CALCULATION ------------
                 var damageBeforeMitigation = baseDamage * criticalDamageMod * attributeMod * elementalDamageMod * slayerMod * combatFocusDamageMod * jewelElementalist * jewelElemental * jewelSelfHarm * jewelLastStand * strikethroughMod;
@@ -1240,7 +1238,7 @@ namespace ACE.Server.WorldObjects
                 var overloadMsg = overload ? $"{overloadPercent}% Overload! " : "";
                 var resistSome = PartialEvasion == PartialEvasion.Some ? "Minor resist! " : "";
                 var resistMost = PartialEvasion == PartialEvasion.Most ? "Major resist! " : "";
-                var strikeThrough = Strikethrough > 0 ? "Strikethrough: " : "";
+                var strikeThrough = Strikethrough > 0 ? "Strikethrough! " : "";
 
                 var nonHealth = Spell.Category == SpellCategory.StaminaLowering || Spell.Category == SpellCategory.ManaLowering;
 

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -32,6 +32,7 @@ namespace ACE.Server.WorldObjects
 
         public int Strikethrough = 0;
         public int StrikethroughLimit = 3;
+        public double StrikethroughChance = 0.5f;
 
         public List<uint> StrikethroughTargets = new List<uint>();
 
@@ -288,7 +289,7 @@ namespace ACE.Server.WorldObjects
             var spellType = GetProjectileSpellType(Spell.Id);
             if (spellType != ProjectileSpellType.Volley)
                 ProjectileImpact();
-            if (spellType == ProjectileSpellType.Volley && Strikethrough == StrikethroughLimit || ThreadSafeRandom.Next(0, 1) == 0)
+            if (spellType == ProjectileSpellType.Volley && Strikethrough == StrikethroughLimit || ThreadSafeRandom.Next(0.0f, 1.0f) < StrikethroughChance)
                 ProjectileImpact();
 
             // ensure valid creature target

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -3949,6 +3949,7 @@ namespace ACE.Server.WorldObjects
             get => GetProperty(PropertyString.CacheLog);
             set { if (value == null) RemoveProperty(PropertyString.CacheLog); else SetProperty(PropertyString.CacheLog, value); }
 
+        }
         public int? ItemSpellId
         {
             get => (int?)GetProperty(PropertyInt.ItemSpellId);


### PR DESCRIPTION
On hitting a target with a volley projectile:
	1. Check to ensure target's guid is not on the StrikethroughTargets list
	2. Call the ProjectileImpact method if the projectile has struck three targets
	3. Increment the projectile's Strikethrough
	4. Add the target's guid to the StrikethroughTargets list 
	5. During damage calculation, scale down damage based on previous targets hit

During collision detection: 
	1. Allow strikethrough projectiles (volleys only atm) to transition cleanly through a target, as though it were ethereal
	2. Prevent collisions from stopping the projectile until it reaches 3 targets (Double checked to ensure no projectiles are persisting on the landblock)
