### PR TITLE
feat: update loot quality scaling per tier

### DIFF
--- a/Source/ACE.Server/Managers/PropertyManager.cs
+++ b/Source/ACE.Server/Managers/PropertyManager.cs
@@ -631,7 +631,8 @@ namespace ACE.Server.Managers
                 ("increase_minimum_encounter_spawn_density", new Property<bool>(true, "enable this to increase the density of random encounters that spawn in low density landblocks")),
                 ("command_who_enabled", new Property<bool>(true, "disable this to prevent players from listing online players in their allegiance")),
                 ("debug_threat_system", new Property<bool>(false, "enable this to see threat system console logging")),
-                ("debug_crafting_system", new Property<bool>(false, "enable this to see crafting system console logging"))
+                ("debug_crafting_system", new Property<bool>(false, "enable this to see crafting system console logging")),
+                ("debug_loot_quality_system", new Property<bool>(false, "enable this to see loot quality system console logging"))
                 );
 
         public static readonly ReadOnlyDictionary<string, Property<long>> DefaultLongProperties =


### PR DESCRIPTION
* Increase the potency of a creatures' "in-tier level" effect on loot quality for lower tiers.
   * Creatures towards the end of their respective tiers drop greatly increased loot quality and a chance for an additional item.
   * This effect diminishes in potency at higher tiers.