### PR TITLE
fix: spell transfer pearl

### DIFF
--- a/Source/ACE.Server/WorldObjects/SpellTransference.cs
+++ b/Source/ACE.Server/WorldObjects/SpellTransference.cs
@@ -221,10 +221,10 @@ namespace ACE.Server.WorldObjects
 
                         player.TryConsumeFromInventoryWithNetworking(source, amountToAdd);
 
+                        pearl.Tier = target.Tier;
                         var wieldReq = LootGenerationFactory.GetWieldDifficultyPerTier(pearl.Tier ?? 1);
                         pearl.LongDesc = $"This pearl contains the spell {spell.Name}.\n\nIt may only be applied to {itemType} with a Wield Requirement of {wieldReq} or greater.\n\nAdding this spell will increase Spellcraft and Arcane Lore of the target item, and will bind it to your character.\n\nIf the spell is an on-hit weapon proc, it will add a Life or War Magic skill wield requirement as well.";
                         pearl.TinkerLog = $"{target.ItemType}";
-                        pearl.Tier = target.Tier;
                         pearl.UiEffects = ACE.Entity.Enum.UiEffects.BoostMana;
                         player.EnqueueBroadcast(new GameMessageUpdateObject(source));
                         player.PlayParticleEffect(PlayScript.EnchantUpBlue, player.Guid);


### PR DESCRIPTION
- now properly takes target Tier before the long-description--previously was just using the base pearl's tier