### PR TITLE
update: crafting xp gain

### DIFF
--- a/Source/ACE.Entity/Enum/EmoteType.cs
+++ b/Source/ACE.Entity/Enum/EmoteType.cs
@@ -146,5 +146,6 @@ namespace ACE.Entity.Enum
         AwardSkillRanks               = 10008,
         CapstoneCacheReward           = 10009,
         AssignCapstoneDungeon         = 10010,
+        AwardNoContribSkillXP         = 10011,
     }
 }

--- a/Source/ACE.Server/Managers/RecipeManager.cs
+++ b/Source/ACE.Server/Managers/RecipeManager.cs
@@ -386,16 +386,17 @@ namespace ACE.Server.Managers
                 if (modified.Contains(target.Guid.Full))
                     UpdateObj(player, target);
             }
-            // CUSTOM CRAFTING - Ranking Up - On success, grant a 20% chance to rank up the skill, up to 10 higher than difficulty
+            // CUSTOM CRAFTING - On success, so long as difficulty is no more than 10 above current skill, grant 20% of rank in no-contribution XP
             if (recipe.Skill > 0 && recipe.Difficulty > 0 && success)
             {
                 var skill = player.GetCreatureSkill((Skill)recipe.Skill);
                 var playerSkill = (Skill)recipe.Skill;
                 if (skill.Ranks < recipe.Difficulty + 10)
                 {
-                    var chance = ThreadSafeRandom.Next(1, 5);
-                    if (chance == 5)
-                        player.GrantSkillRanks(playerSkill, 1);
+                    var xP = player.GetXPBetweenSkillLevels(skill.AdvancementClass, skill.Ranks, skill.Ranks + 1);
+                        xP /= 5;
+
+                    player.NoContribSkillXp(player, playerSkill, (uint)xP, false);
                 }
             }
         }

--- a/Source/ACE.Server/WorldObjects/Jewel.cs
+++ b/Source/ACE.Server/WorldObjects/Jewel.cs
@@ -586,12 +586,13 @@ namespace ACE.Server.WorldObjects
             if (modifiedBase < 1)
                 modifiedBase = 1;
 
-            // Rank chance - if skill is no higher than 40 above difficulty, you get a 25% chance for a rank.
-            if (skillLevel < difficulty + 40)
+            // Rank chance - if skill is no more/less than 25 above or below difficulty, earn 20% of rank in XP.
+            if (Math.Abs(difficulty - skillLevel) < 25)
             {
-                var rankChance = 2.5f;
-                if (rankChance >= ThreadSafeRandom.Next(0f, 10f))
-                    player.GrantSkillRanks(Skill.ItemTinkering, 1);
+                var xP = player.GetXPBetweenSkillLevels(skill.AdvancementClass, skill.Ranks, skill.Ranks + 1);
+                        xP /= 5;
+
+                player.NoContribSkillXp(player, Skill.ItemTinkering, (uint)xP, false);
             }
 
 

--- a/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
@@ -146,6 +146,21 @@ namespace ACE.Server.WorldObjects.Managers
 
                     break;
 
+                case EmoteType.AwardNoContribSkillXP:
+
+                    if (player != null)
+                    {
+                        var playerSkill = (Skill)emote.Stat;
+                        var skill = player.GetCreatureSkill(playerSkill);
+                        var xP = player.GetXPBetweenSkillLevels(skill.AdvancementClass, skill.Ranks, skill.Ranks + 1);
+                        xP /= 5;
+
+                        player.NoContribSkillXp(player, playerSkill, (uint)xP, false);
+
+                    }
+                    break;
+                        
+
                 case EmoteType.AwardNoShareXP:
 
                     if (player != null)

--- a/Source/ACE.Server/WorldObjects/Player_Skills.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Skills.cs
@@ -999,6 +999,10 @@ namespace ACE.Server.WorldObjects
             return true;
         }
 
+        public void NoContribSkillXp(Player player, Skill skill, uint amount, bool reduce)
+        {
+            player.AwardNoContribSkillXP(skill, amount, reduce);
+        }
         private void AwardNoContribSkillXP(Skill skill, uint amount, bool reduce)
         {
             var playerSkill = GetCreatureSkill(skill);

--- a/Source/ACE.Server/WorldObjects/Salvage.cs
+++ b/Source/ACE.Server/WorldObjects/Salvage.cs
@@ -870,13 +870,18 @@ namespace ACE.Server.WorldObjects
                         break;
                  */
                 }
-                // rank chance of 25% per armor slot, quartered for failure
-                var rankChance = success ? 0.25f * armorSlots : 0.0625f * armorSlots;
-                // check to ensure appropriately difficult tinker before granting (is player skill no more than 50 over adjusted diff)
-                if (skill.Current < difficulty)
+
+                // 20% of ranks worth of XP per armor slot, quartered for failure
+                var rankXP = success ? 0.20f * armorSlots : 0.0625f * armorSlots;
+               
+                // check to ensure appropriately difficult tinker before granting (is player skill no more than 50 points away from adjusted diff)
+                if (Math.Abs(skill.Current - difficulty) < 50)
                 {
-                    if (rankChance >= ThreadSafeRandom.Next(0f, 1f))
-                        player.GrantSkillRanks(tinkeringSkill, 1);
+                    var xP = player.GetXPBetweenSkillLevels(skill.AdvancementClass, skill.Ranks, skill.Ranks + 1);
+
+                    var totalXP = (uint)(xP * rankXP);
+
+                        player.NoContribSkillXp(player, tinkeringSkill, totalXP, false);
                 }
 
                 BroadcastTinkering(player, source, target, successChance, success, successAmount);


### PR DESCRIPTION
- replaces pure chance + full rank gain approach with 20% of a ranks worth of xp directly into skill for feeling of progression, as with leadership/loyalty
- adds AwardNoContribSkillXP emote to support campfire/alchemy table xp granting