### PR TITLE
fix: monster aggro and starter comps

### DIFF
--- a/Source/ACE.Server/Factories/LootGenerationFactory_Caster.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Caster.cs
@@ -201,7 +201,7 @@ namespace ACE.Server.Factories
 
             if(profile.Tier == 1)
             {
-                wo.Name += " (damaged)";
+                //wo.Name += " (damaged)";
             }
 
             // assign jewel slots

--- a/Source/ACE.Server/WorldObjects/Monster_Awareness.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Awareness.cs
@@ -236,7 +236,15 @@ namespace ACE.Server.WorldObjects
                     return false;
                 }
 
-                if(visibleTargets.Count > 1 && untargetablePlayer != null)
+                // Remove targets that are far away
+                const float maxAggroRange = 50.0f;
+                foreach (var targetCreature in visibleTargets)
+                {
+                    if (targetCreature.GetDistanceToTarget() > maxAggroRange)
+                        visibleTargets.Remove(targetCreature);
+                }
+
+                if (visibleTargets.Count > 1 && untargetablePlayer != null)
                     visibleTargets.Remove(untargetablePlayer);
 
                 if (untargetablePlayer != null && untargetablePlayer is Player vanishedPlayer && Time.GetUnixTime() < vanishedPlayer.LastVanishActivated + 5)

--- a/Source/ACE.Server/starterGear.json
+++ b/Source/ACE.Server/starterGear.json
@@ -362,17 +362,17 @@
           "stacksize": "10"
         },
         {
-          "weenieId": "753",
+          "weenieId": "760",
           "name": "Realgar",
           "stacksize": "10"
         },
         {
-          "weenieId": "753",
+          "weenieId": "764",
           "name": "Vitriol",
           "stacksize": "10"
         },
         {
-          "weenieId": "753",
+          "weenieId": "763",
           "name": "Verdigris",
           "stacksize": "10"
         },


### PR DESCRIPTION
* prevent monster from aggroing a player it just killed (max aggro range of 50 when searching for new targets)
* fix starter comps wcids