### PR TITLE
feat: control vendor merchandise item types with templates

### DIFF
--- a/Source/ACE.Entity/Enum/ItemType.cs
+++ b/Source/ACE.Entity/Enum/ItemType.cs
@@ -47,10 +47,18 @@ namespace ACE.Entity.Enum
                                               Gem | SpellComponents | Writable | Key | Caster | Portal | PromissoryNote | ManaStone | MagicWieldable,
         RedirectableItemEnchantmentTarget   = MeleeWeapon | Armor | Clothing | MissileWeapon | Caster,
         ItemEnchantableTarget               = MeleeWeapon | Armor | Clothing | Jewelry | Misc | MissileWeapon | Container | Gem | Caster | ManaStone,
-        VendorShopKeep                      = MeleeWeapon | Armor | Clothing | Food | Misc | MissileWeapon | Container | Useless | Writable | Key |
-                                              PromissoryNote | CraftFletchingIntermediate | TinkeringMaterial,
-        VendorGrocer                        = Food | Container | Writable | Key | PromissoryNote | CraftCookingBase,
-        VendorBoyer                         = MissileWeapon | CraftFletchingBase | Container | Money, // (134218560)
-        VendorArchmage                      = Caster | Money | ManaStone | SpellComponents | CraftAlchemyBase, // (8949824)
+
+        VendorShopKeep                      = Misc | Container | Useless | Writable | Key | PromissoryNote | CraftFletchingIntermediate | TinkeringMaterial,
+        VendorGrocer                        = Misc | Food | Container | Writable | Key | PromissoryNote | CraftCookingBase,
+        VendorBowyer                        = Misc | MissileWeapon | Container | PromissoryNote | CraftFletchingBase,
+        VendorArchmage                      = Misc | SpellComponents | Writable | Caster | PromissoryNote | ManaStone | CraftAlchemyBase,
+        VendorBlacksmith                    = MeleeWeapon | Armor | Misc | PromissoryNote,
+        VendorArmorer                       = Armor | Misc | PromissoryNote,
+        VendorWeaponsmith                   = MeleeWeapon | Misc | PromissoryNote,
+        VendorJeweler                       = Jewelry | Misc | Gem | PromissoryNote,
+        VendorScribe                        = Writable | Misc | PromissoryNote,
+        VendorHealer                        = Misc | PromissoryNote,
+        VendorTailor                        = Clothing | Misc | PromissoryNote,
+        VendorBarkeep                       = Misc | Food | PromissoryNote,
     }
 }

--- a/Source/ACE.Server/WorldObjects/Vendor.cs
+++ b/Source/ACE.Server/WorldObjects/Vendor.cs
@@ -117,6 +117,8 @@ namespace ACE.Server.WorldObjects
 
             LastRestockTime = DateTime.UnixEpoch;
             OpenForBusiness = ValidateVendorRequirements();
+            
+            SetMerchandiseItemTypes();
         }
 
         private bool ValidateVendorRequirements()
@@ -1139,6 +1141,26 @@ namespace ACE.Server.WorldObjects
         {
             foreach (var createdItem in createdItems)
                 createdItem.Destroy();
+        }
+
+        private void SetMerchandiseItemTypes()
+        {
+            switch (GetProperty(PropertyString.Template))
+            {
+                case "Archmage":
+                case "Apprentice": MerchandiseItemTypes = (int)ItemType.VendorArchmage; break;
+                case "Armorer": MerchandiseItemTypes = (int)ItemType.VendorArmorer; break;
+                case "Barkeeper": MerchandiseItemTypes = (int)ItemType.VendorBarkeep; break;
+                case "Blacksmith": MerchandiseItemTypes = (int)ItemType.VendorBlacksmith; break;
+                case "Bowyer": MerchandiseItemTypes = (int)ItemType.VendorBowyer; break;
+                case "Grocer": MerchandiseItemTypes = (int)ItemType.VendorGrocer; break;
+                case "Healer": MerchandiseItemTypes = (int)ItemType.VendorHealer; break;
+                case "Jeweler": MerchandiseItemTypes = (int)ItemType.VendorJeweler; break;
+                case "Scribe": MerchandiseItemTypes = (int)ItemType.VendorScribe; break;
+                case "Shopkeeper": MerchandiseItemTypes = (int)ItemType.VendorShopKeep; break;
+                case "Tailor": MerchandiseItemTypes = (int) ItemType.VendorTailor; break;
+                case "Weaponsmith": MerchandiseItemTypes = (int)ItemType.VendorWeaponsmith; break;
+            }
         }
 
         public bool OpenForBusiness


### PR DESCRIPTION
* When a vendor NPC is loaded, update its MerchandiseItemTypes value based on its Template string.
* Also fixes vendors not accepting trade notes and other items.