### PR TITLE
update: encounter cooldown

### DIFF
--- a/Source/ACE.Server/Entity/GeneratorProfile.cs
+++ b/Source/ACE.Server/Entity/GeneratorProfile.cs
@@ -598,6 +598,9 @@ namespace ACE.Server.Entity
             Spawned.Remove(woi.Guid.Full);
 
             NextAvailable = DateTime.UtcNow.AddSeconds(Delay);
+
+            if (Generator.GetProperty(PropertyBool.IsPseudoRandomGenerator) == true)
+                Generator.GeneratorCooldown = Time.GetUnixTime();                 
         }
 
         public bool GeneratorResetInProgress = false;

--- a/Source/ACE.Server/Entity/Landblock.cs
+++ b/Source/ACE.Server/Entity/Landblock.cs
@@ -411,6 +411,7 @@ namespace ACE.Server.Entity
                 if (wo == null) continue;
 
                 wo.SetProperty(PropertyBool.IsPseudoRandomGenerator, true);
+                wo.GeneratorCooldownInterval = 180;
 
                 if (generatedEncounterIdList.Contains(encounter.Id))
                 {

--- a/Source/ACE.Server/WorldObjects/WorldObject_Generators.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Generators.cs
@@ -671,6 +671,9 @@ namespace ACE.Server.WorldObjects
             }
         }
 
+        public double GeneratorCooldown = 0;
+        public double GeneratorCooldownInterval = 0;
+
         /// <summary>
         /// Called every [RegenerationInterval] seconds<para />
         /// Also called from EmoteManager, Chest.Reset(), WorldObject.OnGenerate()
@@ -678,6 +681,10 @@ namespace ACE.Server.WorldObjects
         public void Generator_Generate(int? tier = null)
         {
             //Console.WriteLine($"{Name}.Generator_Generate({RegenerationInterval})");
+
+            // add a minimum 3 minute cooldown to encounter generation
+            if (GeneratorCooldown + GeneratorCooldownInterval > Time.GetUnixTime())
+                return;
 
             if (!GeneratorDisabled)
             {


### PR DESCRIPTION
- encounter generators are now given a 180s cooldown interval, which is only triggered after a monster they generated is killed, ensuring at least 3 mins passes before the gen can respawn again, regardless of the RegenerationInterval

- monster camp creatures are grandchildren of the encounter and wouldn't trigger this,  but shouldn't need to since atm camp gens don't regen at all basically, and the generator holds the slot?