### PR TITLE
fix: allow shield skill to manipulate shield AL properly

### DIFF
--- a/Source/ACE.Server/Network/Structure/AppraiseInfo.cs
+++ b/Source/ACE.Server/Network/Structure/AppraiseInfo.cs
@@ -440,7 +440,8 @@ namespace ACE.Server.Network.Structure
                     if (wo.IsShield)
                         armor = (int)wielder.GetSkillModifiedShieldLevel(baseArmor);
                     else
-                        armor = (int)wielder.GetSkillModifiedArmorLevel(baseArmor, (ArmorWeightClass)(wo.ArmorWeightClass ?? 0));
+                        armor = baseArmor;
+
                     if (armor < baseArmor)
                     {
                         PropertiesInt[PropertyInt.ArmorLevel] = armor;

--- a/Source/ACE.Server/WorldObjects/Creature_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Combat.cs
@@ -800,8 +800,8 @@ namespace ACE.Server.WorldObjects
             }
 
             // get base shield AL
-            var baseSL = shield.GetProperty(PropertyInt.ArmorLevel) ?? 0.0f;
-
+            var baseSL = GetSkillModifiedShieldLevel(shield.GetProperty(PropertyInt.ArmorLevel) ?? 0.0f);
+            
             // shield AL item enchantment additives:
             // impenetrability, brittlemail
             var ignoreMagicArmor = (weapon?.IgnoreMagicArmor ?? false) || (attacker?.IgnoreMagicArmor ?? false);

--- a/Source/ACE.Server/WorldObjects/Monster_Melee.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Melee.cs
@@ -508,18 +508,16 @@ namespace ACE.Server.WorldObjects
             {
                 // Shield Level capped at Shield skill amount
                 var shieldSkill = GetCreatureSkill(Skill.Shield);
-                var shieldCap = shieldSkill.Current;
-
-                var currentSkill = GetModdedShieldSkill();
+                var shieldCap = GetModdedShieldSkill();
 
                 // Shield Level cap doubled if Shield skill is specialized
-                if (shieldSkill.AdvancementClass != SkillAdvancementClass.Specialized)
-                    currentSkill = currentSkill * 2;
+                if (shieldSkill.AdvancementClass == SkillAdvancementClass.Specialized)
+                    shieldCap *= 2;
 
                 // If Shield cap is greater than equipped shield level, shield gains +1 shield level per 10 points under cap
-                if (currentSkill > shieldLevel)
-                    shieldLevel += (currentSkill - shieldLevel) / 10;
-
+                if (shieldCap > shieldLevel)
+                    shieldLevel += (shieldCap - shieldLevel) / 10;
+                
                 return Math.Min(shieldLevel, shieldCap);
             }
             else
@@ -576,7 +574,7 @@ namespace ACE.Server.WorldObjects
             Console.WriteLine("Effective RL: " + effectiveRL);
             Console.WriteLine();*/
 
-            return GetSkillModifiedArmorLevel(effectiveAL, (ArmorWeightClass)(armor.ArmorWeightClass ?? 0), effectiveRL);
+            return effectiveAL * effectiveRL;
         }
 
         /// <summary>


### PR DESCRIPTION
- Armor mod bonuses to shield skill correctly increase shield AL.
- Shield skill level is correctly "effectively" doubled when specialized.
- Refactor some shield and armor AL calculations.