### PR TITLE
Fix mana barrier double kill

### DIFF
--- a/Source/ACE.Server/WorldObjects/Player_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Combat.cs
@@ -802,39 +802,41 @@ namespace ACE.Server.WorldObjects
                 // 25% of damage taken as mana, x3 for trained
                 var manaDamage = (amount * 0.25) * 3 * skillModifier;
                 if (skill.AdvancementClass == SkillAdvancementClass.Specialized)
-                    manaDamage = (amount * 0.25) * 1.5 * skillModifier; 
+                    manaDamage = (amount * 0.25) * 1.5 * skillModifier;
 
-                if (ManaBarrierToggle && Mana.Current >= manaDamage)
+                if (ManaBarrierToggle)
                 {
-                    damageTaken = (uint)(amount * 0.75f);
-                    PlayParticleEffect(PlayScript.RestrictionEffectBlue, Guid);
-                    UpdateVitalDelta(Mana, (int)-Math.Round(manaDamage));
-                    UpdateVitalDelta(Health, (int)-damageTaken);
-                    DamageHistory.Add(source, damageType, (uint)damageTaken);
-                }
-                // if not enough mana, barrier falls and player takes remainder of damage as health
-                if (ManaBarrierToggle && Mana.Current < manaDamage)
-                {
-                    ToggleManaBarrierSetting();
-                    Session.Network.EnqueueSend(new GameMessageSystemChat($"Your mana barrier fails and collapses!", ChatMessageType.Magic));
-                    if (toggles != null)
+                    if (Mana.Current >= manaDamage)
                     {
-                        foreach (var toggle in toggles)
-                            EnchantmentManager.StartCooldown(toggle);
+                        damageTaken = (uint)(amount * 0.75f);
+                        PlayParticleEffect(PlayScript.RestrictionEffectBlue, Guid);
+                        UpdateVitalDelta(Mana, (int)-Math.Round(manaDamage));
+                        UpdateVitalDelta(Health, (int)-damageTaken);
+                        DamageHistory.Add(source, damageType, (uint)damageTaken);
                     }
-                    PlayParticleEffect(PlayScript.HealthDownBlue, Guid);
+                    // if not enough mana, barrier falls and player takes remainder of damage as health
+                    else
+                    {
+                        ToggleManaBarrierSetting();
+                        Session.Network.EnqueueSend(new GameMessageSystemChat($"Your mana barrier fails and collapses!", ChatMessageType.Magic));
+                        if (toggles != null)
+                        {
+                            foreach (var toggle in toggles)
+                                EnchantmentManager.StartCooldown(toggle);
+                        }
+                        PlayParticleEffect(PlayScript.HealthDownBlue, Guid);
 
-                    // find mana damage overage and reconvert to HP damage
-                    var manaRemainder = (manaDamage - Mana.Current) / skillModifier / 1.5;
-                    if (skill.AdvancementClass == SkillAdvancementClass.Specialized)
-                        manaRemainder = (manaDamage - Mana.Current) / skillModifier / 3;
+                        // find mana damage overage and reconvert to HP damage
+                        var manaRemainder = (manaDamage - Mana.Current) / skillModifier / 1.5;
+                        if (skill.AdvancementClass == SkillAdvancementClass.Specialized)
+                            manaRemainder = (manaDamage - Mana.Current) / skillModifier / 3;
 
-                    damageTaken = (uint)((amount * 0.75) + manaRemainder);
-                    UpdateVitalDelta(Mana, (int)-(Mana.Current - 1));
-                    UpdateVitalDelta(Health, (int)-(damageTaken));
-                    DamageHistory.Add(source, damageType, damageTaken);
+                        damageTaken = (uint)((amount * 0.75) + manaRemainder);
+                        UpdateVitalDelta(Mana, (int)-(Mana.Current - 1));
+                        UpdateVitalDelta(Health, (int)-(damageTaken));
+                        DamageHistory.Add(source, damageType, damageTaken);
+                    }
                 }
-
             }
 
             // update stamina

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -1155,7 +1155,7 @@ namespace ACE.Server.WorldObjects
                         if (targetPlayer.Mana.Current >= manaDamage)
                         {
                             amount = (uint)(damage * 0.75);
-                            PlayParticleEffect(PlayScript.RestrictionEffectBlue, Guid);
+                            targetPlayer.PlayParticleEffect(PlayScript.RestrictionEffectBlue, targetPlayer.Guid);
                             targetPlayer.UpdateVitalDelta(targetPlayer.Mana, (int)-Math.Round(manaDamage));
                             targetPlayer.UpdateVitalDelta(targetPlayer.Health, (int)-Math.Round((float)amount));
                             targetPlayer.DamageHistory.Add(ProjectileSource, Spell.DamageType, amount);
@@ -1171,7 +1171,7 @@ namespace ACE.Server.WorldObjects
                                     targetPlayer.EnchantmentManager.StartCooldown(toggle);
                             }
 
-                            PlayParticleEffect(PlayScript.HealthDownBlue, Guid);
+                            targetPlayer.PlayParticleEffect(PlayScript.HealthDownBlue, targetPlayer.Guid);
                             // find mana damage overage and reconvert to HP damage
                             var manaRemainder = (manaDamage - targetPlayer.Mana.Current) / skillModifier / 1.5;
                             if (skill.AdvancementClass == SkillAdvancementClass.Specialized)

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -1150,35 +1150,38 @@ namespace ACE.Server.WorldObjects
                     if (skill.AdvancementClass == SkillAdvancementClass.Specialized)
                         manaDamage = (damage * 0.25) * 1.5 * skillModifier;
 
-                    if (targetPlayer.ManaBarrierToggle && targetPlayer.Mana.Current >= manaDamage)
+                    if (targetPlayer.ManaBarrierToggle)
                     {
-                        amount = (uint)(damage * 0.75);
-                        PlayParticleEffect(PlayScript.RestrictionEffectBlue, Guid);
-                        targetPlayer.UpdateVitalDelta(targetPlayer.Mana, (int)-Math.Round(manaDamage));
-                        targetPlayer.UpdateVitalDelta(targetPlayer.Health, (int)-Math.Round((float)amount));
-                        targetPlayer.DamageHistory.Add(ProjectileSource, Spell.DamageType, amount);
-                    }
-                    // if not enough mana, barrier falls and player takes remainder of damage as health
-                    if (targetPlayer.ManaBarrierToggle && targetPlayer.Mana.Current < manaDamage)
-                    {
-                        targetPlayer.ToggleManaBarrierSetting();
-                        targetPlayer.Session.Network.EnqueueSend(new GameMessageSystemChat($"Your mana barrier fails and collapses!", ChatMessageType.Magic));
-                        if (toggles != null)
+                        if (targetPlayer.Mana.Current >= manaDamage)
                         {
-                            foreach (var toggle in toggles)
-                                targetPlayer.EnchantmentManager.StartCooldown(toggle);
+                            amount = (uint)(damage * 0.75);
+                            PlayParticleEffect(PlayScript.RestrictionEffectBlue, Guid);
+                            targetPlayer.UpdateVitalDelta(targetPlayer.Mana, (int)-Math.Round(manaDamage));
+                            targetPlayer.UpdateVitalDelta(targetPlayer.Health, (int)-Math.Round((float)amount));
+                            targetPlayer.DamageHistory.Add(ProjectileSource, Spell.DamageType, amount);
                         }
+                        // if not enough mana, barrier falls and player takes remainder of damage as health
+                        else
+                        {
+                            targetPlayer.ToggleManaBarrierSetting();
+                            targetPlayer.Session.Network.EnqueueSend(new GameMessageSystemChat($"Your mana barrier fails and collapses!", ChatMessageType.Magic));
+                            if (toggles != null)
+                            {
+                                foreach (var toggle in toggles)
+                                    targetPlayer.EnchantmentManager.StartCooldown(toggle);
+                            }
 
-                        PlayParticleEffect(PlayScript.HealthDownBlue, Guid);
-                        // find mana damage overage and reconvert to HP damage
-                        var manaRemainder = (manaDamage - targetPlayer.Mana.Current) / skillModifier / 1.5;
-                        if (skill.AdvancementClass == SkillAdvancementClass.Specialized)
-                            manaRemainder = (manaDamage - targetPlayer.Mana.Current) / skillModifier / 3;
+                            PlayParticleEffect(PlayScript.HealthDownBlue, Guid);
+                            // find mana damage overage and reconvert to HP damage
+                            var manaRemainder = (manaDamage - targetPlayer.Mana.Current) / skillModifier / 1.5;
+                            if (skill.AdvancementClass == SkillAdvancementClass.Specialized)
+                                manaRemainder = (manaDamage - targetPlayer.Mana.Current) / skillModifier / 3;
 
-                        amount = (uint)((damage * 0.75) + manaRemainder);
-                        targetPlayer.UpdateVitalDelta(targetPlayer.Mana, (int)-(targetPlayer.Mana.Current - 1));
-                        targetPlayer.UpdateVitalDelta(targetPlayer.Health, (int)-(amount));
-                        targetPlayer.DamageHistory.Add(ProjectileSource, Spell.DamageType, amount);
+                            amount = (uint)((damage * 0.75) + manaRemainder);
+                            targetPlayer.UpdateVitalDelta(targetPlayer.Mana, (int)-(targetPlayer.Mana.Current - 1));
+                            targetPlayer.UpdateVitalDelta(targetPlayer.Health, (int)-(amount));
+                            targetPlayer.DamageHistory.Add(ProjectileSource, Spell.DamageType, amount);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
- eliminates chance for health damage to fire off twice on certain hits (likely the cause of double deaths if the first hit kills player?)
