### PR TITLE
update: fury stamps and stam cost

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Ability.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Ability.cs
@@ -446,7 +446,7 @@ namespace ACE.Server.WorldObjects
         {
             var scaledStamps = Math.Round(playerAttacker.ScaleWithPowerAccuracyBar(20f));
 
-            scaledStamps += 10f;
+            scaledStamps += 20f;
 
             var numStrikes = playerAttacker.GetNumStrikes(playerAttacker.AttackType);
             if (numStrikes == 2)
@@ -471,7 +471,7 @@ namespace ACE.Server.WorldObjects
             var stacks = playerAttacker.QuestManager.GetCurrentSolves($"{playerAttacker.Name},Reckless");
             if (stacks > 250)
             {
-                var recklessChance = 0.1f * (stacks - 250) / 250;
+                var recklessChance = 0.075f * (stacks - 250) / 250;
                 if (recklessChance > ThreadSafeRandom.Next(0, 1))
                     playerAttacker.DamageTarget(playerAttacker, playerAttacker);
             }

--- a/Source/ACE.Server/WorldObjects/Player_Melee.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Melee.cs
@@ -317,7 +317,7 @@ namespace ACE.Server.WorldObjects
             if (EquippedCombatAbility == CombatAbility.Fury && QuestManager.HasQuest($"{this.Name},Reckless"))
             {
                 var recklessStacks = this.QuestManager.GetCurrentSolves($"{this.Name},Reckless");
-                float recklessMod = 1 + (recklessStacks / 500);
+                float recklessMod = 1 + (recklessStacks / 1000);
                 staminaCost = (int)(staminaCost * recklessMod);
             }
 


### PR DESCRIPTION
- doubles base rate of building fury
- reduces stamina cost to a max of 50% extra
- reduces self-harm chance to a max of 7.5% from 10%