### PR TITLE
feat: vanish

### DIFF
--- a/Source/ACE.Server/WorldObjects/Monster_Awareness.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Awareness.cs
@@ -239,6 +239,21 @@ namespace ACE.Server.WorldObjects
                 if(visibleTargets.Count > 1 && untargetablePlayer != null)
                     visibleTargets.Remove(untargetablePlayer);
 
+                if (untargetablePlayer != null && untargetablePlayer is Player vanishedPlayer && Time.GetUnixTime() < vanishedPlayer.LastVanishActivated + 5)
+                {
+                    visibleTargets.Remove(untargetablePlayer);
+
+                     if (ThreatLevel != null && ThreatLevel.ContainsKey(untargetablePlayer))
+                        ThreatLevel.Remove(untargetablePlayer);
+
+                    if (visibleTargets.Count == 0)
+                    {
+                        MoveToHome();
+                        return false;
+                    }
+
+                }
+
                 // Generally, a creature chooses whom to attack based on:
                 //  - who it was last attacking,
                 //  - who attacked it last,

--- a/Source/ACE.Server/WorldObjects/Monster_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Magic.cs
@@ -163,6 +163,12 @@ namespace ACE.Server.WorldObjects
                 return;
             }
 
+            if (target != null && target is Player player && Time.GetUnixTime() < player.LastVanishActivated + 5)
+            {
+                FindNextTarget(false, player);
+                return;
+            }
+
             var spell = CurrentSpell;
 
             // turn to?

--- a/Source/ACE.Server/WorldObjects/Monster_Melee.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Melee.cs
@@ -53,6 +53,11 @@ namespace ACE.Server.WorldObjects
                 FindNextTarget(false);
                 return 0.0f;
             }
+            if (targetPlayer != null && Time.GetUnixTime() < targetPlayer.LastVanishActivated + 5)
+            {
+                FindNextTarget(false, targetPlayer);
+                return 0.0f;
+            }
 
             if (CurrentMotionState.Stance == MotionStance.NonCombat)
                 DoAttackStance();

--- a/Source/ACE.Server/WorldObjects/Monster_Missile.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Missile.cs
@@ -34,6 +34,12 @@ namespace ACE.Server.WorldObjects
                 return;
             }
 
+            if (target != null && target is Player player && Time.GetUnixTime() < player.LastVanishActivated + 5)
+            {
+                FindNextTarget(false, player);
+                return;
+            }
+
             var weapon = GetEquippedMissileWeapon();
             var ammo = GetEquippedAmmo();
 

--- a/Source/ACE.Server/WorldObjects/Player_Ability.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Ability.cs
@@ -145,8 +145,22 @@ namespace ACE.Server.WorldObjects
             }
         }
 
+        public double LastVanishActivated = 0;
+
         public void TryUseVanish(WorldObject ability)
         {
+            if (IsStealthed)
+                return;
+            var thieverySkill = GetCreatureSkill(Skill.Lockpick); // Thievery
+            if (thieverySkill.AdvancementClass < SkillAdvancementClass.Trained)
+                return;
+
+            var smoke = WorldObjectFactory.CreateNewWorldObject(1051113);
+            smoke.Location = Location;
+            smoke.EnterWorld();
+
+            this.LastVanishActivated = Time.GetUnixTime();
+            this.BeginStealth();
         }
 
         public void TryUseExposePhysicalWeakness(WorldObject ability)


### PR DESCRIPTION
- adds Vanish combat ability, requires Trained Thievery (decept too? or spec?) 
- -Immediately enter stealth, with no failure chance 
-Monsters attacking that player will check on next attack initialization and will be forced to find a new target, and remove player from their targets lists 
-Creatures on trying to detect stealth will fail for the next 5 seconds, but afterwards stealth can be broken normally
- also adds a combat mode check before dispelling mire foot on EndStealth();