### PR TITLE
fix: untrained jewelcrafting crash

### DIFF
--- a/Source/ACE.Server/Managers/RecipeManager.cs
+++ b/Source/ACE.Server/Managers/RecipeManager.cs
@@ -158,6 +158,9 @@ namespace ACE.Server.Managers
             if (recipe.IsTinkering())
                 return true;
 
+            if (recipe.Skill == (uint)Skill.ItemTinkering)
+                return true;
+
             return recipe.Skill > 0 && recipe.Difficulty > 0;
         }
 


### PR DESCRIPTION
- players without jewelcrafting can carve jewels, but will get null value when attempting to grant xp.
- needs rethinking but this is bandaid for null crash