### PR TITLE
fix: missing mana barrier destruction reference

### DIFF
--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -1164,7 +1164,7 @@ namespace ACE.Server.WorldObjects
                         if (toggles != null)
                         {
                             foreach (var toggle in toggles)
-                                EnchantmentManager.StartCooldown(toggle);
+                                targetPlayer.EnchantmentManager.StartCooldown(toggle);
                         }
 
                         PlayParticleEffect(PlayScript.HealthDownBlue, Guid);


### PR DESCRIPTION
- adds player reference to EnchantmentManager for cooldown on mana barrier after being broken by a spell projectile