### PR TITLE
Crafting xp tweaks

### DIFF
--- a/Source/ACE.Server/Managers/PropertyManager.cs
+++ b/Source/ACE.Server/Managers/PropertyManager.cs
@@ -630,7 +630,8 @@ namespace ACE.Server.Managers
                 ("block_vpn_connections", new Property<bool>(false, "enable this to block user sessions from IPs identified as VPN proxies")),
                 ("increase_minimum_encounter_spawn_density", new Property<bool>(true, "enable this to increase the density of random encounters that spawn in low density landblocks")),
                 ("command_who_enabled", new Property<bool>(true, "disable this to prevent players from listing online players in their allegiance")),
-                ("debug_threat_system", new Property<bool>(false, "enable this to see threat system console logging"))
+                ("debug_threat_system", new Property<bool>(false, "enable this to see threat system console logging")),
+                ("debug_crafting_system", new Property<bool>(false, "enable this to see crafting system console logging"))
                 );
 
         public static readonly ReadOnlyDictionary<string, Property<long>> DefaultLongProperties =

--- a/Source/ACE.Server/Managers/RecipeManager.cs
+++ b/Source/ACE.Server/Managers/RecipeManager.cs
@@ -390,33 +390,13 @@ namespace ACE.Server.Managers
                     UpdateObj(player, target);
             }
             
-            // CUSTOM CRAFTING - On success, so long as difficulty is no more than 10 above current skill, grant 20% of rank in no-contribution XP
+            // CUSTOM CRAFTING
             if (recipe.Skill > 0 && recipe.Difficulty > 0 && success)
             {
                 var skill = player.GetCreatureSkill((Skill)recipe.Skill);
                 var skillType = (Skill)recipe.Skill;
 
-                // check to ensure appropriately difficult craft before granting xp (is player skill no more than 50 points above relative difficulty)
-                if ((int)skill.Current - recipe.Difficulty < 50)
-                {
-                    var progressPercentage = Math.Max(0, 1 - (skill.Current / 200));
-                    var progressMod = 0.01f + 0.49f * progressPercentage;
-
-                    var difficulty = recipe.Difficulty;
-                    var relativeDifficulty = difficulty - skill.Current;
-                    var difficultyMod = 1 + (float)Math.Clamp(relativeDifficulty, -50, 50) / 50;
-
-                    var xP = player.GetXPBetweenSkillLevels(skill.AdvancementClass, skill.Ranks, skill.Ranks + 1);
-                    var totalXp = xP * progressMod * difficultyMod;
-
-                    player.NoContribSkillXp(player, skillType, (uint)totalXp, false);
-
-                    if (PropertyManager.GetBool("debug_crafting_system").Item)
-                        Console.WriteLine($"Skill: {skill.Current}, RecipeDiff: {difficulty}\n" +
-                            $"ProgressPercent: {progressPercentage}, ProgressMod: {progressMod}\n" +
-                            $"CraftDiff: {relativeDifficulty}, DiffMod: {difficultyMod}\n" +
-                            $"ToLevelXp: {xP}, TotalXpAward: {totalXp}");
-                }
+                player.TryAwardCraftingXp(player, skill, skillType, (int)recipe.Difficulty);
             }
         }
 

--- a/Source/ACE.Server/Managers/RecipeManager.cs
+++ b/Source/ACE.Server/Managers/RecipeManager.cs
@@ -406,10 +406,8 @@ namespace ACE.Server.Managers
                     var relativeDifficulty = difficulty - skill.Current;
                     var difficultyMod = 1 + (float)Math.Clamp(relativeDifficulty, -50, 50) / 50;
 
-                    var rankXP = progressMod * difficultyMod;
-
                     var xP = player.GetXPBetweenSkillLevels(skill.AdvancementClass, skill.Ranks, skill.Ranks + 1);
-                    var totalXp = xP * rankXP;
+                    var totalXp = xP * progressMod * difficultyMod;
 
                     player.NoContribSkillXp(player, skillType, (uint)totalXp, false);
 
@@ -417,7 +415,7 @@ namespace ACE.Server.Managers
                         Console.WriteLine($"Skill: {skill.Current}, RecipeDiff: {difficulty}\n" +
                             $"ProgressPercent: {progressPercentage}, ProgressMod: {progressMod}\n" +
                             $"CraftDiff: {relativeDifficulty}, DiffMod: {difficultyMod}\n" +
-                            $"RankXp: {rankXP}, ToLevelXp: {xP}, TotalXpAward: {totalXp}");
+                            $"ToLevelXp: {xP}, TotalXpAward: {totalXp}");
                 }
             }
         }

--- a/Source/ACE.Server/Managers/RecipeManager.cs
+++ b/Source/ACE.Server/Managers/RecipeManager.cs
@@ -389,17 +389,35 @@ namespace ACE.Server.Managers
                 if (modified.Contains(target.Guid.Full))
                     UpdateObj(player, target);
             }
+            
             // CUSTOM CRAFTING - On success, so long as difficulty is no more than 10 above current skill, grant 20% of rank in no-contribution XP
             if (recipe.Skill > 0 && recipe.Difficulty > 0 && success)
             {
                 var skill = player.GetCreatureSkill((Skill)recipe.Skill);
-                var playerSkill = (Skill)recipe.Skill;
-                if (skill.Ranks < recipe.Difficulty + 10)
-                {
-                    var xP = player.GetXPBetweenSkillLevels(skill.AdvancementClass, skill.Ranks, skill.Ranks + 1);
-                        xP /= 5;
+                var skillType = (Skill)recipe.Skill;
 
-                    player.NoContribSkillXp(player, playerSkill, (uint)xP, false);
+                // check to ensure appropriately difficult craft before granting xp (is player skill no more than 50 points above relative difficulty)
+                if ((int)skill.Current - recipe.Difficulty < 50)
+                {
+                    var progressPercentage = Math.Max(0, 1 - (skill.Current / 200));
+                    var progressMod = 0.01f + 0.49f * progressPercentage;
+
+                    var difficulty = recipe.Difficulty;
+                    var relativeDifficulty = difficulty - skill.Current;
+                    var difficultyMod = 1 + (float)Math.Clamp(relativeDifficulty, -50, 50) / 50;
+
+                    var rankXP = progressMod * difficultyMod;
+
+                    var xP = player.GetXPBetweenSkillLevels(skill.AdvancementClass, skill.Ranks, skill.Ranks + 1);
+                    var totalXp = xP * rankXP;
+
+                    player.NoContribSkillXp(player, skillType, (uint)totalXp, false);
+
+                    if (PropertyManager.GetBool("debug_crafting_system").Item)
+                        Console.WriteLine($"Skill: {skill.Current}, RecipeDiff: {difficulty}\n" +
+                            $"ProgressPercent: {progressPercentage}, ProgressMod: {progressMod}\n" +
+                            $"CraftDiff: {relativeDifficulty}, DiffMod: {difficultyMod}\n" +
+                            $"RankXp: {rankXP}, ToLevelXp: {xP}, TotalXpAward: {totalXp}");
                 }
             }
         }

--- a/Source/ACE.Server/WorldObjects/Jewel.cs
+++ b/Source/ACE.Server/WorldObjects/Jewel.cs
@@ -588,29 +588,8 @@ namespace ACE.Server.WorldObjects
 
             if (modifiedBase < 1)
                 modifiedBase = 1;
-            
-            // check to ensure appropriately difficult carve before granting xp (is player skill no more than 50 points above relative difficulty)
-            if ((int)skillLevel - difficulty < 50)
-            {
-                // Awarded xp scales based on level of current skill progress (50% of current rank awarded per tink, down to 1% at 200 skill).
-                // Bonus/penalty xp awarded for relative difficulty of the craft (-50% to +100%).
-                var progressPercentage = Math.Max(0, 1 - (skill.Current / 200));
-                var progressMod = 0.01f + 0.49f * progressPercentage;
 
-                var relativeDifficulty = (float)difficulty - skillLevel;
-                var difficultyMod = 1 + Math.Clamp(relativeDifficulty, -50, 50) / 50;
-
-                var xP = player.GetXPBetweenSkillLevels(skill.AdvancementClass, skill.Ranks, skill.Ranks + 1);
-                var totalXP = (uint)(xP * progressMod * difficultyMod);
-
-                player.NoContribSkillXp(player, Skill.ItemTinkering, (uint)totalXP, false);
-
-                if (PropertyManager.GetBool("debug_crafting_system").Item)
-                    Console.WriteLine($"Skill: {skillLevel}, RecipeDiff: {difficulty}\n" +
-                        $"ProgressPercent: {progressPercentage}, ProgressMod: {progressMod}\n" +
-                        $"CraftDiff: {relativeDifficulty}, DiffMod: {difficultyMod}\n" +
-                        $"ToLevelXp: {xP}, TotalXpAward: {totalXP}");
-            }
+            player.TryAwardCraftingXp(player, skill, Skill.ItemTinkering, (int)difficulty);
 
             // get quality name + write socket and jewel name
             // 0 - prepended quality, 1 - gemstone type, 2 - appended name, 3 - property type, 4 - amount of property, 5 - original gem workmanship

--- a/Source/ACE.Server/WorldObjects/Jewel.cs
+++ b/Source/ACE.Server/WorldObjects/Jewel.cs
@@ -600,10 +600,8 @@ namespace ACE.Server.WorldObjects
                 var relativeDifficulty = (float)difficulty - skillLevel;
                 var difficultyMod = 1 + Math.Clamp(relativeDifficulty, -50, 50) / 50;
 
-                var rankXP = progressMod * difficultyMod;
-
                 var xP = player.GetXPBetweenSkillLevels(skill.AdvancementClass, skill.Ranks, skill.Ranks + 1);
-                var totalXP = (uint)(xP * rankXP);
+                var totalXP = (uint)(xP * progressMod * difficultyMod);
 
                 player.NoContribSkillXp(player, Skill.ItemTinkering, (uint)totalXP, false);
 
@@ -611,7 +609,7 @@ namespace ACE.Server.WorldObjects
                     Console.WriteLine($"Skill: {skillLevel}, RecipeDiff: {difficulty}\n" +
                         $"ProgressPercent: {progressPercentage}, ProgressMod: {progressMod}\n" +
                         $"CraftDiff: {relativeDifficulty}, DiffMod: {difficultyMod}\n" +
-                        $"RankXp: {rankXP}, ToLevelXp: {xP}, TotalXpAward: {totalXP}");
+                        $"ToLevelXp: {xP}, TotalXpAward: {totalXP}");
             }
 
             // get quality name + write socket and jewel name

--- a/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
@@ -165,26 +165,7 @@ namespace ACE.Server.WorldObjects.Managers
                         var skill = player.GetCreatureSkill(playerSkill);
                         var difficulty = emote.Amount ?? 0;
 
-                        // check to ensure appropriately difficult craft before granting xp (is player skill no more than 50 points above relative difficulty)
-                        if ((int)skill.Current - difficulty < 50)
-                        {
-                            var progressPercentage = Math.Max(0, 1 - (skill.Current / 200));
-                            var progressMod = 0.01f + 0.49f * progressPercentage;
-
-                            var relativeDifficulty = difficulty - skill.Current;
-                            var difficultyMod = 1 + (float)Math.Clamp(relativeDifficulty, -50, 50) / 50;
-
-                            var xP = player.GetXPBetweenSkillLevels(skill.AdvancementClass, skill.Ranks, skill.Ranks + 1);
-                            var totalXp = xP * progressMod * difficultyMod;
-
-                            player.NoContribSkillXp(player, playerSkill, (uint)totalXp, false);
-
-                            if (PropertyManager.GetBool("debug_crafting_system").Item)
-                                Console.WriteLine($"Skill: {skill.Current}, RecipeDiff: {difficulty}\n" +
-                                    $"ProgressPercent: {progressPercentage}, ProgressMod: {progressMod}\n" +
-                                    $"CraftDiff: {relativeDifficulty}, DiffMod: {difficultyMod}\n" +
-                                    $"ToLevelXp: {xP}, TotalXpAward: {totalXp}");
-                        }
+                        player.TryAwardCraftingXp(player, skill, playerSkill, difficulty);
                     }
                     break;
                         

--- a/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
@@ -174,10 +174,8 @@ namespace ACE.Server.WorldObjects.Managers
                             var relativeDifficulty = difficulty - skill.Current;
                             var difficultyMod = 1 + (float)Math.Clamp(relativeDifficulty, -50, 50) / 50;
 
-                            var rankXP = progressMod * difficultyMod;
-
                             var xP = player.GetXPBetweenSkillLevels(skill.AdvancementClass, skill.Ranks, skill.Ranks + 1);
-                            var totalXp = xP * rankXP;
+                            var totalXp = xP * progressMod * difficultyMod;
 
                             player.NoContribSkillXp(player, playerSkill, (uint)totalXp, false);
 
@@ -185,7 +183,7 @@ namespace ACE.Server.WorldObjects.Managers
                                 Console.WriteLine($"Skill: {skill.Current}, RecipeDiff: {difficulty}\n" +
                                     $"ProgressPercent: {progressPercentage}, ProgressMod: {progressMod}\n" +
                                     $"CraftDiff: {relativeDifficulty}, DiffMod: {difficultyMod}\n" +
-                                    $"RankXp: {rankXP}, ToLevelXp: {xP}, TotalXpAward: {totalXp}");
+                                    $"ToLevelXp: {xP}, TotalXpAward: {totalXp}");
                         }
                     }
                     break;

--- a/Source/ACE.Server/WorldObjects/Salvage.cs
+++ b/Source/ACE.Server/WorldObjects/Salvage.cs
@@ -883,10 +883,8 @@ namespace ACE.Server.WorldObjects
                 var relativeDifficulty = difficulty - skill.Current;
                 var difficultyMod = 1 + Math.Clamp(relativeDifficulty, -50, 50) / 50;
 
-                var rankXP = progressMod * difficultyMod * armorSlots;
                 var xP = player.GetXPBetweenSkillLevels(skill.AdvancementClass, skill.Ranks, skill.Ranks + 1);
-
-                var totalXp = (uint)(xP * rankXP);
+                var totalXp = (uint)(xP * progressMod * difficultyMod * armorSlots);
                 
                 player.NoContribSkillXp(player, tinkeringSkill, totalXp, false);
 
@@ -894,7 +892,7 @@ namespace ACE.Server.WorldObjects
                     Console.WriteLine($"Skill: {skill.Current}, RecipeDiff: {difficulty}\n" +
                         $"ProgressPercent: {progressPercentage}, ProgressMod: {progressMod}\n" +
                         $"CraftDiff: {relativeDifficulty}, DiffMod: {difficultyMod}\n" +
-                        $"RankXp: {rankXP}, ToLevelXp: {xP}, TotalXpAward: {totalXp}");
+                        $"ToLevelXp: {xP}, TotalXpAward: {totalXp}");
             }
 
             BroadcastTinkering(player, source, target, successChance, success, successAmount);

--- a/Source/ACE.Server/WorldObjects/Salvage.cs
+++ b/Source/ACE.Server/WorldObjects/Salvage.cs
@@ -871,28 +871,30 @@ namespace ACE.Server.WorldObjects
                  */
                 }
             }
-
-            // Awarded xp scales based on level of current skill progress (50% of current rank awarded per tink, down to 1% at 200 skill).
-            // Up to x2 xp when succeeding at recipes that are up to 50 more difficult than current skill.
-            // x0.25 if failed.
-            var progressPercentage = Math.Max(0, 1 - (skill.Current / 200));
-            var progressMod = 0.01f + 0.49f * progressPercentage;
-
-            var skillDiff = difficulty - skill.Current;
-            var diffMod = success ? Math.Clamp(1 + (float)skillDiff / 50, 1.0, 2.0) : 1.0f;
-
-            var successMod = success ? 1.0f : 0.25f;
-
-            var rankXP = progressMod * diffMod * successMod * armorSlots;
             
-            // check to ensure appropriately difficult tinker before granting (is player skill no more than 50 points away from adjusted diff)
+            // check to ensure appropriately difficult tinker before granting (is player skill no more than 50 points above relative difficulty)
             if (skill.Current - difficulty < 50)
             {
+                // Awarded xp scales based on level of current skill progress (50% of current rank awarded per tink, down to 1% at 200 skill).
+                // Bonus/penalty xp awarded for relative difficulty of the craft (-50% to +100%).
+                var progressPercentage = Math.Max(0, 1 - (skill.Current / 200));
+                var progressMod = 0.01f + 0.49f * progressPercentage;
+
+                var relativeDifficulty = difficulty - skill.Current;
+                var difficultyMod = 1 + Math.Clamp(relativeDifficulty, -50, 50) / 50;
+
+                var rankXP = progressMod * difficultyMod * armorSlots;
                 var xP = player.GetXPBetweenSkillLevels(skill.AdvancementClass, skill.Ranks, skill.Ranks + 1);
 
-                var totalXP = (uint)(xP * rankXP);
+                var totalXp = (uint)(xP * rankXP);
                 
-                player.NoContribSkillXp(player, tinkeringSkill, totalXP, false);
+                player.NoContribSkillXp(player, tinkeringSkill, totalXp, false);
+
+                if (PropertyManager.GetBool("debug_crafting_system").Item)
+                    Console.WriteLine($"Skill: {skill.Current}, RecipeDiff: {difficulty}\n" +
+                        $"ProgressPercent: {progressPercentage}, ProgressMod: {progressMod}\n" +
+                        $"CraftDiff: {relativeDifficulty}, DiffMod: {difficultyMod}\n" +
+                        $"RankXp: {rankXP}, ToLevelXp: {xP}, TotalXpAward: {totalXp}");
             }
 
             BroadcastTinkering(player, source, target, successChance, success, successAmount);

--- a/Source/ACE.Server/WorldObjects/Salvage.cs
+++ b/Source/ACE.Server/WorldObjects/Salvage.cs
@@ -871,30 +871,8 @@ namespace ACE.Server.WorldObjects
                  */
                 }
             }
-            
-            // check to ensure appropriately difficult tinker before granting (is player skill no more than 50 points above relative difficulty)
-            if (skill.Current - difficulty < 50)
-            {
-                // Awarded xp scales based on level of current skill progress (50% of current rank awarded per tink, down to 1% at 200 skill).
-                // Bonus/penalty xp awarded for relative difficulty of the craft (-50% to +100%).
-                var progressPercentage = Math.Max(0, 1 - (skill.Current / 200));
-                var progressMod = 0.01f + 0.49f * progressPercentage;
 
-                var relativeDifficulty = difficulty - skill.Current;
-                var difficultyMod = 1 + Math.Clamp(relativeDifficulty, -50, 50) / 50;
-
-                var xP = player.GetXPBetweenSkillLevels(skill.AdvancementClass, skill.Ranks, skill.Ranks + 1);
-                var totalXp = (uint)(xP * progressMod * difficultyMod * armorSlots);
-                
-                player.NoContribSkillXp(player, tinkeringSkill, totalXp, false);
-
-                if (PropertyManager.GetBool("debug_crafting_system").Item)
-                    Console.WriteLine($"Skill: {skill.Current}, RecipeDiff: {difficulty}\n" +
-                        $"ProgressPercent: {progressPercentage}, ProgressMod: {progressMod}\n" +
-                        $"CraftDiff: {relativeDifficulty}, DiffMod: {difficultyMod}\n" +
-                        $"ToLevelXp: {xP}, TotalXpAward: {totalXp}");
-            }
-
+            player.TryAwardCraftingXp(player, skill, tinkeringSkill, difficulty, armorSlots);
             BroadcastTinkering(player, source, target, successChance, success, successAmount);
             TinkeringCleanup(player, source, target);
         }


### PR DESCRIPTION
- Update crafting xp rewards for Tinkering, Jewelcrafting, Cooking, and Alchemy.
- Successful crafts award an amount of xp depending on the following:
   - Cost of current skill rank.
   - Overall skill level progress, from 1 to 200 skill. (mod scales from 50% to 1%)
   - Relative difficulty of craft attempt, from -50 (easy) to 50 (hard). (mod scales from 50% to 200%)
   - Relative difficulty must be higher than -50 to receive any xp.
   - FinalXp = RankCost * ProgressMod * DifficultyMod.
- Campfire and Alchemy Table emote scripts updated to work with this system.