### PR TITLE
feat: cast-on-strike rebalance

### DIFF
--- a/Source/ACE.Server/Factories/LootGenerationFactory_Caster.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Caster.cs
@@ -174,21 +174,7 @@ namespace ACE.Server.Factories
             // burden?
 
             // spells
-            if (!isMagical)
-            {
-                wo.ItemManaCost = null;
-                wo.ItemMaxMana = null;
-                wo.ItemCurMana = null;
-                wo.ItemSpellcraft = null;
-                wo.ItemDifficulty = null;
-            }
-            else
-            {
-                // if a caster was from a MagicItem profile, it always had a SpellDID
-                MutateCaster_SpellDID(wo, profile);
-
-                AssignMagic(wo, profile, roll);
-            }
+            AssignMagic(wo, profile, roll, false, isMagical);
 
             // item value
             //if (wo.HasMutateFilter(MutateFilter.Value))   // fixme: data
@@ -234,7 +220,7 @@ namespace ACE.Server.Factories
                 return;
             }
 
-            var spellLevel = SpellLevelChance.Roll(profile.Tier);
+            var spellLevel = Math.Clamp(profile.Tier - 1, 1, 7);
 
             wo.SpellDID = (uint)spellLevels[spellLevel - 1];
 

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Clothing.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Clothing.cs
@@ -182,18 +182,7 @@ namespace ACE.Server.Factories
             wo.SetProperty(PropertyFloat.ArmorResourcePenalty, mod);
 
             // Spells
-            if (isMagical)
-            {
-                AssignMagic(wo, profile, roll, true);
-            }
-            else
-            {
-                wo.ItemManaCost = null;
-                wo.ItemMaxMana = null;
-                wo.ItemCurMana = null;
-                wo.ItemSpellcraft = null;
-                wo.ItemDifficulty = null;
-            }
+            AssignMagic(wo, profile, roll, true, isMagical);
 
             var totalSkillModPercentile = 0.0;
             var totalGearRatingPercentile = 0.0;
@@ -667,19 +656,9 @@ namespace ACE.Server.Factories
 
             wo.Value = Roll_ItemValue(wo, profile.Tier);
 
-            if (isMagical)
-            {
-                // looks like society armor always had impen on it
-                AssignMagic(wo, profile, roll, true);
-            }
-            else
-            {
-                wo.ItemManaCost = null;
-                wo.ItemMaxMana = null;
-                wo.ItemCurMana = null;
-                wo.ItemSpellcraft = null;
-                wo.ItemDifficulty = null;
-            }
+            // looks like society armor always had impen on it
+            AssignMagic(wo, profile, roll, true, isMagical);
+
             AssignArmorLevel(wo, profile.Tier, LootTables.ArmorType.SocietyArmor);
 
             wo.LongDesc = GetLongDesc(wo);

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Dinnerware.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Dinnerware.cs
@@ -53,7 +53,7 @@ namespace ACE.Server.Factories
 
             // "Empty Flask" was the only dinnerware that never received spells
             if (isMagical && wo.WeenieClassId != (uint)WeenieClassName.flasksimple)
-                AssignMagic(wo, profile, roll);
+                AssignMagic(wo, profile, roll, false, isMagical);
 
             // item value
             if (wo.HasMutateFilter(MutateFilter.Value))

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Jewelry.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Jewelry.cs
@@ -54,17 +54,7 @@ namespace ACE.Server.Factories
             wo.GemType = RollGemType(profile.Tier);
 
             // assign magic
-            if (isMagical)
-                AssignMagic(wo, profile, roll);
-            else
-            {
-                wo.ItemManaCost = null;
-                wo.ItemMaxMana = null;
-                wo.ItemCurMana = null;
-                wo.ItemSpellcraft = null;
-                wo.ItemDifficulty = null;
-                wo.ManaRate = null;
-            }
+            AssignMagic(wo, profile, roll, false, isMagical);
 
             // item value
             //  if (wo.HasMutateFilter(MutateFilter.Value))     // fixme: data

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Magic.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Magic.cs
@@ -18,24 +18,24 @@ namespace ACE.Server.Factories
 {
     public static partial class LootGenerationFactory
     {
-        private static void AssignMagic(WorldObject wo, TreasureDeath profile, TreasureRoll roll, bool isArmor = false)
+        private static void AssignMagic(WorldObject wo, TreasureDeath profile, TreasureRoll roll, bool isArmor = false, bool isMagical = false)
         {
             int numSpells = 0;
             int numEpics = 0;
             int numLegendaries = 0;
 
-            if (roll == null)
-            {
-                // previous method
-                if (!AssignMagic_Spells(wo, profile, isArmor, out numSpells, out numEpics, out numLegendaries))
-                    return;
-            }
-            else
+            if (isMagical)
             {
                 // new method
                 if (!AssignMagic_New(wo, profile, roll, out numSpells))
                     return;
+
+                if(wo.IsCaster)
+                    MutateCaster_SpellDID(wo, profile);
             }
+
+            if (RollProcSpell(wo, profile, roll))
+                numSpells++;
 
             if (numSpells == 0 && wo.SpellDID == null && wo.ProcSpell == null)
             {
@@ -914,13 +914,13 @@ namespace ACE.Server.Factories
         {
             switch(tier)
             {
-                case 1: return 100;
-                case 2: return 200;
-                case 3: return 250;
-                case 4: return 300;
-                case 5: return 350;
-                case 6: return 400;
-                case 7: return 450;
+                case 1: return 75;
+                case 2: return 175;
+                case 3: return 225;
+                case 4: return 275;
+                case 5: return 325;
+                case 6: return 375;
+                case 7: return 425;
                 default: return 50;
             }
         }

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Melee.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Melee.cs
@@ -183,17 +183,7 @@ namespace ACE.Server.Factories
             MutateBurden(wo, profile, true);
 
             // spells
-            if (!isMagical)
-            {
-                // clear base
-                wo.ItemManaCost = null;
-                wo.ItemMaxMana = null;
-                wo.ItemCurMana = null;
-                wo.ItemSpellcraft = null;
-                wo.ItemDifficulty = null;
-            }
-            else
-                AssignMagic(wo, profile, roll);
+            AssignMagic(wo, profile, roll, false, isMagical);
 
             // item value
             //if (wo.HasMutateFilter(MutateFilter.Value))   // fixme: data

--- a/Source/ACE.Server/Factories/LootGenerationFactory_Missile.cs
+++ b/Source/ACE.Server/Factories/LootGenerationFactory_Missile.cs
@@ -141,21 +141,11 @@ namespace ACE.Server.Factories
             MutateBurden(wo, profile, true);
 
             // spells
-            if (!isMagical)
-            {
-                wo.ItemManaCost = null;
-                wo.ItemMaxMana = null;
-                wo.ItemCurMana = null;
-                wo.ItemSpellcraft = null;
-                wo.ItemDifficulty = null;
-                wo.ManaRate = null;
-            }
-            else
-                AssignMagic(wo, profile, roll);
+            AssignMagic(wo, profile, roll, false, isMagical);
 
             // item value
             //if (wo.HasMutateFilter(MutateFilter.Value))   // fixme: data
-                MutateValue(wo, profile.Tier, roll);
+            MutateValue(wo, profile.Tier, roll);
 
             // long description
             wo.LongDesc = GetLongDesc(wo);


### PR DESCRIPTION
* Allow CoS spells to roll on items that don't have other spells.
* Set chance for any melee/missile weapon to have a CoS spell to 25%.
* Reduce base Arcane Lore requirements for magic gear by 25 points in each tier.
* Refactor AssignMagic code.