### PR TITLE
feat: special item packs

### DIFF
--- a/Source/ACE.Server/Managers/WorldManager.cs
+++ b/Source/ACE.Server/Managers/WorldManager.cs
@@ -279,7 +279,9 @@ namespace ACE.Server.Managers
             if (olthoiPlayerReturnedToLifestone)
                 session.Network.EnqueueSend(new GameMessageSystemChat("You have returned to the Olthoi Queen to serve the hive.", ChatMessageType.Broadcast));
             else if (playerLoggedInOnNoLogLandblock) // see http://acpedia.org/wiki/Mount_Elyrii_Hive
-                session.Network.EnqueueSend(new GameMessageSystemChat("The currents of portal space cannot return you from whence you came. Your previous location forbids login.", ChatMessageType.Broadcast));            
+                session.Network.EnqueueSend(new GameMessageSystemChat("The currents of portal space cannot return you from whence you came. Your previous location forbids login.", ChatMessageType.Broadcast));
+
+            player.RecalculateBurden();
         }
 
         private static string AppendLines(params string[] lines)

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -748,6 +748,8 @@ namespace ACE.Server.WorldObjects
                 rootContainer.Value += (stack.StackUnitValue ?? 0) * amount;
             }
 
+            RecalculateBurden();
+
             return true;
         }
 
@@ -1309,6 +1311,15 @@ namespace ACE.Server.WorldObjects
         {
             //Console.WriteLine($"-> DoHandleActionPutItemInContainer({item.Name}, {itemRootOwner?.Name}, {itemWasEquipped}, {container?.Name}, {containerRootOwner?.Name}, {placement})");
 
+            ItemType containerValidTypes = (ItemType)(container.MerchandiseItemTypes ?? 0);
+            var itemType = item.WeenieType == WeenieType.Ammunition ? ItemType.CraftFletchingIntermediate : item.ItemType;
+            if (containerValidTypes != 0 && (itemType & containerValidTypes) == 0)
+            {
+                Session.Network.EnqueueSend(new GameEventCommunicationTransientString(Session, $"The {container.Name} can't hold that type of item!")); // Custom error message
+                Session.Network.EnqueueSend(new GameEventInventoryServerSaveFailed(Session, item.Guid.Full));
+                return false;
+            }
+
             Position prevLocation = null;
             Landblock prevLandblock = null;
 
@@ -1422,6 +1433,10 @@ namespace ACE.Server.WorldObjects
             Session.Network.EnqueueSend(
                 new GameMessagePublicUpdateInstanceID(item, PropertyInstanceId.Container, container.Guid),
                 new GameEventItemServerSaysContainId(Session, item, container));
+
+            // SPECIALIZED PACKS: Only recalculate burden on an item going into a container when it's a spec pack
+            if (container != null && container.MerchandiseItemTypes.HasValue)
+               RecalculateBurden();
 
             return true;
         }
@@ -2458,6 +2473,15 @@ namespace ACE.Server.WorldObjects
                 return;
             }
 
+            ItemType containerValidTypes = (ItemType)(container.MerchandiseItemTypes ?? 0);
+            var itemType = stack.WeenieType == WeenieType.Ammunition ? ItemType.CraftFletchingIntermediate : stack.ItemType;
+            if (containerValidTypes != 0 && (itemType & containerValidTypes) == 0)
+            {
+                Session.Network.EnqueueSend(new GameEventCommunicationTransientString(Session, $"The {container.Name} can't hold that type of item!")); // Custom error message
+                Session.Network.EnqueueSend(new GameEventInventoryServerSaveFailed(Session, stackId));
+                return;
+            }
+
             if ((stackRootOwner == this && containerRootOwner != this)  || (stackRootOwner != this && containerRootOwner == this)) // Movement is between the player and the world
             {
                 if (stackRootOwner is Vendor)
@@ -2595,6 +2619,8 @@ namespace ACE.Server.WorldObjects
             else
                 Session.Network.EnqueueSend(new GameMessageSetStackSize(stack));
 
+            RecalculateBurden();
+
             return true;
         }
 
@@ -2717,6 +2743,7 @@ namespace ACE.Server.WorldObjects
 
                 var returnStance = new Motion(CurrentMotionState.Stance);
                 EnqueueBroadcastMotion(returnStance);
+                RecalculateBurden();
             });
 
             actionChain.EnqueueChain();
@@ -3301,6 +3328,8 @@ namespace ACE.Server.WorldObjects
                 _log.Debug($"[CORPSE] {Name} (0x{Guid}) merged {amount:N0} {(sourceStack.IsDestroyed ? $"which resulted in the destruction" : $"leaving behind {sourceStack.StackSize:N0}")} of {sourceStack.Name} (0x{sourceStack.Guid}) to {targetStack.Name} (0x{targetStack.Guid}) from {sourceStackRootOwner.Name} (0x{sourceStackRootOwner.Guid})");
                 targetStack.SaveBiotaToDatabase();
             }
+
+            RecalculateBurden();
 
             return true;
         }
@@ -4112,6 +4141,8 @@ namespace ACE.Server.WorldObjects
                 Value += (target.Value ?? 0);
             }
 
+            RecalculateBurden();
+
             return true;
         }
 
@@ -4122,5 +4153,27 @@ namespace ACE.Server.WorldObjects
         {
             return GetEquippedObjectsOfWCID(weenieClassId).Select(i => i.StackSize ?? 1).Sum();
         }
+
+        public void RecalculateBurden()
+        {
+            var totalBurden = 0;
+            foreach (var wieldedObject in EquippedObjects.Values)
+            {
+                totalBurden += wieldedObject.EncumbranceVal ?? 0;
+            }
+            foreach (var inventoryObject in Inventory.Values)
+            {
+                if (inventoryObject is Container container && container.MerchandiseItemTypes.HasValue)
+                {
+                    totalBurden += (int)inventoryObject.EncumbranceVal / 2;
+                }
+                else
+                    totalBurden += inventoryObject.EncumbranceVal ?? 0;
+            }
+            EncumbranceVal = totalBurden;
+            Session.Network.EnqueueSend(new GameMessagePrivateUpdatePropertyInt(this, PropertyInt.EncumbranceVal, EncumbranceVal ?? 0));
+        }
+
+
     }
 }


### PR DESCRIPTION
- enables the creation of item packs which only contain certain item types, by setting the MerchandiseItemType on the pack weenie
- items in the pack only contribute half their weight toward burden (player burden must be recalculated when inventory changes to ensure this works)