### PR TITLE
feat: update campfire mechanics

### DIFF
--- a/Source/ACE.Entity/Enum/Properties/PropertyBool.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyBool.cs
@@ -186,6 +186,7 @@ namespace ACE.Entity.Enum.Properties
         TakeItemsSilently                = 143, // allows for no/custom messages for NPC TakeItems emote
         DungeonLockout                   = 144, // if object is on landblock, no new players will be added to permitted list
         CannotBreakStealth               = 145,
+        CampfireHotspot                  = 146,
 
         /* custom */
         [ServerOnly]

--- a/Source/ACE.Server/WorldObjects/Hotspot.cs
+++ b/Source/ACE.Server/WorldObjects/Hotspot.cs
@@ -203,8 +203,8 @@ namespace ACE.Server.WorldObjects
             
             if (player != null)
                 player.RechargeEmpoweredScarabs(this);
-
-            if (player != null && this.Tier != null)
+            
+            if (player != null && CampfireHotspot == true)
             {   
                 var forwardCommand = player.CurrentMovementData.MovementType == MovementType.Invalid && player.CurrentMovementData.Invalid != null ? player.CurrentMovementData.Invalid.State.ForwardCommand : MotionCommand.Invalid;
                 if (forwardCommand == MotionCommand.Sitting || forwardCommand == MotionCommand.Sleeping || forwardCommand == MotionCommand.Crouch)
@@ -215,19 +215,17 @@ namespace ACE.Server.WorldObjects
 
                     if (player.CampfireTimer < Time.GetUnixTime())
                     {
-                      
-                        var spell = new ACE.Server.Entity.Spell(SpellId.SprintOther1);  // placeholder
-                        player.CreateEnchantment(player, this, null, spell);
-                        player.Session.Network.EnqueueSend(new GameMessageSystemChat($"Gazing into the fire calms your soul.", ChatMessageType.Magic));
+                        if(player.WellRestedHotspot == null)
+                            player.Session.Network.EnqueueSend(new GameMessageSystemChat($"Gazing into the fire calms your soul.", ChatMessageType.Magic));
+
                         player.CampfireTimer = 0;
+                        player.WellRestedHotspot = this;
                     }
-                    
-                        
                 }
                 else
                     player.CampfireTimer = 0;
-                    
             }
+
             switch (DamageType)
             {
                 default:

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -121,6 +121,8 @@ namespace ACE.Server.WorldObjects
             }
         }
 
+        public Hotspot? WellRestedHotspot = null;
+
         public ConfirmationManager ConfirmationManager;
 
         public SquelchManager SquelchManager;

--- a/Source/ACE.Server/WorldObjects/Player_Networking.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Networking.cs
@@ -371,6 +371,18 @@ namespace ACE.Server.WorldObjects
             // TODO: use real motion / animation system from physics
             //CurrentMotionCommand = movementData.Invalid.State.ForwardCommand;
             CurrentMovementData = movementData;
+
+            if (WellRestedHotspot != null)
+            {
+                var forwardCommand =  CurrentMovementData.Invalid.State.ForwardCommand;
+                if (forwardCommand != MotionCommand.Crouch && forwardCommand != MotionCommand.Sitting && forwardCommand != MotionCommand.Sleeping)
+                {
+                    var spell = new ACE.Server.Entity.Spell(SpellId.TrinketXPBoost1);  // placeholder
+                    CreateEnchantment(this, WellRestedHotspot, null, spell);
+
+                    WellRestedHotspot = null;
+                }
+            }
         }
 
         private EnvironChangeType? currentFogColor;

--- a/Source/ACE.Server/WorldObjects/WorldObject.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject.cs
@@ -1201,5 +1201,11 @@ namespace ACE.Server.WorldObjects
             get => GetProperty(PropertyBool.CannotBreakStealth);
             set { if (!value.HasValue) RemoveProperty(PropertyBool.CannotBreakStealth); else SetProperty(PropertyBool.CannotBreakStealth, value.Value); }
         }
+
+        public bool? CampfireHotspot
+        {
+            get => GetProperty(PropertyBool.CampfireHotspot);
+            set { if (!value.HasValue) RemoveProperty(PropertyBool.CampfireHotspot); else SetProperty(PropertyBool.CampfireHotspot, value.Value); }
+        }
     }
 }


### PR DESCRIPTION
* Hotspot created by a campfire requires CampfireHotspot bool to be set to true to work.
* Once player receives the "Gazing into the fire calms your soul." message, it will not appear again until after player stands up.
* Campfire buff effect no longer applies until the player stands up.
* Placeholder buff changed to Augmented Understanding I.
* Future:
   * Make 3 tiers of campfires for 3 different levels of buff effects?
   * Create different types of campfire with different spells? Or allow manipulating of campfires by cooking different foods in them to change the active spell?