### PR TITLE
feat: level scaling

### DIFF
--- a/Source/ACE.Entity/Enum/CombatAbility.cs
+++ b/Source/ACE.Entity/Enum/CombatAbility.cs
@@ -27,6 +27,7 @@ namespace ACE.Entity.Enum
         ExposeMagicalWeakness,
         Multishot,
         ActivatedCombatAbilities,
-        ManaBarrier
+        ManaBarrier,
+        PowerScaler
     }
 }

--- a/Source/ACE.Server/Entity/Fellowship.cs
+++ b/Source/ACE.Server/Entity/Fellowship.cs
@@ -10,6 +10,7 @@ using ACE.Server.Network.GameEvent.Events;
 using ACE.Server.Network.GameMessages.Messages;
 using ACE.Server.Network.Structure;
 using ACE.Server.WorldObjects;
+using ACE.Server.WorldObjects.Managers;
 using Serilog;
 
 namespace ACE.Server.Entity
@@ -339,6 +340,7 @@ namespace ACE.Server.Entity
                     AssignNewLeader(null, null);
 
                     CalculateXPSharing();
+                    UpdateAllMembers();
                 }
             }
             else if (!disband)
@@ -371,6 +373,7 @@ namespace ACE.Server.Entity
                 player.Fellowship = null;
 
                 CalculateXPSharing();
+                UpdateAllMembers();
             }
         }
 
@@ -474,7 +477,23 @@ namespace ACE.Server.Entity
             if (leader == null)
                 return;
 
-            var maxLevelDiff = fellows.Values.Max(f => Math.Abs((leader.Level ?? 1) - (f.Level ?? 1)));
+            //var maxLevelDiff = fellows.Values.Max(f => Math.Abs((leader.Level ?? 1) - (f.Level ?? 1)));
+
+            // instead of comparing to leader level, we now find the lowest level in the fellowship and compare to it.
+            // Anyone with scaling and no more than 25 levels higher is reduced to their level for the purposes of comparison.
+            // If there are non-scaled higher level players in the fellow, it will share unevenly as intended
+            var lowestLevel = fellows.Values.Min(f =>  f.Level ?? 1);
+
+            var maxLevelDiff = fellows.Values.Max(f =>
+            {
+                int fLevel = f.Level ?? 1;
+                var fromMax = fLevel - lowestLevel;
+
+                if (fromMax <= 25 && f.EnchantmentManager.HasSpell(5379))
+                    fLevel = lowestLevel;
+
+                return Math.Abs(lowestLevel - fLevel);  
+            }); 
 
             if (maxLevelDiff <= 5)
             {

--- a/Source/ACE.Server/Factories/PlayerFactory.cs
+++ b/Source/ACE.Server/Factories/PlayerFactory.cs
@@ -394,7 +394,7 @@ namespace ACE.Server.Factories
             if (!player.IsOlthoiPlayer)
             {
                 player.Sanctuary = new Position(player.Location);
-                player.SetProperty(PropertyBool.RecallsDisabled, true);
+                player.SetProperty(PropertyBool.RecallsDisabled, false);
 
                 if (PropertyManager.GetBool("pk_server").Item)
                     player.SetProperty(PropertyInt.PlayerKillerStatus, (int)PlayerKillerStatus.PK);

--- a/Source/ACE.Server/WorldObjects/Creature_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Combat.cs
@@ -1635,5 +1635,78 @@ namespace ACE.Server.WorldObjects
             _log.Warning($"DamageEvent.GetSecondaryAttributeMod() - Incorrect skill used ({skill}) for attacker ({Name})");
             return 0.0f;
         }
+
+        // LEVEL SCALING
+        public static float GetPlayerDamageScaler(int playerLevel, int monsterLevel)
+        {
+            if (playerLevel > 50) playerLevel = 50;
+            if (playerLevel < 10) playerLevel = 10;
+            if (monsterLevel > 50) monsterLevel = 50;
+            if (monsterLevel < 10) monsterLevel = 10;
+
+            var expectedDamage = GetPlayerDamageAtLevel(playerLevel);
+            var deleveledDamaged = GetPlayerDamageAtLevel(monsterLevel);
+
+            var damageScaler = (float)(deleveledDamaged / expectedDamage);
+
+            var levelGap = playerLevel - monsterLevel;
+            // reduce damage done by a further 8% for each 10/"tiers-worth" of level difference to account for tinkering/jewelcrafting and other sources of player power as level climbs
+            float gapMod = 1f - (float)(levelGap / 10f) / 12.5f;
+
+            return damageScaler * gapMod;
+
+        }
+        public static float GetPlayerDamageAtLevel(int level)
+        { 
+            int[] levelData = { 10, 20, 30, 40, 50 };
+            int[] damage = { 2010, 4017, 7680, 15051, 20282 };
+
+            for (int i = 0; i < levelData.Length - 1; i++)
+            {
+                if (level >= levelData[i] && level <= levelData[i + 1])
+                {
+                    float ratio = (float)(level - levelData[i]) / (levelData[i + 1] - levelData[i]);
+                    return (int)(damage[i] + ratio * (damage[i + 1] - damage[i]));
+                }
+            }
+
+            return 1;
+        }
+
+        public static float GetMonsterDamageScaler(int playerLevel, int monsterLevel)
+        {
+            if (playerLevel > 50) playerLevel = 50;
+            if (playerLevel < 10) playerLevel = 10;
+            if (monsterLevel > 50) monsterLevel = 50;
+            if (monsterLevel < 10) monsterLevel = 10;
+
+            var expectedDamage = GetMonsterDamageAtLevel(monsterLevel);
+            var upleveledDamage = GetMonsterDamageAtLevel(playerLevel);
+
+            var damageScaler = (float)(upleveledDamage / expectedDamage);
+
+            var levelGap = playerLevel - monsterLevel;
+            // increase damage done by a further 8% for each 10/"tiers-worth" of level difference to account for tinkering/jewelcrafting and other sources of player defense as level climbs
+            float gapMod = 1f + (float)(levelGap / 10f) / 12.5f;
+
+            return damageScaler * gapMod;
+
+        }
+        public static float GetMonsterDamageAtLevel(int level)
+        {
+            int[] levelData = { 10, 20, 30, 40, 50 };
+            int[] damage = { 747, 2879, 4679, 7781, 11399};
+
+            for (int i = 0; i < levelData.Length - 1; i++)
+            {
+                if (level >= levelData[i] && level <= levelData[i + 1])
+                {
+                    float ratio = (float)(level - levelData[i]) / (levelData[i + 1] - levelData[i]);
+                    return (int)(damage[i] + ratio * (damage[i + 1] - damage[i]));
+                }
+            }
+
+            return 1;
+        }
     }
 }

--- a/Source/ACE.Server/WorldObjects/Player_Location.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Location.cs
@@ -199,6 +199,8 @@ namespace ACE.Server.WorldObjects
 
         public void HandleActionTeleToMarketPlace()
         {
+            return;
+
             if (IsOlthoiPlayer)
             {
                 Session.Network.EnqueueSend(new GameEventWeenieError(Session, WeenieError.OlthoiCanOnlyRecallToLifestone));

--- a/Source/ACE.Server/WorldObjects/Player_Spells.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Spells.cs
@@ -540,8 +540,8 @@ namespace ACE.Server.WorldObjects
 
             // this is a legacy method, but is still a decent failsafe to catch any existing issues
 
-            // get active item enchantments
-            var enchantments = Biota.PropertiesEnchantmentRegistry.Clone(BiotaDatabaseLock).Where(i => i.Duration == -1 && i.SpellId != (int)SpellId.Vitae).ToList();
+            // get active item enchantments -- exclude vitae and level scaler
+            var enchantments = Biota.PropertiesEnchantmentRegistry.Clone(BiotaDatabaseLock).Where(i => i.Duration == -1 && i.SpellId != (int)SpellId.Vitae && i.SpellId != 5379).ToList();
 
             foreach (var enchantment in enchantments)
             {

--- a/Source/ACE.Server/WorldObjects/Portal.cs
+++ b/Source/ACE.Server/WorldObjects/Portal.cs
@@ -167,7 +167,7 @@ namespace ACE.Server.WorldObjects
                     return new ActivationResult(new GameEventWeenieError(player.Session, WeenieError.YouAreNotPowerfulEnoughToUsePortal));
                 }
 
-                if (player.Level > MaxLevel && MaxLevel != 0)
+                if (player.Level > MaxLevel && MaxLevel != 0 && !player.EnchantmentManager.HasSpell(5379))
                 {
                     // You are too powerful to interact with that portal!
                     return new ActivationResult(new GameEventWeenieError(player.Session, WeenieError.YouAreTooPowerfulToUsePortal));

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -331,6 +331,17 @@ namespace ACE.Server.WorldObjects
 
             if (damage != null)
             {
+                // LEVEL SCALING - If player has Scaling Spell, check to ensure their level is greater than the monster in question, then scale their damage done/damage taken if so
+                float levelScalingMod = 1f;
+
+                if (player != null && player.EnchantmentManager.HasSpell(5379) && player.Level.HasValue && creatureTarget.Level.HasValue && player.Level > creatureTarget.Level)
+                    levelScalingMod = Creature.GetPlayerDamageScaler((int)player.Level, (int)creatureTarget.Level);
+
+                if (targetPlayer != null && targetPlayer.EnchantmentManager.HasSpell(5379) && targetPlayer.Level.HasValue && sourceCreature.Level.HasValue && targetPlayer.Level > sourceCreature.Level)
+                    levelScalingMod = Creature.GetMonsterDamageScaler((int)targetPlayer.Level, (int)sourceCreature.Level);
+
+                damage *= levelScalingMod;
+
                 if (Spell.MetaSpellType == ACE.Entity.Enum.SpellType.EnchantmentProjectile)
                 {
                     // handle EnchantmentProjectile successfully landing on target


### PR DESCRIPTION
- players with the scaling debuff will have their damage done and received scaled when fighting monsters below them in level, including flat 15% penalties to evasion and resistance (both incoming and outgoing)
- scaler debuff enables players to bypass MaxLevel restrictions on portals, so they can enter capstones only if scaled.
- recalculates fellow xp share split based on whether a player is scaled or not, allowed scaled players up to 25 levels above lowest in fellow to join as if they were same level
- scaler cannot be deactivated in fellowship or while inside a dungeon to prevent cheating
- also removed restrictions on Lifestone Recall and eliminates marketplace recall
