### PR TITLE
Update spellcraft

### DIFF
--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -442,7 +442,7 @@ namespace ACE.Server.WorldObjects
                     if (itemCaster == null && targetCreature != null)
                         GenerateSupportSpellThreat(spell, targetCreature);
 
-                    HandleCastSpell_Transfer(spell, targetCreature, fromProc, showMsg);
+                    HandleCastSpell_Transfer(spell, targetCreature, showMsg);
                     break;
 
                 case SpellType.Projectile:
@@ -1043,7 +1043,7 @@ namespace ACE.Server.WorldObjects
         /// Handles casting SpellType.Transfer spells
         /// usually for Life Magic, ie. Stamina to Mana, Drain
         /// </summary>
-        private void HandleCastSpell_Transfer(Spell spell, Creature targetCreature, bool fromProc, bool showMsg = true)
+        private void HandleCastSpell_Transfer(Spell spell, Creature targetCreature, bool showMsg = true)
         {
             var player = this as Player;
             var creature = this as Creature;


### PR DESCRIPTION
- Spellcraft can now only roll on loot that has castable spells (proc spells and wand spells).
- Spellcraft rolls are now equal to the castable spell's difficulty + up to 50% more.
- Self-targeted Life proc spells are now affected by the item's spellcraft and wielder's Life magic skill.
   - Formula = ((spellcraft + life magic) / 2) / spell difficulty. 
   - Maximum penalty is 50% effectiveness.
   - Maximum benefit is 200% effectiveness.