### PR TITLE
fix: burden on login

### DIFF
--- a/Source/ACE.Server/Managers/WorldManager.cs
+++ b/Source/ACE.Server/Managers/WorldManager.cs
@@ -281,7 +281,14 @@ namespace ACE.Server.Managers
             else if (playerLoggedInOnNoLogLandblock) // see http://acpedia.org/wiki/Mount_Elyrii_Hive
                 session.Network.EnqueueSend(new GameMessageSystemChat("The currents of portal space cannot return you from whence you came. Your previous location forbids login.", ChatMessageType.Broadcast));
 
-            player.RecalculateBurden();
+            var act = new ActionChain();
+            act.AddDelaySeconds(3.0f);
+            act.AddAction(session.Player, () =>
+            {
+                if (session != null && session.Player != null)
+                    session.Player.RecalculateBurden();
+            });
+            act.EnqueueChain();
         }
 
         private static string AppendLines(params string[] lines)


### PR DESCRIPTION
- replaces a straight method call to recalc burden with a 3 sec delayed action chain, to hopefully ensure it fires off on the live server so players login with the proper burden