### PR TITLE
fix: attribute jewels

### DIFF
--- a/Source/ACE.Server/WorldObjects/Entity/CreatureAttribute.cs
+++ b/Source/ACE.Server/WorldObjects/Entity/CreatureAttribute.cs
@@ -96,40 +96,6 @@ namespace ACE.Server.WorldObjects.Entity
             {
                 uint total = Ranks + StartingValue;
 
-                // JEWEL - Attributes: Adds to Base
-
-                if (creature is Creature player)
-                {
-                    switch (Attribute)
-                    {
-                        case PropertyAttribute.Strength:
-                            if (player.GetEquippedItemsRatingSum(PropertyInt.GearStrength) > 0)
-                                total += (uint)(player.GetEquippedItemsRatingSum(PropertyInt.GearStrength));
-                            break;
-                        case PropertyAttribute.Endurance:
-                            if (player.GetEquippedItemsRatingSum(PropertyInt.GearEndurance) > 0)
-                                total += (uint)(player.GetEquippedItemsRatingSum(PropertyInt.GearEndurance));
-                            break;
-                        case PropertyAttribute.Coordination:
-                            if (player.GetEquippedItemsRatingSum(PropertyInt.GearCoordination) > 0)
-                                total += (uint)(player.GetEquippedItemsRatingSum(PropertyInt.GearCoordination));
-                            break;
-                        case PropertyAttribute.Quickness:
-                            if (player.GetEquippedItemsRatingSum(PropertyInt.GearQuickness) > 0)
-                                total += (uint)(player.GetEquippedItemsRatingSum(PropertyInt.GearQuickness));
-                            break;
-                        case PropertyAttribute.Focus:
-                            if (player.GetEquippedItemsRatingSum(PropertyInt.GearFocus) > 0)
-                                total += (uint)(player.GetEquippedItemsRatingSum(PropertyInt.GearFocus));
-                            break;
-                        case PropertyAttribute.Self:
-                            if (player.GetEquippedItemsRatingSum(PropertyInt.GearSelf) > 0)
-                                total += (uint)(player.GetEquippedItemsRatingSum(PropertyInt.GearSelf));
-                            break;
-                    }
-                }
-                
-
                 return total;
             }
         }

--- a/Source/ACE.Server/WorldObjects/Player_Inventory.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Inventory.cs
@@ -319,6 +319,49 @@ namespace ACE.Server.WorldObjects
             if (manaScarab != null)
                 manaScarab.OnEquip(this);
 
+            // handle gear attribute ratings
+            if (item.GearStrength > 0)
+            {
+                var playerAttr = Attributes[PropertyAttribute.Strength];
+                playerAttr.StartingValue += (uint)item.GearStrength;
+                Session.Network.EnqueueSend(new GameMessagePrivateUpdateAttribute(this, playerAttr));
+            }
+
+            if (item.GearEndurance > 0)
+            {
+                var playerAttr = Attributes[PropertyAttribute.Endurance];
+                playerAttr.StartingValue += (uint)item.GearEndurance;
+                Session.Network.EnqueueSend(new GameMessagePrivateUpdateAttribute(this, playerAttr));
+            }
+
+            if (item.GearCoordination > 0)
+            {
+                var playerAttr = Attributes[PropertyAttribute.Coordination];
+                playerAttr.StartingValue += (uint)item.GearCoordination;
+                Session.Network.EnqueueSend(new GameMessagePrivateUpdateAttribute(this, playerAttr));
+            }
+
+            if (item.GearQuickness > 0)
+            {
+                var playerAttr = Attributes[PropertyAttribute.Quickness];
+                playerAttr.StartingValue += (uint)item.GearQuickness;
+                Session.Network.EnqueueSend(new GameMessagePrivateUpdateAttribute(this, playerAttr));
+            }
+
+            if (item.GearFocus > 0)
+            {
+                var playerAttr = Attributes[PropertyAttribute.Focus];
+                playerAttr.StartingValue += (uint)item.GearFocus;
+                Session.Network.EnqueueSend(new GameMessagePrivateUpdateAttribute(this, playerAttr));
+            }
+
+            if (item.GearSelf > 0)
+            {
+                var playerAttr = Attributes[PropertyAttribute.Self];
+                playerAttr.StartingValue += (uint)item.GearSelf;
+                Session.Network.EnqueueSend(new GameMessagePrivateUpdateAttribute(this, playerAttr));
+            }
+
             return true;
         }
 
@@ -446,6 +489,50 @@ namespace ACE.Server.WorldObjects
                     HandleActionChangeCombatMode(newCombatMode);
                 }
             }
+
+            // handle gear attribute ratings
+            if (item.GearStrength > 0)
+            {
+                var playerAttr = Attributes[PropertyAttribute.Strength];
+                playerAttr.StartingValue -= (uint)item.GearStrength;
+                Session.Network.EnqueueSend(new GameMessagePrivateUpdateAttribute(this, playerAttr));
+            }
+
+            if (item.GearEndurance > 0)
+            {
+                var playerAttr = Attributes[PropertyAttribute.Endurance];
+                playerAttr.StartingValue -= (uint)item.GearEndurance;
+                Session.Network.EnqueueSend(new GameMessagePrivateUpdateAttribute(this, playerAttr));
+            }
+
+            if (item.GearCoordination > 0)
+            {
+                var playerAttr = Attributes[PropertyAttribute.Coordination];
+                playerAttr.StartingValue -= (uint)item.GearCoordination;
+                Session.Network.EnqueueSend(new GameMessagePrivateUpdateAttribute(this, playerAttr));
+            }
+
+            if (item.GearQuickness > 0)
+            {
+                var playerAttr = Attributes[PropertyAttribute.Quickness];
+                playerAttr.StartingValue -= (uint)item.GearQuickness;
+                Session.Network.EnqueueSend(new GameMessagePrivateUpdateAttribute(this, playerAttr));
+            }
+
+            if (item.GearFocus > 0)
+            {
+                var playerAttr = Attributes[PropertyAttribute.Focus];
+                playerAttr.StartingValue -= (uint)item.GearFocus;
+                Session.Network.EnqueueSend(new GameMessagePrivateUpdateAttribute(this, playerAttr));
+            }
+
+            if (item.GearSelf > 0)
+            {
+                var playerAttr = Attributes[PropertyAttribute.Self];
+                playerAttr.StartingValue -= (uint)item.GearSelf;
+                Session.Network.EnqueueSend(new GameMessagePrivateUpdateAttribute(this, playerAttr));
+            }
+
 
             return true;
         }


### PR DESCRIPTION
- on equip/deequip now adds/removes gear rating amount to the appropriate player attribute's StartingValue
- previously the benefit was only being registered in the appraisal window--now the character attribute and skills panel will properly reflect the bonuses
- StartingValue is used in Base calculation so code here no longer needed