### PR TITLE
feat: low-tier endgame

### DIFF
--- a/Source/ACE.Entity/Enum/Properties/PropertyBool.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyBool.cs
@@ -188,6 +188,7 @@ namespace ACE.Entity.Enum.Properties
         CannotBreakStealth               = 145,
         CampfireHotspot                  = 146,
         MutableQuestItem                 = 147,
+        StruckByUnshrouded               = 148,
 
         /* custom */
         [ServerOnly]

--- a/Source/ACE.Server/Entity/DamageHistory.cs
+++ b/Source/ACE.Server/Entity/DamageHistory.cs
@@ -94,6 +94,10 @@ namespace ACE.Server.Entity
 
             Creature.OnHealthUpdate();
 
+            if (!Creature.StruckByUnshrouded)
+                if (attacker is Player && attacker.Level > Creature.Level + 10 && !attacker.EnchantmentManager.HasSpell(5379))
+                    Creature.StruckByUnshrouded = true;
+
         }
         
         /// <summary>

--- a/Source/ACE.Server/Entity/DamageHistoryInfo.cs
+++ b/Source/ACE.Server/Entity/DamageHistoryInfo.cs
@@ -22,12 +22,15 @@ namespace ACE.Server.Entity
 
         public readonly bool IsOlthoiPlayer;
 
+        public int Level;
+
         public DamageHistoryInfo(WorldObject attacker, float totalDamage = 0.0f)
         {
             Attacker = new WeakReference<WorldObject>(attacker);
 
             Guid = attacker.Guid;
             Name = attacker.Name;
+            Level = attacker.Level ?? 1;
 
             IsOlthoiPlayer = attacker is Player player && player.IsOlthoiPlayer;
 

--- a/Source/ACE.Server/WorldObjects/Creature_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Combat.cs
@@ -1708,5 +1708,7 @@ namespace ACE.Server.WorldObjects
 
             return 1;
         }
+
+        public bool StruckByUnshrouded = false;
     }
 }


### PR DESCRIPTION
- adds prototype low-tier endgame system whereby shrouded(scaled) players have a chance to gain a piece of alt currency upon killing lower tier monster (increased if accompanied by appropriate-tier lowbie)

- can be expanded to trigger spawns, events, etc.

- when a creature is struck by a player 10+ levels above them who doesn't have the shroud debuff, they will stamp themselves StruckByUnshrouded.

- upon death, if a creature does not have StruckByUnshrouded (ie. no unscaled high level players have helped kill), they will check their DamageHistory to see if any scaled 10+ level players did 1/3 or more of total damage.
- if so, they assign a flat chance and then check to see if any appropriate level players (5 levels on either side of monster level) did 1/3 damage or more of the damage too, and grants a bonus chance if so.
- on successful roll, places a piece of alt currency in the scaled players inventory