### PR TITLE
update: overload fixes

### DIFF
--- a/Source/ACE.Server/WorldObjects/Creature_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Magic.cs
@@ -50,7 +50,7 @@ namespace ACE.Server.WorldObjects
             if (combatFocus != null)
                 combatAbility = combatFocus.GetCombatAbility();
 
-            // Overload - Increased cost up to 100%+ with Overload stacks
+            // Overload - Increased cost up to 50%+ with Overload stacks
             if (combatAbility == CombatAbility.Overload && this.QuestManager.HasQuest($"{this.Name},Overload"))
             {
                 if (spell.Flags.HasFlag(SpellFlags.FastCast))

--- a/Source/ACE.Server/WorldObjects/Player_Ability.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Ability.cs
@@ -32,6 +32,7 @@ namespace ACE.Server.WorldObjects
         public double LastEnchantedWeaponActivated = 0;
 
         public bool OverloadActivated = false;
+        public bool OverloadDumped = false;
         public bool RecklessActivated = false;
 
         public double MultishotActivatedDuration = 10;

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -658,7 +658,7 @@ namespace ACE.Server.WorldObjects
             var combatFocusDamageMod = 1.0f;
             if (sourcePlayer != null)
             {
-                // Overload - Increased effectiveness up to 50%+ with Overload stacks, double bonus + erase stacks on activated ability
+                // Overload - Increased effectiveness up to 25%+ with Overload stacks, double bonus + erase stacks on activated ability
                 if (sourcePlayer.EquippedCombatAbility == CombatAbility.Overload && sourcePlayer.QuestManager.HasQuest($"{sourcePlayer.Name},Overload"))
                 {
                     if (sourcePlayer.OverloadActivated == false)
@@ -670,8 +670,9 @@ namespace ACE.Server.WorldObjects
                     if (sourcePlayer.OverloadActivated && sourcePlayer.LastOverloadActivated > Time.GetUnixTime() - sourcePlayer.OverloadActivatedDuration)
                     {
                         sourcePlayer.OverloadActivated = false;
+                        sourcePlayer.OverloadDumped = true;
                         var overloadStacks = sourcePlayer.QuestManager.GetCurrentSolves($"{sourcePlayer.Name},Overload");
-                        var overloadMod = (float)overloadStacks / 500;
+                        var overloadMod = (float)overloadStacks / 1000;
                         combatFocusDamageMod += overloadMod;
                         sourcePlayer.QuestManager.Erase($"{sourcePlayer.Name},Overload");
                     }
@@ -679,6 +680,7 @@ namespace ACE.Server.WorldObjects
                     if (sourcePlayer.OverloadActivated && sourcePlayer.LastOverloadActivated < Time.GetUnixTime() - sourcePlayer.OverloadActivatedDuration)
                     {
                         sourcePlayer.OverloadActivated = false;
+                        sourcePlayer.OverloadDumped = false;
                         sourcePlayer.QuestManager.Erase($"{sourcePlayer.Name},Overload");
                     }
                 }
@@ -1274,6 +1276,12 @@ namespace ACE.Server.WorldObjects
                 if (sourcePlayer != null)
                 {
                     var critProt = critDefended ? " Your critical hit was avoided with their augmentation!" : "";
+
+                    if (sourcePlayer.OverloadDumped == true)
+                    {
+                        sourcePlayer.OverloadDumped = false;
+                        overloadMsg = "Overload Discharged! ";
+                    }    
 
                     var attackerMsg = $"{resistMost}{resistSome}{strikeThrough}{critMsg}{overpowerMsg}{overloadMsg}{sneakMsg}You {verb} {target.Name} for {amount} points with {Spell.Name}.{critProt}";
 

--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -727,7 +727,7 @@ namespace ACE.Server.WorldObjects
                 if (combatFocus != null)
                     combatAbility = combatFocus.GetCombatAbility();
 
-                // Overload - Increased effectiveness up to 50%+ with Overload stacks
+                // Overload - Increased effectiveness up to 25%+ with Overload stacks
                 if (combatAbility == CombatAbility.Overload)
                 {
                     overload = true;
@@ -746,10 +746,11 @@ namespace ACE.Server.WorldObjects
                     if (player.OverloadActivated && player.LastOverloadActivated > Time.GetUnixTime() - player.OverloadActivatedDuration)
                     {
                         player.OverloadActivated = false;
+                        player.OverloadDumped = true;
                         if (player.QuestManager.HasQuest($"{player.Name},Overload"))
                         {
                             var overloadStacks = player.QuestManager.GetCurrentSolves($"{player.Name},Overload");
-                            var overloadMod = 1 + (float)overloadStacks / 500;
+                            var overloadMod = 1 + (float)overloadStacks / 1000;
                             tryBoost = (int)(tryBoost * overloadMod);
                             player.QuestManager.Erase($"{player.Name},Overload");
                         }
@@ -757,6 +758,7 @@ namespace ACE.Server.WorldObjects
                     if (player.OverloadActivated && player.LastOverloadActivated < Time.GetUnixTime() - player.OverloadActivatedDuration)
                     {
                         player.OverloadActivated = false;
+                        player.OverloadDumped = false;
                         if (player.QuestManager.HasQuest($"{player.Name},Overload"))
                             player.QuestManager.Erase($"{player.Name},Overload");
                     }
@@ -877,6 +879,11 @@ namespace ACE.Server.WorldObjects
             {
                 string casterMessage;
                 var overloadMsg = overload ? $"{overloadPercent}% Overload! " : "";
+                if (player.OverloadDumped == true)
+                {
+                    player.OverloadDumped = false;
+                    overloadMsg = "Overload Discharged! ";
+                }
 
                 if (player != targetCreature)
                 {
@@ -1151,7 +1158,7 @@ namespace ACE.Server.WorldObjects
                 if (combatFocus != null)
                     combatAbility = combatFocus.GetCombatAbility();
 
-                // COMBAT ABILITY: Overload - Increased effectiveness up to 50%+ with Overload stacks, double bonus + erase stacks on activated
+                // COMBAT ABILITY: Overload - Increased effectiveness up to 25%+ with Overload stacks, double bonus + erase stacks on activated
                 if (combatAbility == CombatAbility.Overload)
                 {
                     overload = true;
@@ -1171,11 +1178,12 @@ namespace ACE.Server.WorldObjects
                     if (player.OverloadActivated == true && player.LastOverloadActivated > Time.GetUnixTime() - player.OverloadActivatedDuration)
                     {
                         player.OverloadActivated = false;
+                        player.OverloadDumped = true;
 
                         if (player.QuestManager.HasQuest($"{player.Name},Overload"))
                         {
                             var overloadStacks = player.QuestManager.GetCurrentSolves($"{player.Name},Overload");
-                            var overloadMod = 1 + (float)overloadStacks / 500;
+                            var overloadMod = 1 + (float)overloadStacks / 1000;
                             srcVitalChange = (uint)(srcVitalChange * overloadMod);
                             destVitalChange = (uint)(destVitalChange * overloadMod);
                             player.QuestManager.Erase($"{player.Name},Overload");
@@ -1184,6 +1192,7 @@ namespace ACE.Server.WorldObjects
                     if (player.OverloadActivated == true && player.LastOverloadActivated < Time.GetUnixTime() - player.OverloadActivatedDuration)
                     {
                         player.OverloadActivated = false;
+                        player.OverloadDumped = false;
 
                         if (player.QuestManager.HasQuest($"{player.Name},Overload"))                           
                             player.QuestManager.Erase($"{player.Name},Overload");
@@ -1297,6 +1306,11 @@ namespace ACE.Server.WorldObjects
             string sourceMsg = null, targetMsg = null;
 
             var overloadMsg = overload ? $"{overloadPercent}% Overload! " : "";
+            if (player != null && player.OverloadDumped == true)
+            {
+                player.OverloadDumped = false;
+                overloadMsg = "Overload Discharged! ";
+            }
 
             if (playerSource != null && playerDestination != null && transferSource.Guid == destination.Guid)
             {
@@ -1318,9 +1332,9 @@ namespace ACE.Server.WorldObjects
                 if (playerDestination != null)
                 {
                     if (destination == this)
-                        sourceMsg = $"You gain {destVitalChange} points of {destVital} due to casting {spell.Name} on {targetCreature.Name}";
+                        sourceMsg = $"{overloadMsg}You gain {destVitalChange} points of {destVital} due to casting {spell.Name} on {targetCreature.Name}";
                     else
-                        targetMsg = $"You gain {destVitalChange} points of {destVital} due to {caster.Name} casting {spell.Name} on you";
+                        targetMsg = $"{overloadMsg}You gain {destVitalChange} points of {destVital} due to {caster.Name} casting {spell.Name} on you";
                 }
             }
 

--- a/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
@@ -1024,11 +1024,11 @@ namespace ACE.Server.WorldObjects
                     if (combatFocus != null)
                         combatAbility = combatFocus.GetCombatAbility();
 
-                    // Overload - Increased cost up to 100%+ with Overload stacks
+                    // Overload - Increased cost up to 50%+ with Overload stacks
                     if (combatAbility == CombatAbility.Overload && playerAttacker.QuestManager.HasQuest($"{playerAttacker.Name},Overload"))
                     {
                         var overloadStacks = playerAttacker.QuestManager.GetCurrentSolves($"{playerAttacker.Name},Overload");
-                        float overloadMod = 1 + (overloadStacks / 500);
+                        float overloadMod = 1 + (overloadStacks / 1000);
                         baseCost = (uint)(baseCost * overloadMod);
                     }
                     // Battery - 20% mana cost reduction minimum, increasing with lower mana or 0 cost during Battery Activated


### PR DESCRIPTION
- fix overload activated effectiveness bonus to properly grant only double
- adds a modified message to alert players that a spell was impacted by the overload activated ability