### PR TITLE
update: fury fixes

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Ability.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Ability.cs
@@ -33,6 +33,7 @@ namespace ACE.Server.WorldObjects
 
         public bool OverloadActivated = false;
         public bool RecklessActivated = false;
+        public bool RecklessDumped = false;
 
         public double MultishotActivatedDuration = 10;
         public double PhalanxActivatedDuration = 10;
@@ -469,12 +470,7 @@ namespace ACE.Server.WorldObjects
                 playerAttacker.QuestManager.Increment($"{playerAttacker.Name},Reckless", (int)scaledStamps);
 
             var stacks = playerAttacker.QuestManager.GetCurrentSolves($"{playerAttacker.Name},Reckless");
-            if (stacks > 250)
-            {
-                var recklessChance = 0.075f * (stacks - 250) / 250;
-                if (recklessChance > ThreadSafeRandom.Next(0, 1))
-                    playerAttacker.DamageTarget(playerAttacker, playerAttacker);
-            }
+
             return stacks;
         }
 

--- a/Source/ACE.Server/WorldObjects/Player_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Combat.cs
@@ -222,6 +222,12 @@ namespace ACE.Server.WorldObjects
                                     recklessPercent = 0;
 
                                 recklessMsg = $"{recklessPercent} Fury! ";
+
+                                if (this.RecklessDumped == true)
+                                {
+                                    this.RecklessDumped = false;
+                                    recklessMsg = $"Furious Blow! ";
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
- made reckless activated proc unevadable to match overload
- fury self-damage now a flat 50% of damage done to foe (or max 10% of player health) to prevent armor mitigation
- updates attack message to indicate the activated proc
- ensures clean death if player dies due to self-harm
- fix random chance to float, was proccing 50% because of ints