### PR TITLE
feat: adjust threat system

### DIFF
--- a/Source/ACE.Server/Managers/PropertyManager.cs
+++ b/Source/ACE.Server/Managers/PropertyManager.cs
@@ -629,7 +629,8 @@ namespace ACE.Server.Managers
                 ("allow_xp_at_max_level", new Property<bool>(false, "enable this to allow players to continue earning xp after reaching max level")),
                 ("block_vpn_connections", new Property<bool>(false, "enable this to block user sessions from IPs identified as VPN proxies")),
                 ("increase_minimum_encounter_spawn_density", new Property<bool>(true, "enable this to increase the density of random encounters that spawn in low density landblocks")),
-                ("command_who_enabled", new Property<bool>(true, "disable this to prevent players from listing online players in their allegiance"))
+                ("command_who_enabled", new Property<bool>(true, "disable this to prevent players from listing online players in their allegiance")),
+                ("debug_threat_system", new Property<bool>(false, "enable this to see threat system console logging"))
                 );
 
         public static readonly ReadOnlyDictionary<string, Property<long>> DefaultLongProperties =

--- a/Source/ACE.Server/WorldObjects/Monster_Awareness.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Awareness.cs
@@ -148,8 +148,8 @@ namespace ACE.Server.WorldObjects
         }
 
 
-        private static bool DebugThreatSystem = false;
-        private static int ThreatStartingAmount = 100;
+        private bool DebugThreatSystem { get => PropertyManager.GetBool("debug_threat_system").Item; }
+        private const int ThreatStartingAmount = 100;
         private double ThreatGainedSinceLastTick = 1;
 
         public Dictionary<Creature, int> ThreatLevel;
@@ -211,11 +211,11 @@ namespace ACE.Server.WorldObjects
 
             foreach (Creature key in ThreatLevel.Keys)
             {
-                if (ThreatLevel[key] > 50)
+                if (ThreatLevel[key] > ThreatStartingAmount)
                     ThreatLevel[key] -= amount;
 
-                if (ThreatLevel[key] < 50)
-                    ThreatLevel[key] = 50;
+                if (ThreatLevel[key] < ThreatStartingAmount)
+                    ThreatLevel[key] = ThreatStartingAmount;
             }
         }
 
@@ -290,7 +290,7 @@ namespace ACE.Server.WorldObjects
 
                     if (DebugThreatSystem)
                     {
-                        Console.WriteLine($"\n\n--------------\nThreatLevel list for {Name}:");
+                        Console.WriteLine($"\n\n--------------\nThreatLevel list for {Name} ({WeenieClassId}):");
                         foreach (Creature targetCreature in ThreatLevel.Keys)
                         {
                             Console.WriteLine($"-{targetCreature.Name}: {ThreatLevel[targetCreature]}");

--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -2801,30 +2801,32 @@ namespace ACE.Server.WorldObjects
         {
             var player = this as Player;
 
-            if (player == null)
+            if (player == null || playerTarget == null)
+                return;
+
+            if (playerTarget == player) // don't add support threat if player is targeting themself
                 return;
 
             var targetThreatRange = 3.0; // casting support spells on another player adds threat to monsters that are close to the targeted player
-            var casterThreatRange = 20.0; // casting any support spell adds threat to all creatures in the area
+            var casterThreatRange = 3.0; // casting any support spell adds threat to all creatures near the caster
 
             var nearbyMonstersOfTarget = playerTarget.GetNearbyMonsters(targetThreatRange);
             var nearbyMonstersOfCaster = player.GetNearbyMonsters(casterThreatRange);
 
-            var threatAmount = 5 * spell.Level;
+            var threatAmount = 2 * spell.Level;
 
             if (spell.MetaSpellType == SpellType.Boost)
                 threatAmount = (uint)(amount / 2);
 
             List<Creature> threatenedByTargetSupport = new List<Creature>();
 
-            if (playerTarget != player)
-                foreach (var creature in nearbyMonstersOfTarget)
-                {
-                    creature.IncreaseTargetThreatLevel(player, (int)threatAmount * 2);
-                    threatenedByTargetSupport.Add(creature);
-                }
+            foreach (var creature in nearbyMonstersOfTarget)
+            {
+                creature.IncreaseTargetThreatLevel(player, (int)threatAmount * 2);
+                threatenedByTargetSupport.Add(creature);
+            }
 
-            // don't increase a monster's threat towards a caster again if they already received threat from a targeted support spell
+            // While increasing threat of enemies nearby caster, don't increase a monster's threat towards them again if they already received threat from a targeted support spell
             foreach (var creature in nearbyMonstersOfCaster)
             {
                 var skip = false;


### PR DESCRIPTION
* Adjust minimum threat level to be the same as starting threat level (100).
* Reduce support spell threat range (from caster) to 3 from 20.
* Reduce support spell threat gained amount to (2 x spell level) from (5 x spell level).
* Make sure self-target spells don't add threat.
* Add server property (debug_threat_system) that can be turned on for detailed threat console logging for all active players.