### PR TITLE
fix: mana barrier/double kills

### DIFF
--- a/Source/ACE.Server/WorldObjects/Creature_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Death.cs
@@ -682,20 +682,7 @@ namespace ACE.Server.WorldObjects
 
                     if (dropped.Count == 0 && !isPKLdeath)
                         player.Session.Network.EnqueueSend(new GameMessageSystemChat($"You have retained all your items. You do not need to recover your corpse!", ChatMessageType.Broadcast));
-                }
-
-                if (player.ManaBarrierToggle)
-                {
-                    var toggles = player.GetInventoryItemsOfWCID(1051110);
-
-                    player.ToggleManaBarrierSetting();
-                    player.Session.Network.EnqueueSend(new GameMessageSystemChat($"Upon death, your mana barrier fails and collapses!", ChatMessageType.Magic));
-                    if (toggles != null)
-                    {
-                        foreach (var toggle in toggles)
-                            EnchantmentManager.StartCooldown(toggle);
-                    }
-                }
+                }                
             }
             else
             {

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -1329,6 +1329,13 @@ namespace ACE.Server.WorldObjects
                         target.EmoteManager.OnReceiveCritical(sourcePlayer);
                 }
             }
+            else if (targetPlayer != null && !targetPlayer.IsInDeathProcess)
+            {
+                targetPlayer.IsInDeathProcess = true;
+                var lastDamager = ProjectileSource != null ? new DamageHistoryInfo(ProjectileSource) : null;
+                targetPlayer.OnDeath(lastDamager, Spell.DamageType, critical);
+                targetPlayer.Die();
+            }
             else
             {
                 var lastDamager = ProjectileSource != null ? new DamageHistoryInfo(ProjectileSource) : null;

--- a/Source/ACE.Server/WorldObjects/WorldObject_Use.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Use.cs
@@ -93,16 +93,6 @@ namespace ACE.Server.WorldObjects
 
                 return;
             }
-
-            if (player != null)
-            {
-                if (!player.ManaBarrierToggle && this.WeenieClassId == 1051110)
-                {
-                    // Console.WriteLine("No Cooldown");
-                }
-                else
-                    player.EnchantmentManager.StartCooldown(this);
-            }
                 
             // perform motion animation - rarely used (only 4 instances in PY16 db)
             if (ActivationResponse.HasFlag(ActivationResponse.Animate))


### PR DESCRIPTION
- removes mana barrier cooldown on death and on manual untoggling--only way mana barrier goes on cooldown now is if it is broken by zeroing out on mana

- adds IsInDeathProcess checks before OnDeath/Die is called, and sets it as true if the check is passed (as opposed to base ACE where it is not set to true until Die is called).  Hopefully, this will prevent these methods from being called twice in a row before player receives lifestone protection, whatever the cause