### PR TITLE
feat: adjust jump spec issues

### DIFF
--- a/Source/ACE.Server/Entity/BaseDamageMod.cs
+++ b/Source/ACE.Server/Entity/BaseDamageMod.cs
@@ -50,7 +50,7 @@ namespace ACE.Server.Entity
                 BaseDamage.MaxDamage = (int)Math.Round(BaseDamage.MaxDamage * weapon.EnchantmentManager.GetDamageBonus());
 
             DamageBonus *= weapon.EnchantmentManager.GetDamageBonus();
-            VarianceMod *= weapon.EnchantmentManager.GetVarianceMod();
+            //VarianceMod *= weapon.EnchantmentManager.GetVarianceMod();
 
             //DamageMod = (float)(weapon.GetProperty(PropertyFloat.DamageMod) ?? 1.0f) + (((float)(weapon.GetProperty(PropertyFloat.DamageMod) ?? 1.0f) - 1.0f) * (weapon.EnchantmentManager.GetDamageMod() - 1.0f));
             DamageMod = (float)(weapon.GetProperty(PropertyFloat.DamageMod) ?? 1.0f);
@@ -62,7 +62,7 @@ namespace ACE.Server.Entity
 
                 // factor in wielder auras for enchantable weapons
                 DamageBonus *= wielder.EnchantmentManager.GetDamageBonus();
-                VarianceMod *= wielder.EnchantmentManager.GetVarianceMod();
+                //VarianceMod *= wielder.EnchantmentManager.GetVarianceMod();
 
                 //DamageMod += (DamageMod - 1.0f) * (wielder.EnchantmentManager.GetDamageMod() - 1.0f);;
             }

--- a/Source/ACE.Server/Network/Structure/WeaponProfile.cs
+++ b/Source/ACE.Server/Network/Structure/WeaponProfile.cs
@@ -57,6 +57,7 @@ namespace ACE.Server.Network.Structure
             MaxVelocity = weapon.MaximumVelocity ?? 1.0f;
             WeaponOffense = GetWeaponOffense(weapon);
             //MaxVelocityEstimated = (uint)Math.Round(MaxVelocity);   // not found in pcaps?
+            //Console.WriteLine($"{Damage} {DamageVariance} {DamageMod}");
         }
 
         /// <summary>
@@ -97,7 +98,7 @@ namespace ACE.Server.Network.Structure
             var varianceMod = weapon.EnchantmentManager.GetVarianceMod();
             var auraVarianceMod = weapon.Wielder != null ? weapon.Wielder.EnchantmentManager.GetVarianceMod() : 1.0f;
             Enchantment_DamageVariance = weapon.IsEnchantable ? varianceMod * auraVarianceMod : varianceMod;
-            return (float)(baseVariance * Enchantment_DamageVariance);
+            return (float)(baseVariance);
         }
 
         /// <summary>

--- a/Source/ACE.Server/Network/Structure/WeaponProfile.cs
+++ b/Source/ACE.Server/Network/Structure/WeaponProfile.cs
@@ -57,7 +57,6 @@ namespace ACE.Server.Network.Structure
             MaxVelocity = weapon.MaximumVelocity ?? 1.0f;
             WeaponOffense = GetWeaponOffense(weapon);
             //MaxVelocityEstimated = (uint)Math.Round(MaxVelocity);   // not found in pcaps?
-            //Console.WriteLine($"{Damage} {DamageVariance} {DamageMod}");
         }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/Player.cs
+++ b/Source/ACE.Server/WorldObjects/Player.cs
@@ -1015,7 +1015,7 @@ namespace ACE.Server.WorldObjects
             if (GetCreatureSkill(Skill.Jump).AdvancementClass == SkillAdvancementClass.Specialized)
             {
                 var jumpSpell = new Spell(SpellId.JumpSpecialization);
-                CreateEnchantment(this, this, null, jumpSpell);
+                CreateEnchantmentSilent(jumpSpell, this);
             }
         }
 


### PR DESCRIPTION
* Remove spell cast text. (still displays spell expire text)
* Prevent variance buff from occurring.
   * This is a bandaid fix that disables variance buffs altogether. The VarianceMod float id is 22, same as the Jump skill id. Even when using the Skill enchantment flag, instead of the float flag, it still seems to cause both the jump buff and variance buff to occur simultaneously. We don't use variance buffs atm so it is currently not a problem to disable it. Would have to revisit this issue if we ever want to use variance buffs.