### PR TITLE
Feat banking

### DIFF
--- a/Source/ACE.Database/SerializedShardDatabase.cs
+++ b/Source/ACE.Database/SerializedShardDatabase.cs
@@ -190,7 +190,15 @@ namespace ACE.Database
 
         }
 
+        public void GetBankInventoryInParallel(uint storageId, uint parentId, bool includedNestedItems, Action<List<Biota>> callback)
+        {
+            _queue.Add(new Task(() =>
+            {
+                var c = BaseDatabase.GetBankInventoryInParallel(storageId, parentId, includedNestedItems);
+                callback?.Invoke(c);
+            }));
 
+        }
         public void IsCharacterNameAvailable(string name, Action<bool> callback)
         {
             _queue.Add(new Task(() =>

--- a/Source/ACE.Entity/Enum/Properties/PropertyInstanceId.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyInstanceId.cs
@@ -75,6 +75,7 @@ namespace ACE.Entity.Enum.Properties
         [ServerOnly][Ephemeral]
         PetDevice                        = 45,
         HotspotOwner                     = 46,
+        BankAccountId                    = 47,
 
         [ServerOnly]
         PCAPRecordedObjectIID            = 8000,

--- a/Source/ACE.Server/Command/Handlers/AdminCommands.cs
+++ b/Source/ACE.Server/Command/Handlers/AdminCommands.cs
@@ -1663,8 +1663,6 @@ namespace ACE.Server.Command.Handlers
                 house = house1.RootHouse;
             else if (target is Hook hook)
                 house = hook.House.RootHouse;
-            else if (target is Storage storage)
-                house = storage.House.RootHouse;
             else if (target is SlumLord slumLord1)
                 house = slumLord1.House.RootHouse;
             else if (target is HousePortal housePortal)

--- a/Source/ACE.Server/WorldObjects/Container.cs
+++ b/Source/ACE.Server/WorldObjects/Container.cs
@@ -88,7 +88,7 @@ namespace ACE.Server.WorldObjects
             SetEphemeralValues(true);
 
             // A player has their possessions passed via the ctor. All other world objects must load their own inventory
-            if (!(this is Player) && !ObjectGuid.IsPlayer(ContainerId ?? 0))
+            if (!(this is Player) && !ObjectGuid.IsPlayer(ContainerId ?? 0) && this.WeenieType != WeenieType.Storage)
             {
                 DatabaseManager.Shard.GetInventoryInParallel(biota.Id, false, biotas =>
                 {
@@ -153,7 +153,7 @@ namespace ACE.Server.WorldObjects
         /// The only time this should be used is to populate Inventory from the ctor.
         /// This will remove from worldObjects as they're sorted.
         /// </summary>
-        private void SortWorldObjectsIntoInventory(IList<WorldObject> worldObjects)
+        public void SortWorldObjectsIntoInventory(IList<WorldObject> worldObjects)
         {
             // This will pull out all of our main pack items and side slot items (foci & containers)
             for (int i = worldObjects.Count - 1; i >= 0; i--)

--- a/Source/ACE.Server/WorldObjects/Jewel.cs
+++ b/Source/ACE.Server/WorldObjects/Jewel.cs
@@ -648,7 +648,7 @@ namespace ACE.Server.WorldObjects
                 }
                 // cycle through slots, emptying out ones that aren't already
 
-                for (int i = 1; i <= 8; i++)
+                for (int i = 1; i <= 2; i++)
                 {
                     string currentSocket = (string)target.GetType().GetProperty($"JewelSocket{i}").GetValue(target);
 

--- a/Source/ACE.Server/WorldObjects/Salvage.cs
+++ b/Source/ACE.Server/WorldObjects/Salvage.cs
@@ -174,7 +174,7 @@ namespace ACE.Server.WorldObjects
 
         public static bool CheckTinkerType(Player player, WorldObject source, WorldObject target, Skill tinkeringSkill)
         {
-            if (tinkeringSkill == Skill.WeaponTinkering && target.ItemType == ItemType.MeleeWeapon || target.ArmorWeightClass == 4)
+            if (tinkeringSkill == Skill.WeaponTinkering && target.ItemType == ItemType.MeleeWeapon || target.WeenieType == WeenieType.Missile || target.ArmorWeightClass == 4)
                 return true;
 
             if (tinkeringSkill == Skill.ItemTinkering && target.ItemType == ItemType.Jewelry)
@@ -195,11 +195,14 @@ namespace ACE.Server.WorldObjects
             if (tinkeringSkill == Skill.ArmorTinkering && target.ArmorWeightClass == 1 && target.ArmorLevel > 0)
                 return true;
 
-            if (tinkeringSkill == Skill.Fletching && target.ItemType == ItemType.MissileWeapon)
+            if (tinkeringSkill == Skill.Fletching && target.WeenieType == WeenieType.MissileLauncher)
                 return true;
 
-            if (ImbueSalvage.Contains((MaterialType)source.MaterialType) && target.ItemType == ItemType.MeleeWeapon || target.ItemType == ItemType.MissileWeapon || target.ItemType == ItemType.Caster)
-                return true;
+            if (ImbueSalvage.Contains((MaterialType)source.MaterialType))
+            {
+                if (target.ItemType == ItemType.MeleeWeapon || target.ItemType == ItemType.MissileWeapon || target.ItemType == ItemType.Caster)
+                    return true;
+            }
 
             // wand checks
             if (source.MaterialType == ACE.Entity.Enum.MaterialType.Malachite || source.MaterialType == ACE.Entity.Enum.MaterialType.Amethyst
@@ -243,7 +246,7 @@ namespace ACE.Server.WorldObjects
                 {
                     // Weapon - 1% Defense | Armor - 0.25% Defense + Shield Mod
                     case ACE.Entity.Enum.MaterialType.Brass:    // Brass
-                        if (target.ItemType == ItemType.MeleeWeapon)
+                        if (target.ItemType == ItemType.MeleeWeapon || target.WeenieType == WeenieType.Missile)
                         {
                             if (target.WeaponPhysicalDefense == null)
                             {
@@ -265,7 +268,7 @@ namespace ACE.Server.WorldObjects
 
                         // Weapon - 5% base damage + 0.5% Defense | Armor - 0.125% Defense + Shield Mod and 5% Armor Level
                     case ACE.Entity.Enum.MaterialType.Bronze:    // Bronze
-                        if (target.ItemType == ItemType.MeleeWeapon)
+                        if (target.ItemType == ItemType.MeleeWeapon || target.WeenieType == WeenieType.Missile)
                         {
                             if (target.WeaponPhysicalDefense == null)
                             {
@@ -292,7 +295,7 @@ namespace ACE.Server.WorldObjects
 
                         // Weapon - 1% attack | Armor - 0.25% AttackMod + 2H mod
                     case ACE.Entity.Enum.MaterialType.Copper:    // Copper
-                        if (target.ItemType == ItemType.MeleeWeapon)
+                        if (target.ItemType == ItemType.MeleeWeapon || target.WeenieType == WeenieType.Missile)
                         {
                             if (target.WeaponOffense == null)
                             {
@@ -314,7 +317,7 @@ namespace ACE.Server.WorldObjects
 
                         // Weapon - 0.5% Attack and 5% damage | Armor - 0.125% Attack and 2h Mods + 5% ArmorLevel
                     case ACE.Entity.Enum.MaterialType.Gold:    // Gold
-                        if (target.ItemType == ItemType.MeleeWeapon)
+                        if (target.ItemType == ItemType.MeleeWeapon || target.WeenieType == WeenieType.Missile)
                         {
                             if (target.WeaponOffense == null)
                             {
@@ -343,7 +346,7 @@ namespace ACE.Server.WorldObjects
 
                         // Weapon - 7.5% Damage but +5 WeaponTime | Armor - 7.5% ArmorLevel but -0.25% Stam Penalty
                     case ACE.Entity.Enum.MaterialType.Iron:    // Iron
-                        if (target.ItemType == ItemType.MeleeWeapon)
+                        if (target.ItemType == ItemType.MeleeWeapon || target.WeenieType == WeenieType.Missile)
                         {
                             var damageBonus = (int)(target.BaseDamage * 0.075) < 1 ? 1 : (int)(target.BaseDamage * 0.075);
                             target.Damage += damageBonus;
@@ -364,7 +367,7 @@ namespace ACE.Server.WorldObjects
 
                         // Weapon - 0.5% MagicD Mod + 5% Damage | Armor - 2 Aegis and 5% ArmorLevel
                     case ACE.Entity.Enum.MaterialType.Pyreal:    // Pyreal
-                        if (target.ItemType == ItemType.MeleeWeapon)
+                        if (target.ItemType == ItemType.MeleeWeapon || target.WeenieType == WeenieType.Missile)
                         {
                             if (target.WeaponMagicalDefense == null)
                             {
@@ -390,7 +393,7 @@ namespace ACE.Server.WorldObjects
 
                         // Weapon - 1% MagicD Mod | Armor - 3 Aegis + 0.25% HP Regen
                     case ACE.Entity.Enum.MaterialType.Silver:    // Silver
-                        if (target.ItemType == ItemType.MeleeWeapon)
+                        if (target.ItemType == ItemType.MeleeWeapon || target.WeenieType == WeenieType.Missile)
                         {
                             if (target.WeaponMagicalDefense == null)
                             {
@@ -412,7 +415,7 @@ namespace ACE.Server.WorldObjects
 
                         // Weapon - 0.5% Defense + 0.5% Offense    | Armor - 5% Armor + 0.25% HP Regen
                     case ACE.Entity.Enum.MaterialType.Steel:    // Steel
-                        if (target.ItemType == ItemType.MeleeWeapon)
+                        if (target.ItemType == ItemType.MeleeWeapon || target.WeenieType == WeenieType.Missile)
                         {
                             if (target.WeaponOffense == null)
                             {

--- a/Source/ACE.Server/WorldObjects/Storage.cs
+++ b/Source/ACE.Server/WorldObjects/Storage.cs
@@ -1,20 +1,22 @@
+using ACE.Database;
 using ACE.Entity;
 using ACE.Entity.Enum;
 using ACE.Entity.Models;
-using ACE.Server.Entity;
+using ACE.Server.Entity.Actions;
 using ACE.Server.Network.GameEvent.Events;
+using ACE.Server.Network.GameMessages;
 using ACE.Server.Network.GameMessages.Messages;
 using Serilog;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Biota = ACE.Entity.Models.Biota;
 
 namespace ACE.Server.WorldObjects
 {
-    public class Storage : Chest
+    public class Storage : Container
     {
         private readonly ILogger _log = Log.ForContext<Storage>();
-
-        public House House { get => ParentLink as House; }
-
-        public override double Default_ChestResetInterval => double.PositiveInfinity;
 
         /// <summary>
         /// A new biota be created taking all of its values from weenie.
@@ -35,55 +37,146 @@ namespace ACE.Server.WorldObjects
         private void SetEphemeralValues()
         {
             IsLocked = false;
+
             IsOpen = false;
 
-            // unanimated objects will float in the air, and not be affected by gravity
-            // unless we give it a bit of velocity to start
-            // fixes floating storage chests
-            //Velocity = new Vector3(0, 0, 0.5f);
             BumpVelocity = true;
+
+            BankChests.Add(this);
         }
 
-        public override ActivationResult CheckUseRequirements(WorldObject activator)
+        public static List<Storage> BankChests = new List<Storage> { };
+
+        public static Player BankUser;
+
+        public override void Open(Player player)
         {
-            var baseRequirements = base.CheckUseRequirements(activator);
-            if (!baseRequirements.Success)
-                return baseRequirements;
+           player.LastOpenedContainerId = Guid;
 
-            if (!(activator is Player player))
-                return new ActivationResult(false);
+            IsOpen = true;
 
-            if (player.IgnoreHouseBarriers)
-                return new ActivationResult(true);
+            Viewer = player.Guid.Full;
 
-            var rootHouse = House?.RootHouse;
+            BankUser = player;
 
-            if (rootHouse == null)
+            Translucency = 1f;
+
+            PlayParticleEffect(PlayScript.Destroy, Guid);
+
+            player.Session.Network.EnqueueSend(new GameEventTell(this, "I am commanded to serve you by storing your objects.", player, ChatMessageType.Tell));
+
+            DatabaseManager.Shard.GetBankInventoryInParallel(Guid.Full, player.Account.AccountId, true, biotas =>
             {
-                _log.Error($"[HOUSE] {player.Name} tried to use Storage chest @ {Location}, couldn't find RootHouse (this shouldn't happen)");
-                return new ActivationResult(false);
-            }
-
-            if (!rootHouse.HasPermission(player, true))
-            {
-                player.Session.Network.EnqueueSend(new GameEventCommunicationTransientString(player.Session, $"You do not have permission to access {Name}"));
-                EnqueueBroadcast(new GameMessageSound(Guid, Sound.OpenFailDueToLock, 1.0f));
-                return new ActivationResult(false);
-            }
-            return new ActivationResult(true);
+                EnqueueAction(new ActionEventDelegate(() => SortBiotasIntoBank(biotas)));
+            });
         }
 
+        protected void SortBiotasIntoBank(IEnumerable<ACE.Database.Models.Shard.Biota> biotas)
+        {
+            var worldObjects = new List<WorldObject>();
+
+            foreach (var biota in biotas)
+                worldObjects.Add(Factories.WorldObjectFactory.CreateWorldObject(biota));
+
+            // check for GUID in any other banks and remove from inventory if so.
+            foreach (var worldObject in worldObjects)
+            {
+               foreach (var bank in BankChests)
+                {
+                    if (bank.Inventory.Keys.Contains(worldObject.Guid))
+                       bank.Inventory.Remove(worldObject.Guid);
+                }
+
+            }
+            SortWorldObjectsIntoBank(worldObjects);
+
+            if (worldObjects.Count > 0)
+                _log.Error("Inventory detected without a container to put it in to.");
+        }
+
+        private void SortWorldObjectsIntoBank(IList<WorldObject> worldObjects)
+        {
+            for (int i = worldObjects.Count - 1; i >= 0; i--)
+            {
+               if ((worldObjects[i].ContainerId ?? 0) == Biota.Id)
+                { 
+                worldObjects[i].ContainerId = Biota.Id;
+                worldObjects[i].OwnerId = Biota.Id;
+
+                if (!Inventory.Keys.Contains(worldObjects[i].Guid))
+                     Inventory[worldObjects[i].Guid] = worldObjects[i];
+
+                    worldObjects[i].Container = this;
+
+                    worldObjects.RemoveAt(i);
+               }
+            }
+
+            var mainPackItems = Inventory.Values.Where(wo => !wo.UseBackpackSlot).OrderBy(wo => wo.PlacementPosition).ToList();
+            for (int i = 0; i < mainPackItems.Count; i++)
+                mainPackItems[i].PlacementPosition = i;
+            var sidPackItems = Inventory.Values.Where(wo => wo.UseBackpackSlot).OrderBy(wo => wo.PlacementPosition).ToList();
+            for (int i = 0; i < sidPackItems.Count; i++)
+                sidPackItems[i].PlacementPosition = i;
+
+            var sideContainers = Inventory.Values.Where(i => i.WeenieType == WeenieType.Container).ToList();
+            foreach (var container in sideContainers)
+            {
+                var cont = container as Container;
+                cont.SortWorldObjectsIntoInventory(worldObjects);
+            }
+
+           SendBankVaultInventory(BankUser);
+        }
+
+        private void SendBankVaultInventory(Player player)
+        {
+            // send createobject for all objects in this container's inventory to player
+            var itemsToSend = new List<GameMessage>();
+
+            foreach (var item in Inventory.Values.Where(i => i.BankAccountId == player.Account.AccountId))
+            {
+                itemsToSend.Add(new GameMessageCreateObject(item));
+
+                if (item is Container container)
+                {
+                    foreach (var containerItem in container.Inventory.Values)
+                        itemsToSend.Add(new GameMessageCreateObject(containerItem));
+                }
+            }
+
+            player.Session.Network.EnqueueSend(new GameEventViewContents(player.Session, this));
+
+            // send sub-containers
+            foreach (var container in Inventory.Values.Where(i => i is Container))
+                player.Session.Network.EnqueueSend(new GameEventViewContents(player.Session, (Container)container));
+
+            player.Session.Network.EnqueueSend(itemsToSend.ToArray());
+        }
+        public override void Close(Player player)
+        {
+            if (!IsOpen) return;
+
+            BankUser = null;
+
+            Translucency = 0f;
+
+            SaveBiotaToDatabase();
+
+            player.Session.Network.EnqueueSend(new GameEventTell(this, "Please return with more items.", player, ChatMessageType.Tell));
+
+            PlayParticleEffect(PlayScript.UnHide, Guid);
+
+            FinishClose(player);
+            
+        }
         /// <summary>
-        /// This event is raised when player adds item to storage
-        /// </summary>
+         /// This event is raised when player adds item to storage
+         /// </summary>
         protected override void OnAddItem()
         {
-            //Console.WriteLine("Storage.OnAddItem()");
-
             if (Inventory.Count > 0)
             {
-                // Here we explicitly save the storage to the database to prevent item loss.
-                // If the player adds an item to the storage, and the server crashes before the storage has been saved, the item will be lost.
                 SaveBiotaToDatabase();
             }
         }
@@ -93,9 +186,6 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         protected override void OnRemoveItem(WorldObject removedItem)
         {
-            //Console.WriteLine("Storage.OnRemoveItem()");
-
-            // Here we explicitly save the storage to the database to prevent property desync.
             SaveBiotaToDatabase();
         }
     }

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -3955,5 +3955,11 @@ namespace ACE.Server.WorldObjects
             get => (int?)GetProperty(PropertyInt.ItemSpellId);
             set { if (!value.HasValue) RemoveProperty(PropertyInt.ItemSpellId); else SetProperty(PropertyInt.ItemSpellId, value.Value); }
         }
+
+        public uint? BankAccountId
+        {
+            get => GetProperty(PropertyInstanceId.BankAccountId);
+            set { if (!value.HasValue) RemoveProperty(PropertyInstanceId.BankAccountId); else SetProperty(PropertyInstanceId.BankAccountId, value.Value); }
+        }
     }
 }


### PR DESCRIPTION
- repurposes Storage to create player banking system
- when players use a banking golem, query the DB for items flagged with the AccountId (as BankAccountID on the item)
-  add them to the golem's inventory (while removing from their original containers/inventories)
- show them to the player in a storage window.
- any bank golem in the world will show the same items to any character on the players account
- removing and adding items to the bank does not play the pickup animation, so players can move their items in and out quickly and efficiently 

- when players place items into this window, they are stamped with the BankAccountID
- when players withdraw items, BankAccountID is set to 0
- includes checks / DB saves for players moving items within storage window to ensure position placement within packs and BankAccountIDs are active upon next DB query
