### PR TITLE
update: overload stamps, mana cost, self harm chance

### DIFF
--- a/Source/ACE.Server/WorldObjects/Creature_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Magic.cs
@@ -54,7 +54,7 @@ namespace ACE.Server.WorldObjects
                     baseCost = 5 * spell.Level;
 
                 var overloadStacks = this.QuestManager.GetCurrentSolves($"{this.Name},Overload");
-                float overloadMod = 1 + (overloadStacks / 500);
+                float overloadMod = 1 + (overloadStacks / 1000);
                 baseCost = (uint)(baseCost * overloadMod);
             }
             // Battery - 20% mana cost reduction minimum, increasing with lower mana or 0 cost during Battery Activated

--- a/Source/ACE.Server/WorldObjects/Player_Ability.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Ability.cs
@@ -480,7 +480,7 @@ namespace ACE.Server.WorldObjects
 
         public static int HandleOverloadStamps(Player sourcePlayer, int? spellTypeScaler, uint spellLevel)
         {
-            var baseStamps = 25;
+            var baseStamps = 50;
             var playerLevel = (int)(sourcePlayer.Level / 10);
 
             if (playerLevel > 7)
@@ -543,7 +543,7 @@ namespace ACE.Server.WorldObjects
             var stacks = sourcePlayer.QuestManager.GetCurrentSolves($"{sourcePlayer.Name},Overload");
             if (stacks > 250)
             { 
-                var overloadChance = 0.1f * (stacks - 250) / 250;
+                var overloadChance = 0.075f * (stacks - 250) / 250;
                 if (overloadChance > ThreadSafeRandom.Next(0, 1))
                 {
                     var damage = sourcePlayer.Health.MaxValue / 10;


### PR DESCRIPTION
- doubles base rate players build overload
- reduces max mana cost increase to 50%
- self-harm chance reduced to 7.5%