### PR TITLE
fix: multi-spell transfer selection

### DIFF
--- a/Source/ACE.Entity/Enum/Properties/PropertyDataId.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyDataId.cs
@@ -140,6 +140,7 @@ namespace ACE.Entity.Enum.Properties
         EmpoweredScarabTriggerSpellId = 63,
         [ServerOnly]
         SpellExtracted = 64,
+        SpellToExtract = 65,
 
 
         [ServerOnly]

--- a/Source/ACE.Server/WorldObjects/SpellTransference.cs
+++ b/Source/ACE.Server/WorldObjects/SpellTransference.cs
@@ -133,12 +133,18 @@ namespace ACE.Server.WorldObjects
                     player.SendUseDoneEvent();
                     return;
                 }
+                // if not confirmed yet, we select a spell from the item and assign the ID to the pearl's SpellToExtract property.
+                // confirmation runs this method a second time after hitting yes
+                // so with multi-spell items, if we don't somehow save the previous spell it will roll again, potentially picking a different one
+                if (!confirmed)
+                {
+                    var spellToExtractRoll = ThreadSafeRandom.Next(0, spellCount - 1);
+                    var spellToExtractId = spells[spellToExtractRoll];
 
-                var spellToExtractRoll = ThreadSafeRandom.Next(0, spellCount - 1);
-                var spellToExtractId = spells[spellToExtractRoll];
+                    source.SpellToExtract = (uint?)spellToExtractId;
+                }
 
-                Spell chosenSpell = new Spell(spellToExtractId);
-
+                Spell chosenSpell = new Spell((uint)source.SpellToExtract);
                 var chance = 100;
 
                 var showDialog = player.GetCharacterOption(CharacterOption.UseCraftingChanceOfSuccessDialog);
@@ -186,10 +192,10 @@ namespace ACE.Server.WorldObjects
                     var spellName = "";
                     if (success)
                     {
-                        Spell spell = new Spell(spellToExtractId);
+                        Spell spell = new Spell((int)source.SpellToExtract);
                         spellName = spell.Name;
 
-                        pearl.SpellExtracted = (uint?)spellToExtractId;
+                        pearl.SpellExtracted = source.SpellToExtract;
 
                         var itemType = "";
                         if (target.ItemType == ItemType.Jewelry)

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -3752,6 +3752,12 @@ namespace ACE.Server.WorldObjects
             set { if (!value.HasValue) RemoveProperty(PropertyDataId.SpellExtracted); else SetProperty(PropertyDataId.SpellExtracted, value.Value); }
         }
 
+        public uint? SpellToExtract
+        {
+            get => GetProperty(PropertyDataId.SpellToExtract);
+            set { if (!value.HasValue) RemoveProperty(PropertyDataId.SpellToExtract); else SetProperty(PropertyDataId.SpellToExtract, value.Value); }
+        }
+
         public double? BaseArmorWarMagicMod
         {
             get => (double?)GetProperty(PropertyFloat.BaseArmorWarMagicMod);


### PR DESCRIPTION
- confirmation runs a method a second time after the player hits "yes" so it was rolling for a new spell each time, and players were extracting the wrong spells from multi-spell items
- adds a check to roll for a new spell from the selected item ONLY if unconfirmed, and saves that spellID onto the pearl itself to preserve the player's choice