### PR TITLE
update: remove busy check from combat ability use

### DIFF
--- a/Source/ACE.Server/WorldObjects/Gem.cs
+++ b/Source/ACE.Server/WorldObjects/Gem.cs
@@ -54,12 +54,14 @@ namespace ACE.Server.WorldObjects
             if (!(activator is Player player))
                 return;
 
-            if (player.IsBusy || player.Teleporting || player.suicideInProgress)
+            if (CombatAbilityId == null)
             {
-                player.SendWeenieError(WeenieError.YoureTooBusy);
-                return;
+                if (player.IsBusy || player.Teleporting || player.suicideInProgress)
+                {
+                    player.SendWeenieError(WeenieError.YoureTooBusy);
+                    return;
+                }
             }
-
             if (player.IsJumping)
             {
                 player.SendWeenieError(WeenieError.YouCantDoThatWhileInTheAir);
@@ -384,11 +386,14 @@ namespace ACE.Server.WorldObjects
                 var containedItem = player.FindObject(Guid.Full, Player.SearchLocations.MyInventory | Player.SearchLocations.MyEquippedItems);
                 if (containedItem != null) // item is contained by player
                 {
-                    if (player.IsBusy || player.Teleporting || player.suicideInProgress)
+                    if (CombatAbilityId == null)
                     {
-                        player.Session.Network.EnqueueSend(new GameEventWeenieError(player.Session, WeenieError.YoureTooBusy));
-                        player.EnchantmentManager.StartCooldown(this);
-                        return;
+                        if (player.IsBusy || player.Teleporting || player.suicideInProgress)
+                        {
+                            player.Session.Network.EnqueueSend(new GameEventWeenieError(player.Session, WeenieError.YoureTooBusy));
+                            player.EnchantmentManager.StartCooldown(this);
+                            return;
+                        }
                     }
 
                     if (player.IsDead)

--- a/Source/ACE.Server/WorldObjects/WorldObject_Use.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Use.cs
@@ -380,7 +380,7 @@ namespace ACE.Server.WorldObjects
                             if (player.Stamina.Current < staminaCost)
                             {
                                 player.Session.Network.EnqueueSend(new GameMessageSystemChat($"You do not have enough stamina.", ChatMessageType.Broadcast));
-                                return new ActivationResult(false); ;
+                                return new ActivationResult(false); 
                             }
                         }
                         break;


### PR DESCRIPTION
- removes busy check on combat ability use, allowing them to be used instantaneously regardless of whether player is in the middle of an animation