### PR TITLE
fix: bandaid for strikethrough null refernece

### DIFF
--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -276,7 +276,8 @@ namespace ACE.Server.WorldObjects
         {
             //Console.WriteLine($"{Name}.OnCollideObject({target.Name})");
 
-            if (StrikethroughTargets.Contains(target.Guid.Full)) return;
+            if (target != null && StrikethroughTargets != null)
+                if (StrikethroughTargets.Contains(target.Guid.Full)) return;
 
             var player = ProjectileSource as Player;
 


### PR DESCRIPTION
- eliminates cooldown for anything but being broken by monster damage