### PR TITLE
Passup xp adjustments

### DIFF
--- a/Source/ACE.Server/Managers/AllegianceManager.cs
+++ b/Source/ACE.Server/Managers/AllegianceManager.cs
@@ -268,34 +268,25 @@ namespace ACE.Server.Managers
             if (leadership < 1) leadership = 1;
 
             // NEW SYSTEM
-            // Vassal Generated XP Mod = (Loyalty / 300) * 0.5
-            // Patron Received XP Mod = (Leadership / 300) * (Rank / 10)
+            // Vassal Generated XP Mod = 0.5 + (0.5 * (Loyalty / 263)) * 0.1
+            // Patron Received XP Mod = (0.5 + (0.5 * (Leadership / 263))) * (0.5 + (0.5 * (Rank / 10)))
             // Passup % = Generated Mod * Received Mod
             //
-            // Passup XP ranges from 0% to 50%.
+            // Passup XP ranges from 1.25% to 10%.
             // directFactor can be enabled to reduce continued passup by an additional 50%.
-            //
-            // Example A - players with MAXIMUM Loyalty (300), Leadership(300), and Rank(10): 
-            // Player earns 1000xp, generating 500xp for their patron.
-            // Patron receives 500xp passup. Then, generates 250xp passup to the grand patron.
-            // Grand Patron receives the 250xp. 
-            //
-            // Example B - players with MID-RANGE Loyalty (150), Leadership (150), and Rank (5)
-            // Player earns 1000xp, generating 250 xp for their patron.
-            // Patron receives 63 xp passup. Then, generates 16 xp passup to the grand patron.
-            // Grand Patron receives 4 xp.
 
             //var directFactor = direct ? 1.0f : 0.5f; // Currently not in use. May not be needed. Requires further testing.
-            var loyaltyMod = loyalty / SkillCap;
-            var leadershipMod = leadership / SkillCap;
-            var rankMod = (float)(patron.AllegianceRank ?? 0) == 0 ? 1 : (float)(patron.AllegianceRank ?? 0) / 10;
+            var loyaltyMod = 0.5f + (0.5f * (loyalty / SkillCap));
+            var generatedMod = loyaltyMod * 0.1f;
 
-            var generated = loyaltyMod * 0.5f; // directFactor to be used here if needed.
-            var received = leadershipMod * rankMod;
-            var passup = generated * received;
+            var leadershipMod = 0.5f + (0.5f * (leadership / SkillCap));
+            var rankMod = 0.5f + (0.5f * ((float)(patron.AllegianceRank ?? 1) / 10));
+            var receivedMod = leadershipMod * rankMod;
 
-            var generatedAmount = (uint)(amount * generated);
-            var passupAmount = (uint)(amount * passup);
+            var passupMod = generatedMod * receivedMod;
+
+            var generatedAmount = (uint)(amount * generatedMod);
+            var passupAmount = (uint)Math.Max(1, amount * passupMod);
 
             //Console.WriteLine($"{vassal.Name} earned {amount} xp and generated {generatedAmount} xp for passup ({Math.Round(generated, 3)}% mod). {patron.Name}'s {Math.Round(received, 3)}% received mod earned them {passupAmount} xp.");
 
@@ -318,7 +309,7 @@ namespace ACE.Server.Managers
 
                 var onlinePatron = PlayerManager.GetOnlinePlayer(patron.Guid);
                 if (onlinePatron != null)
-                    onlinePatron.AddAllegianceXP();
+                    onlinePatron.AddAllegianceXP(vassal);
 
                 // call recursively
                 DoPassXP(patronNode, passupAmount, false);

--- a/Source/ACE.Server/Managers/AllegianceManager.cs
+++ b/Source/ACE.Server/Managers/AllegianceManager.cs
@@ -269,10 +269,10 @@ namespace ACE.Server.Managers
 
             // NEW SYSTEM
             // Vassal Generated XP Mod = 0.5 + (0.5 * (Loyalty / 263)) * 0.1
-            // Patron Received XP Mod = (0.5 + (0.5 * (Leadership / 263))) * (0.5 + (0.5 * (Rank / 10)))
+            // Patron Received XP Mod = (0.5 + (0.5 * (Leadership / 263))) * (0.4 + (0.6 * (Rank / 10)))
             // Passup % = Generated Mod * Received Mod
             //
-            // Passup XP ranges from 1.25% to 10%.
+            // Passup XP ranges from 1% to 10%.
             // directFactor can be enabled to reduce continued passup by an additional 50%.
 
             //var directFactor = direct ? 1.0f : 0.5f; // Currently not in use. May not be needed. Requires further testing.
@@ -280,7 +280,7 @@ namespace ACE.Server.Managers
             var generatedMod = loyaltyMod * 0.1f;
 
             var leadershipMod = 0.5f + (0.5f * (leadership / SkillCap));
-            var rankMod = 0.5f + (0.5f * ((float)(patron.AllegianceRank ?? 1) / 10));
+            var rankMod = 0.4f + (0.6f * ((float)(patron.AllegianceRank ?? 1) / 10));
             var receivedMod = leadershipMod * rankMod;
 
             var passupMod = generatedMod * receivedMod;


### PR DESCRIPTION
* Rebalance passup xp
  * Change vassal generated xp range from 0% to 50% to 5% to 10%, depending on vassal Loyalty.
  * Change patron received xp range from 0% to 100% to 25% to 100%, depending on patron Leadership and Rank.
  * Final xp gained range for patrons: 1% to 10%.
* Adjust Leadership skill leveling
  * Formula = CachedXp * FellowshipMod * TimeSwornMod
* Adjust Loyalty skill leveling
  * Add a levelOffset mod to prevent slower loyalty leveling rate at high player levels.
  * Formula = ProportionCurrentLevelXpEarned * LevelOffset * LoyaltyRankXpCost * FellowshipMod * TimeSwornMod