### PR TITLE
feat: allegiance rework

### DIFF
--- a/Source/ACE.Entity/Enum/Properties/PropertyFloat.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyFloat.cs
@@ -218,6 +218,8 @@ namespace ACE.Entity.Enum.Properties
         Damage                         = 189,
         WeaponAuraDamage               = 190,
         StaminaCostReductionMod        = 191,
+        RankContribution               = 192,
+        SworeAllegiance                = 193,
 
         [ServerOnly]
         PCAPRecordedWorkmanship        = 8004,

--- a/Source/ACE.Entity/Enum/Properties/PropertyInstanceId.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyInstanceId.cs
@@ -75,6 +75,7 @@ namespace ACE.Entity.Enum.Properties
         [ServerOnly][Ephemeral]
         PetDevice                        = 45,
         HotspotOwner                     = 46,
+        PatronAccountId                  = 47,
 
         [ServerOnly]
         PCAPRecordedObjectIID            = 8000,

--- a/Source/ACE.Entity/Enum/Properties/PropertyString.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyString.cs
@@ -103,6 +103,7 @@ namespace ACE.Entity.Enum.Properties
         JewelSocket1 = 9010,
         JewelSocket2 = 9011,
         CacheLog     = 9012,
+        AllegianceLog = 9013,
     }
 
     public static class PropertyStringExtensions

--- a/Source/ACE.Server/Entity/AllegianceNode.cs
+++ b/Source/ACE.Server/Entity/AllegianceNode.cs
@@ -155,7 +155,7 @@ namespace ACE.Server.Entity
                 if (vassal.Player.GetProperty(PropertyFloat.LoginTimestamp) + 1209600 < Time.GetUnixTime()) continue;
 
                 // check to see if this character is an alt on the same account
-                if (vassal.Player.Account.AccountId == player.Player.Account.AccountId) continue;
+                if (vassal.Player.Account.AccountId == Player.Account.AccountId) continue;
 
                 var rankContrib = vassal.Player.GetProperty(PropertyFloat.RankContribution);
 

--- a/Source/ACE.Server/Entity/AllegianceNode.cs
+++ b/Source/ACE.Server/Entity/AllegianceNode.cs
@@ -154,6 +154,9 @@ namespace ACE.Server.Entity
                 // check to see if player has logged in within the past 2 weeks
                 if (vassal.Player.GetProperty(PropertyFloat.LoginTimestamp) + 1209600 < Time.GetUnixTime()) continue;
 
+                // check to see if this character is an alt on the same account
+                if (vassal.Player.Account.AccountId == player.Player.Account.AccountId) continue;
+
                 var rankContrib = vassal.Player.GetProperty(PropertyFloat.RankContribution);
 
                 if (rankContrib != null)

--- a/Source/ACE.Server/Entity/AllegianceNode.cs
+++ b/Source/ACE.Server/Entity/AllegianceNode.cs
@@ -1,4 +1,6 @@
+using ACE.Common;
 using ACE.Entity;
+using ACE.Entity.Enum.Properties;
 using ACE.Server.Managers;
 using ACE.Server.WorldObjects;
 using System;
@@ -105,12 +107,9 @@ namespace ACE.Server.Entity
             // - 15 = 5
             // - 25 - 6
             // - 50 = 7
-
-            var followerIds = GetUniqueFollowerIds(this);
-            var patronIds = GetPatronIds(this);
             
-            // Calculate Rank based on valid followers and Leadership skill
-            var uniqueFollowers = GetValidFollowers(followerIds, patronIds);
+            var uniqueFollowers = GetUniqueFollowers(this);
+
             var leadershipBonus = Player.GetCurrentLeadership() / 100;
 
             switch (uniqueFollowers)
@@ -142,77 +141,34 @@ namespace ACE.Server.Entity
             }
         }
 
-        public List<uint> GetUniqueFollowerIds(AllegianceNode player)
+        public double GetUniqueFollowers(AllegianceNode player)
         {
-            var uniqueFollowerIds = new List<uint>();
+            double uniqueFollowers = 0;
 
             var vassals = player.Vassals.Values.ToList();
-            //Console.WriteLine($"Vassals Count: {vassals.Count}");
 
-            // Scan through each vassal
+            if (vassals == null || Vassals.Count == 0) return 0;
+
             foreach (AllegianceNode vassal in vassals)
             {
-                // Compare vassal ID to list of unique IDs
-                var idIsUnique = true;
-                foreach (uint accountId in uniqueFollowerIds)
-                {
-                    if (vassal.Player.Account.AccountId == accountId)
-                    {
-                        idIsUnique = false;
-                    }
-                }
+                // check to see if player has logged in within the past 2 weeks
+                if (vassal.Player.GetProperty(PropertyFloat.LoginTimestamp) + 1209600 < Time.GetUnixTime()) continue;
 
-                // If we didn't see a matched ID in the list, add the vassal's ID to the list
-                if (idIsUnique)
-                {
-                    uniqueFollowerIds.Add(vassal.Player.Account.AccountId);
-                }
+                var rankContrib = vassal.Player.GetProperty(PropertyFloat.RankContribution);
 
-                // If the vassal has vassals, run this function for their vassals as well
+                if (rankContrib != null)
+                    uniqueFollowers += (double)rankContrib;
+
                 if (vassal.Vassals.Count > 0)
                 {
-                    foreach (uint accountId in GetUniqueFollowerIds(vassal))
+                    foreach (var follower in vassal.Vassals.Values)
                     {
-                        uniqueFollowerIds.Add(accountId);
+                        uniqueFollowers += GetUniqueFollowers(vassal);
                     }
                 }
             }
 
-            //Console.WriteLine($"{player.Player.Name}'s UniqueFollowerIds Count: {uniqueFollowerIds.Count}");
-            return uniqueFollowerIds;
-        }
-
-        public List<uint> GetPatronIds (AllegianceNode player)
-        {
-            var patronIds = new List<uint>();
-            var patron = player.Patron;
-
-            if (patron != null)
-            {
-                Console.WriteLine($"Patron: {patron.Player.Name}. PatronIDs: {patronIds.Count}.");
-                patronIds.Add(patron.Player.Account.AccountId);
-                patronIds.AddRange(GetPatronIds(patron));
-            }
-
-            return patronIds;
-        }
-
-        public int GetValidFollowers(List<uint> followerIds, List<uint> patronIds)
-        {
-            var validFollowers = followerIds.Count;
-
-            foreach (var follower in followerIds)
-            {
-                foreach (var patron in patronIds)
-                {
-                    if (patron == follower)
-                    {
-                        validFollowers--;
-                    }
-                }
-            }
-
-            return validFollowers;
+            return uniqueFollowers;
         }
 
         public void Walk(Action<AllegianceNode> action, bool self = true)

--- a/Source/ACE.Server/Entity/IPlayer.cs
+++ b/Source/ACE.Server/Entity/IPlayer.cs
@@ -59,6 +59,8 @@ namespace ACE.Server.Entity
 
         uint? PatronId { get; set; }
 
+        uint? PatronAccountId { get; set; }
+
         ulong AllegianceXPCached { get; set; }
 
         ulong AllegianceXPGenerated { get; set; }
@@ -68,6 +70,8 @@ namespace ACE.Server.Entity
         int? AllegianceOfficerRank { get; set; }
 
         bool ExistedBeforeAllegianceXpChanges { get; set; }
+
+        double? SworeAllegiance { get; set; }
 
         uint? HouseId { get; set; }
 

--- a/Source/ACE.Server/Entity/Landblock.cs
+++ b/Source/ACE.Server/Entity/Landblock.cs
@@ -184,6 +184,8 @@ namespace ACE.Server.Entity
 
         public double CapstoneUptime = 0;
 
+        public List<uint> PlayerAccountIds = new List<uint>();
+
         public Landblock(LandblockId id)
         {
             //log.Debug($"Landblock({(id.Raw | 0xFFFF):X8})");
@@ -718,7 +720,16 @@ namespace ACE.Server.Entity
                         }
                     }
                 }
-
+                foreach (var player in players)
+                {
+                    if (player.PatronAccountId != null)
+                    {
+                        if (PlayerAccountIds.Contains((uint)player.PatronAccountId))
+                            player.WithPatron = true;
+                        else
+                            player.WithPatron = false;
+                    }
+                }
                 if (!Permaload && HasNoKeepAliveObjects)
                 {
                     if (lastActiveTime + dormantInterval < thisHeartBeat)
@@ -828,7 +839,10 @@ namespace ACE.Server.Entity
                     worldObjects[kvp.Key] = kvp.Value;
 
                     if (kvp.Value is Player player)
+                    {
                         players.Add(player);
+                        PlayerAccountIds.Add(player.Account.AccountId);
+                    } 
                     else if (kvp.Value is Creature creature)
                         sortedCreaturesByNextTick.AddLast(creature);
 
@@ -850,7 +864,10 @@ namespace ACE.Server.Entity
                     if (worldObjects.Remove(objectGuid, out var wo))
                     {
                         if (wo is Player player)
+                        {
                             players.Remove(player);
+                            PlayerAccountIds.Remove(player.Account.AccountId);
+                        }
                         else if (wo is Creature creature)
                             sortedCreaturesByNextTick.Remove(creature);
 
@@ -1855,6 +1872,5 @@ namespace ACE.Server.Entity
             {new LandblockId(0x12FA << 16 | 0xFFFF), new Position(0x12FA030F, 100.572f, -160.084f, 0.005f, 0f, 0f, 0.711837f, 0.702345f) },
 
         };
-
     }
 }

--- a/Source/ACE.Server/Entity/OfflinePlayer.cs
+++ b/Source/ACE.Server/Entity/OfflinePlayer.cs
@@ -200,6 +200,12 @@ namespace ACE.Server.Entity
             set { if (!value.HasValue) RemoveProperty(PropertyInstanceId.Patron); else SetProperty(PropertyInstanceId.Patron, value.Value); }
         }
 
+        public uint? PatronAccountId
+        {
+            get => GetProperty(PropertyInstanceId.PatronAccountId);
+            set { if (!value.HasValue) RemoveProperty(PropertyInstanceId.PatronAccountId); else SetProperty(PropertyInstanceId.PatronAccountId, value.Value); }
+        }
+
         public ulong AllegianceXPCached
         {
             get => (ulong)(GetProperty(PropertyInt64.AllegianceXPCached) ?? 0);
@@ -222,6 +228,11 @@ namespace ACE.Server.Entity
         {
             get => GetProperty(PropertyInt.AllegianceOfficerRank);
             set { if (!value.HasValue) RemoveProperty(PropertyInt.AllegianceOfficerRank); else SetProperty(PropertyInt.AllegianceOfficerRank, value.Value); }
+        }
+        public double? SworeAllegiance
+        {
+            get => GetProperty(PropertyFloat.SworeAllegiance);
+            set { if (!value.HasValue) RemoveProperty(PropertyFloat.SworeAllegiance); else SetProperty(PropertyFloat.SworeAllegiance, value.Value); }
         }
 
         /// <summary>

--- a/Source/ACE.Server/Physics/Common/Landblock.cs
+++ b/Source/ACE.Server/Physics/Common/Landblock.cs
@@ -10,6 +10,7 @@ using ACE.Server.Physics.Animation;
 using ACE.Server.Physics.BSP;
 using ACE.Server.Physics.Extensions;
 using ACE.Server.Managers;
+using ACE.Server.WorldObjects;
 
 namespace ACE.Server.Physics.Common
 {
@@ -703,5 +704,7 @@ namespace ACE.Server.Physics.Common
         {
             ServerObjects = ServerObjects.OrderBy(i => i.Order).ToList();
         }
+
+
     }
 }

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -1594,6 +1594,18 @@ namespace ACE.Server.WorldObjects
             set { if (!value.HasValue) RemoveProperty(PropertyInstanceId.Patron); else SetProperty(PropertyInstanceId.Patron, value.Value); }
         }
 
+        public uint? PatronAccountId
+        {
+            get => GetProperty(PropertyInstanceId.PatronAccountId);
+            set { if (!value.HasValue) RemoveProperty(PropertyInstanceId.PatronAccountId); else SetProperty(PropertyInstanceId.PatronAccountId, value.Value); }
+        }
+
+        public double? SworeAllegiance
+        {
+            get => GetProperty(PropertyFloat.SworeAllegiance);
+            set { if (!value.HasValue) RemoveProperty(PropertyFloat.SworeAllegiance); else SetProperty(PropertyFloat.SworeAllegiance, value.Value); }
+        }
+
         public ushort? HookType
         {
             get => (ushort?)GetProperty(PropertyInt.HookType);
@@ -3955,5 +3967,12 @@ namespace ACE.Server.WorldObjects
             get => (int?)GetProperty(PropertyInt.ItemSpellId);
             set { if (!value.HasValue) RemoveProperty(PropertyInt.ItemSpellId); else SetProperty(PropertyInt.ItemSpellId, value.Value); }
         }
+
+        public string AllegianceLog
+        {
+            get => GetProperty(PropertyString.AllegianceLog);
+            set { if (value == null) RemoveProperty(PropertyString.AllegianceLog); else SetProperty(PropertyString.AllegianceLog, value); }
+        }
+
     }
 }


### PR DESCRIPTION
On swearing:
	- If no loyalty skill, train it.
	- if Patron no leader skill, train it
         - vassal stamped with UnixTime they swore - SworeAllegiance
	- vassal stamps themselves with AllegianceLog = Patron Name, Acct Id, Time of swearing (currently unused but I expect it could be valuable)
	- if player had a previous patron, reduce loyalty by half. No penalty if the vassal is just reswearing to one of their previous patron's other characters (accountID check)


Earning Loyalty:
	- Players earn experience into Loyalty at a base rate of 1 rank of skill per 1 player level general XP gained
	- This rate increases over time the player is sworn to patron, up to an additional 1 rank of skill / level after 3 months
	- This rate increases by an additional 1 rank / level while player is in a fellow with their patron (FellowedWithPatron) doing activities together (WithPatron)

Experience Passup:
	- Amount is doubled if player is in fellow with their patron doing activities together
	- Amount is mulitplied by 0.75 if patron was offline while earned 
	- Experienced gained while in a fellowship is reverted to even-split for the purposes of passup.
	- After two weeks of being inactive, a patron stops gaining cached passup xp
	
Earning Leadership Skill:
	- Patrons gain 5% of passup XP directly into their Leadership skill
	- No leadership loss on kicking/breaking vassals. Slower progress of leader gain means loyalty (and rank) will play a bigger role in passup xp gains given the current formula.

Calculating Rank:
	- Each unique account represents a total of 1 unique follower's worth of Rank Contribution, with this Rank Contribution divided amongst the characters on that account based on their level relative to the other characters. (If I have 1 level 50 and 2 25s, each of the 25s gets 0.25 Rank Contribution and the 50 gets 0.5).
	- On log off, we calculate the RankContribution for each character on the entire account, summing levels (if over level 10) and then dividing each by the total to find the proportional contribution.
	- When Calculating Rank, we simply sum up all the RankContribution of all active players (logged in within the last 14 days) beneath them in the chain.
