### PR TITLE
fix: wonky cleaves

### DIFF
--- a/Source/ACE.Server/WorldObjects/Creature.cs
+++ b/Source/ACE.Server/WorldObjects/Creature.cs
@@ -486,9 +486,14 @@ namespace ACE.Server.WorldObjects
                 visibleTargets.Add(creature);
             }
 
-            BuildTargetDistance(visibleTargets);
+            var nearestTargets = BuildTargetDistance(visibleTargets);
 
-            return visibleTargets;
+            var sortedTargets = new List<Creature>();
+
+            foreach (var target in nearestTargets)
+                sortedTargets.Add(target.Target);
+
+            return sortedTargets;
         }
 
     }


### PR DESCRIPTION
- fixes wonky missile/magic cleaves
- distance sorted result from BuildTargetDistance was not being captured previously so it was just using the unsorted list