### PR TITLE
Shroud level scaling rework

### DIFF
--- a/Source/ACE.Server/Entity/DamageEvent.cs
+++ b/Source/ACE.Server/Entity/DamageEvent.cs
@@ -556,7 +556,7 @@ namespace ACE.Server.Entity
             // ---- ARMOR ----
             var armorRendingMod = 1.0f;
             if (Weapon != null && Weapon.HasImbuedEffect(ImbuedEffectType.ArmorRending))
-                armorRendingMod = 1.0f - WorldObject.GetArmorRendingMod(attackSkill);
+                armorRendingMod = 1.0f - WorldObject.GetArmorRendingMod(attackSkill, playerAttacker, defender);
 
             var armorCleavingMod = attacker.GetArmorCleavingMod(Weapon);
 

--- a/Source/ACE.Server/Entity/DamageEvent.cs
+++ b/Source/ACE.Server/Entity/DamageEvent.cs
@@ -604,7 +604,7 @@ namespace ACE.Server.Entity
                 ArmorMod = 1.0f;
 
             // ---- RESISTANCE ----
-            WeaponResistanceMod = WorldObject.GetWeaponResistanceModifier(Weapon, attacker, attackSkill, DamageType);
+            WeaponResistanceMod = WorldObject.GetWeaponResistanceModifier(Weapon, attacker, attackSkill, DamageType, defender);
 
             if (playerDefender != null)
             {

--- a/Source/ACE.Server/Entity/LevelScaling.cs
+++ b/Source/ACE.Server/Entity/LevelScaling.cs
@@ -1,0 +1,293 @@
+using ACE.Entity.Enum;
+using ACE.Server.Managers;
+using ACE.Server.WorldObjects;
+using Serilog;
+using System;
+
+namespace ACE.Server.Entity
+{
+    public static class LevelScaling
+    {
+        /* Level scaling is active when two main conditions are met:
+         *  -A player has a Weakening Curse active from using a Stone of Shrouding.
+         *  -The player is in combat with an enemy that is lower level than them.
+         * 
+         * When level scaling is active, the following adjustments are made to the player and enemy:
+         *  -During player attacks on the enemy:
+         *   -Player damage is scaled down based on monster average max health.
+         *   -Player attack skill is scaled down.
+         *   -Player main attribute is scaled down for attribute mod calculations.
+         *   -Monster armor is scaled up.
+         *   -Monster ward is scaled up.
+         *  -During enemy attacks on the player
+         *   -Monster damage is scaled up based on player average max health.
+         *   -Player defense skill is scaled down.
+         *   -Player armor is scaled down.
+         *   -Player ward is scaled down.
+         *   -Player resistance is scaled down.
+         *  -During player heals on other players:
+         *   -Player heal amount is scaled down based on the target's level.
+         *   
+         *   NOTE: May need an additional modifier to add more difficulty to higher level players if imbues and other crafting are too good.
+         *   Handled previously with this formula: (float gapMod = 1f - (float)(levelGap / 10f) / 12.5f)
+         */
+
+        private static readonly int[] AvgPlayerHealthPerTier = { 45, 95, 125, 155, 185, 215, 245, 320 };
+        private static readonly int[] AvgPlayerArmorWardPerTier = { 50, 100, 130, 160, 190, 220, 250 };
+        private static readonly int[] AvgPlayerAttributePerTier = { 125, 175, 200, 215, 230, 250, 270 };
+        private static readonly int[] AvgPlayerAttackSkillPerTier = { 75, 150, 175, 200, 225, 275, 350, 500 };
+        private static readonly int[] AvgPlayerDefenseSkillPerTier = { 75, 150, 175, 200, 225, 275, 350, 500 };
+        private static readonly float[] AvgPlayerResistancePerTier = { 1.0f, 0.9f, 0.9f, 0.85f, 0.85f, 0.8f, 0.8f, 0.75f, 0.75f };
+        private static readonly int[] AvgPlayerBoostPerTier = {  10, 15, 20, 25, 30, 35, 40, 40};
+
+        private static readonly int[] AvgMonsterArmorWardPerTier = { 20, 45, 68, 101, 152, 228, 342, 513 };
+        private static readonly int[] AvgMonsterHealthPerTier = { 50, 150, 350, 500, 800, 1200, 1600, 2000 };
+
+        public static float GetMonsterDamageDealtHealthScalar(Creature player, Creature monster)
+        {
+            if (!CanScalePlayer(player, monster))
+                return 1.0f;
+
+            var statAtPlayerLevel = GetPlayerHealthAtLevel(player.Level.Value);
+            var statAtMonsterLevel = GetPlayerHealthAtLevel(monster.Level.Value);
+
+            if (PropertyManager.GetBool("debug_level_scaling_system").Item)
+                Console.WriteLine($"\nGetMonsterDamageDealtHealthScalar(Player {player.Name}, Monster {monster.Name})" +
+                    $"\n  statAtPlayerLevel: {statAtPlayerLevel}, statAtMonsterLevel: {statAtMonsterLevel}, scalarMod: {(float)statAtPlayerLevel / statAtMonsterLevel}");
+
+            return (float)statAtPlayerLevel / statAtMonsterLevel;
+        }
+
+        public static float GetMonsterDamageTakenHealthScalar(Creature player, Creature monster)
+        {
+            if (!CanScalePlayer(player, monster))
+                return 1.0f;
+
+            var statAtPlayerLevel = GetMonsterHealthAtLevel(player.Level.Value);
+            var statAtMonsterLevel = GetMonsterHealthAtLevel(monster.Level.Value);
+
+            if (PropertyManager.GetBool("debug_level_scaling_system").Item)
+                Console.WriteLine($"\nGetMonsterDamageTakenHealthScalar(Player {player.Name}, Monster {monster.Name})" +
+                    $"\n  statAtPlayerLevel: {statAtPlayerLevel}, statAtMonsterLevel: {statAtMonsterLevel}, scalarMod: {((float)statAtMonsterLevel / statAtPlayerLevel + 1) / 2}");
+
+            return ((float)statAtMonsterLevel / statAtPlayerLevel + 1) / 2;
+        }
+
+        public static float GetMonsterArmorWardScalar(Creature player, Creature monster)
+        {
+            if (!CanScalePlayer(player, monster))
+                return 1.0f;
+
+            var statAtPlayerLevel = GetMonsterArmorWardAtLevel(player.Level.Value);
+            var statAtMonsterLevel = GetMonsterArmorWardAtLevel(monster.Level.Value);
+
+            if (PropertyManager.GetBool("debug_level_scaling_system").Item)
+                Console.WriteLine($"\nGetMonsterArmorWardScalar(Player {player.Name}, Monster {monster.Name})" +
+                    $"\n  statAtPlayerLevel: {statAtPlayerLevel}, statAtMonsterLevel: {statAtMonsterLevel}, scalarMod: {(float)statAtPlayerLevel / statAtMonsterLevel}");
+
+            return (float)statAtPlayerLevel / statAtMonsterLevel;
+        }
+
+        public static float GetPlayerArmorWardScalar(Creature player, Creature monster)
+        {
+            if (!CanScalePlayer(player, monster))
+                return 1.0f;
+
+            var statAtPlayerLevel = GetPlayerArmorWardAtLevel(player.Level.Value);
+            var statAtMonsterLevel = GetPlayerArmorWardAtLevel(monster.Level.Value);
+
+            if (PropertyManager.GetBool("debug_level_scaling_system").Item)
+                Console.WriteLine($"\nGetPlayerArmorWardScalar(Player {player.Name}, Monster {monster.Name})" +
+                    $"\n  statAtPlayerLevel: {statAtPlayerLevel}, statAtMonsterLevel: {statAtMonsterLevel}, scalarMod: {(float)statAtMonsterLevel / statAtPlayerLevel}");
+
+            return (float)statAtMonsterLevel / statAtPlayerLevel;
+        }
+
+        public static float GetPlayerAttributeScalar(Creature player, Creature monster)
+        {
+            if (!CanScalePlayer(player, monster))
+                return 1.0f;
+
+            var statAtPlayerLevel = GetPlayerAttributeAtLevel(player.Level.Value);
+            var statAtMonsterLevel = GetPlayerAttributeAtLevel(monster.Level.Value);
+
+            if (PropertyManager.GetBool("debug_level_scaling_system").Item)
+                Console.WriteLine($"\nGetPlayerAttributeScalar(Player {player.Name}, Monster {monster.Name})" +
+                    $"\n  statAtPlayerLevel: {statAtPlayerLevel}, statAtMonsterLevel: {statAtMonsterLevel}, scalarMod: {(float)statAtMonsterLevel / statAtPlayerLevel}");
+
+            return (float)statAtMonsterLevel / statAtPlayerLevel;
+        }
+
+        public static float GetPlayerAttackSkillScalar(Creature player, Creature monster)
+        {
+            if (!CanScalePlayer(player, monster))
+                return 1.0f;
+
+            var statAtPlayerLevel = GetPlayerAttackSkillAtLevel(player.Level.Value);
+            var statAtMonsterLevel = GetPlayerAttackSkillAtLevel(monster.Level.Value);
+
+            if (PropertyManager.GetBool("debug_level_scaling_system").Item)
+                Console.WriteLine($"\nGetPlayerAttackSkillScalar(Player {player.Name}, Monster {monster.Name})" +
+                    $"\n  statAtPlayerLevel: {statAtPlayerLevel}, statAtMonsterLevel: {statAtMonsterLevel}, scalarMod: {(float)statAtMonsterLevel / statAtPlayerLevel}");
+
+            return (float)statAtMonsterLevel / statAtPlayerLevel;
+        }
+
+        public static float GetPlayerDefenseSkillScalar(Creature player, Creature monster)
+        {
+            if (!CanScalePlayer(player, monster))
+                return 1.0f;
+
+            var statAtPlayerLevel = GetPlayerDefenseSkillAtLevel(player.Level.Value);
+            var statAtMonsterLevel = GetPlayerDefenseSkillAtLevel(monster.Level.Value);
+
+            if (PropertyManager.GetBool("debug_level_scaling_system").Item)
+                Console.WriteLine($"\nGetPlayerDefenseSkillScalar(Player {player.Name}, Monster {monster.Name})" +
+                    $"\n  statAtPlayerLevel: {statAtPlayerLevel}, statAtMonsterLevel: {statAtMonsterLevel}, scalarMod: {(float)statAtMonsterLevel / statAtPlayerLevel}");
+
+            return (float)statAtMonsterLevel / statAtPlayerLevel;
+        }
+
+        public static float GetPlayerResistanceScalar(Creature player, Creature monster)
+        {
+            if (!CanScalePlayer(player, monster))
+                return 1.0f;
+
+            var statAtPlayerLevel = GetPlayerResistanceAtLevel(player.Level.Value);
+            var statAtMonsterLevel = GetPlayerResistanceAtLevel(monster.Level.Value);
+
+            if (PropertyManager.GetBool("debug_level_scaling_system").Item)
+                Console.WriteLine($"\nGetPlayerResistanceScalar(Player {player.Name}, Monster {monster.Name})" +
+                    $"\n  statAtPlayerLevel: {statAtPlayerLevel}, statAtMonsterLevel: {statAtMonsterLevel}, scalarMod: {(float)statAtMonsterLevel / statAtPlayerLevel}");
+
+            return (float)statAtMonsterLevel / statAtPlayerLevel;
+        }
+
+        public static float GetPlayerBoostSpellScalar(Creature player, Creature monster)
+        {
+            if (!CanScalePlayer(player, monster))
+                return 1.0f;
+
+            var statAtPlayerLevel = GetPlayerBoostAtLevel(player.Level.Value);
+            var statAtMonsterLevel = GetPlayerBoostAtLevel(monster.Level.Value);
+
+            if (PropertyManager.GetBool("debug_level_scaling_system").Item)
+                Console.WriteLine($"\nGetPlayerBoostSpellScalar(Player {player.Name}, Monster {monster.Name})" +
+                    $"\n  statAtPlayerLevel: {statAtPlayerLevel}, statAtMonsterLevel: {statAtMonsterLevel}, scalarMod: {(float)statAtPlayerLevel / statAtMonsterLevel}");
+
+            return (float)statAtMonsterLevel / statAtPlayerLevel;
+        }
+
+        // --- Private Get At-Level Helpers ---
+        private static int GetPlayerHealthAtLevel(int level)
+        {
+            GetRangeAndStatWeight(level, out var range, out var statweight);
+
+            var stat = (AvgPlayerHealthPerTier[range + 1] - AvgPlayerHealthPerTier[range]) * statweight + AvgPlayerHealthPerTier[range];
+
+            return (int)stat;
+        }
+
+        private static int GetPlayerArmorWardAtLevel(int level)
+        {
+            GetRangeAndStatWeight(level, out var range, out var statweight);
+
+            var stat = (AvgPlayerArmorWardPerTier[range + 1] - AvgPlayerArmorWardPerTier[range]) * statweight + AvgPlayerArmorWardPerTier[range];
+
+            return (int)stat;
+        }
+
+        private static int GetPlayerAttributeAtLevel(int level)
+        {
+            GetRangeAndStatWeight(level, out var range, out var statweight);
+
+            var stat = (AvgPlayerAttributePerTier[range + 1] - AvgPlayerAttributePerTier[range]) * statweight + AvgPlayerAttributePerTier[range];
+
+            return (int)stat;
+        }
+
+        private static int GetPlayerAttackSkillAtLevel(int level)
+        {
+            GetRangeAndStatWeight(level, out var range, out var statweight);
+
+            var stat = (AvgPlayerAttackSkillPerTier[range + 1] - AvgPlayerAttackSkillPerTier[range]) * statweight + AvgPlayerAttackSkillPerTier[range];
+
+            return (int)stat;
+        }
+
+        private static int GetPlayerDefenseSkillAtLevel(int level)
+        {
+            GetRangeAndStatWeight(level, out var range, out var statweight);
+
+            var stat = (AvgPlayerDefenseSkillPerTier[range + 1] - AvgPlayerDefenseSkillPerTier[range]) * statweight + AvgPlayerDefenseSkillPerTier[range];
+
+            return (int)stat;
+        }
+
+        private static float GetPlayerResistanceAtLevel(int level)
+        {
+            GetRangeAndStatWeight(level, out var range, out var statweight);
+
+            var stat = (AvgPlayerResistancePerTier[range + 1] - AvgPlayerResistancePerTier[range]) * statweight + AvgPlayerResistancePerTier[range];
+
+            return stat;
+        }
+
+        private static int GetPlayerBoostAtLevel(int level)
+        {
+            GetRangeAndStatWeight(level, out var range, out var statweight);
+
+            var stat = (AvgPlayerBoostPerTier[range + 1] - AvgPlayerBoostPerTier[range]) * statweight + AvgPlayerBoostPerTier[range];
+
+            return (int)stat;
+        }
+
+        private static int GetMonsterHealthAtLevel(int level)
+        {
+            GetRangeAndStatWeight(level, out var range, out var statweight);
+
+            var stat = (AvgMonsterHealthPerTier[range + 1] - AvgMonsterHealthPerTier[range]) * statweight + AvgMonsterHealthPerTier[range];
+
+            return (int)stat;
+        }
+
+        private static int GetMonsterArmorWardAtLevel(int level)
+        {
+            GetRangeAndStatWeight(level, out var range, out var statweight);
+
+            var stat = (AvgMonsterArmorWardPerTier[range + 1] - AvgMonsterArmorWardPerTier[range]) * statweight + AvgMonsterArmorWardPerTier[range];
+
+            return (int)stat;
+        }
+
+        private static void GetRangeAndStatWeight(int level, out int range, out float statweight)
+        {
+            switch (level)
+            {
+                case < 20: range = 0; statweight = (level - 10.0f) / 10; break;
+                case < 30: range = 1; statweight = (level - 20.0f) / 10; break;
+                case < 40: range = 2; statweight = (level - 30.0f) / 10; break;
+                case < 50: range = 3; statweight = (level - 40.0f) / 10; break;
+                case < 75: range = 4; statweight = (level - 50.0f) / 25; break;
+                case < 100: range = 5; statweight = (level - 75.0f) / 25; break;
+                default: range = 6; statweight = (level - 100.0f) / 26; break;
+            }
+
+            statweight = Math.Min(statweight, 1.0f);
+        }
+
+        private static bool CanScalePlayer(Creature player, Creature monster)
+        {
+            if (player == null || monster == null)
+                return false;
+
+            if (!player.EnchantmentManager.HasSpell((uint)SpellId.CurseWeakness1))
+                return false;
+
+            if (player.Level.HasValue && monster.Level.HasValue && player.Level <= monster.Level)
+                return false;
+
+            return true;
+        }
+    }
+}

--- a/Source/ACE.Server/Managers/PropertyManager.cs
+++ b/Source/ACE.Server/Managers/PropertyManager.cs
@@ -632,7 +632,8 @@ namespace ACE.Server.Managers
                 ("command_who_enabled", new Property<bool>(true, "disable this to prevent players from listing online players in their allegiance")),
                 ("debug_threat_system", new Property<bool>(false, "enable this to see threat system console logging")),
                 ("debug_crafting_system", new Property<bool>(false, "enable this to see crafting system console logging")),
-                ("debug_loot_quality_system", new Property<bool>(false, "enable this to see loot quality system console logging"))
+                ("debug_loot_quality_system", new Property<bool>(false, "enable this to see loot quality system console logging")),
+                ("debug_level_scaling_system", new Property<bool>(false, "enable this to see level scaling system console logging"))
                 );
 
         public static readonly ReadOnlyDictionary<string, Property<long>> DefaultLongProperties =

--- a/Source/ACE.Server/WorldObjects/Creature.cs
+++ b/Source/ACE.Server/WorldObjects/Creature.cs
@@ -50,6 +50,9 @@ namespace ACE.Server.WorldObjects
         /// </summary>
         public Dictionary<uint, int> ammoHitWith;
 
+        public Creature LastAttackedCreature;
+        public double LastAttackedCreatureTime;
+
         /// <summary>
         /// A decaying count of attacks this creature has received recently.
         /// </summary>

--- a/Source/ACE.Server/WorldObjects/Creature_BodyPart.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_BodyPart.cs
@@ -30,6 +30,8 @@ namespace ACE.Server.WorldObjects
         {
             var effectiveArmorVsType = GetEffectiveArmorVsType(damageType, armorLayers, attacker, weapon, armorRendingMod);
 
+            effectiveArmorVsType = effectiveArmorVsType * LevelScaling.GetMonsterArmorWardScalar(attacker, Creature);
+
             return SkillFormula.CalcArmorMod(effectiveArmorVsType);
         }
 

--- a/Source/ACE.Server/WorldObjects/Creature_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Combat.cs
@@ -590,10 +590,10 @@ namespace ACE.Server.WorldObjects
         /// Returns the animation speed for an attack,
         /// based on the current quickness and weapon speed
         /// </summary>
-        public float GetAnimSpeed()
+        public float GetAnimSpeed(Creature target = null)
         {
             var animSpeed = 1.0f;
-            var quickness = (float)Quickness.Current;
+            var quickness = Quickness.Current * LevelScaling.GetPlayerAttributeScalar(this, target);
             var weaponSpeed = (float)GetWeaponSpeed(this);
 
             var minAttackSpeed = 0.8f;

--- a/Source/ACE.Server/WorldObjects/Creature_Death.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Death.cs
@@ -888,12 +888,9 @@ namespace ACE.Server.WorldObjects
                                 }
                             }
                         }
-
                     }
-
                 }
             }
-
         }
 
         /// <summary>

--- a/Source/ACE.Server/WorldObjects/Creature_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Properties.cs
@@ -1,5 +1,6 @@
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
+using ACE.Server.Entity;
 using ACE.Server.Managers;
 using ACE.Server.Network.GameMessages.Messages;
 using System;
@@ -128,6 +129,8 @@ namespace ACE.Server.WorldObjects
                     var augFactor = Math.Min(1.0f, resistAug * 0.1f);
                     protMod *= 1.0f - augFactor;
                 }
+
+                protMod = protMod * LevelScaling.GetPlayerResistanceScalar(player, attacker as Creature);
             }
 
             // vulnerability mod becomes either life vuln or weapon resistance mod,

--- a/Source/ACE.Server/WorldObjects/Monster_Melee.cs
+++ b/Source/ACE.Server/WorldObjects/Monster_Melee.cs
@@ -460,6 +460,8 @@ namespace ACE.Server.WorldObjects
             //Console.WriteLine("Armor Self: " + bodyArmorMod);
             effectiveAL += bodyArmorMod;
 
+            effectiveAL = effectiveAL * LevelScaling.GetPlayerArmorWardScalar(defender, this);
+
             // Armor Rending reduces physical armor too?
             if (effectiveAL > 0)
                 effectiveAL *= armorRendingMod;

--- a/Source/ACE.Server/WorldObjects/Player_Combat.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Combat.cs
@@ -38,8 +38,6 @@ namespace ACE.Server.WorldObjects
 
         public DateTime NextRefillTime;
 
-        public Creature LastAttackedCreature;
-        public double LastAttackedCreatureTime;
         public double LastPkAttackTimestamp
         {
             get => GetProperty(PropertyFloat.LastPkAttackTimestamp) ?? 0;

--- a/Source/ACE.Server/WorldObjects/Player_Melee.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Melee.cs
@@ -452,7 +452,7 @@ namespace ACE.Server.WorldObjects
         {
             // get the proper animation speed for this attack,
             // based on weapon speed and player quickness
-            var baseSpeed = GetAnimSpeed();
+            var baseSpeed = GetAnimSpeed(target as Creature);
 
             var isDualWieldSpec = GetCreatureSkill(Skill.DualWield).AdvancementClass == SkillAdvancementClass.Specialized;
             var animSpeedMod = (IsDualWieldAttack && isDualWieldSpec) ? 1.25f : 1.0f; // Dual Wield Spec Bonus: +25% faster dual-wield swing animation

--- a/Source/ACE.Server/WorldObjects/Player_Missile.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Missile.cs
@@ -319,7 +319,7 @@ namespace ACE.Server.WorldObjects
             }
 
             // reload animation
-            var animSpeed = GetAnimSpeed();
+            var animSpeed = GetAnimSpeed(target as Creature);
             var reloadTime = EnqueueMotionPersist(actionChain, stance, MotionCommand.Reload, animSpeed);
 
             // reset for next projectile

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -699,8 +699,8 @@ namespace ACE.Server.WorldObjects
             var specDefenseMod = 1.0f;
             if (targetPlayer != null && targetPlayer.GetCreatureSkill(Skill.MagicDefense).AdvancementClass == SkillAdvancementClass.Specialized)
             {
-                var magicDefenseSkill = targetPlayer.GetCreatureSkill(Skill.MagicDefense);
-                var bonusAmount = (float)Math.Min(magicDefenseSkill.Current, 500) / 50;
+                var magicDefenseSkill = targetPlayer.GetModdedMagicDefSkill() * LevelScaling.GetPlayerDefenseSkillScalar(targetPlayer, sourceCreature);
+                var bonusAmount = (float)Math.Min(magicDefenseSkill, 500) / 50;
 
                 specDefenseMod = 0.9f - bonusAmount * 0.01f;
             }

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -332,17 +332,6 @@ namespace ACE.Server.WorldObjects
 
             if (damage != null)
             {
-                // LEVEL SCALING - If player has Scaling Spell, check to ensure their level is greater than the monster in question, then scale their damage done/damage taken if so
-                float levelScalingMod = 1f;
-
-                if (player != null && player.EnchantmentManager.HasSpell(5379) && player.Level.HasValue && creatureTarget.Level.HasValue && player.Level > creatureTarget.Level)
-                    levelScalingMod = Creature.GetPlayerDamageScaler((int)player.Level, (int)creatureTarget.Level);
-
-                if (targetPlayer != null && targetPlayer.EnchantmentManager.HasSpell(5379) && targetPlayer.Level.HasValue && sourceCreature.Level.HasValue && targetPlayer.Level > sourceCreature.Level)
-                    levelScalingMod = Creature.GetMonsterDamageScaler((int)targetPlayer.Level, (int)sourceCreature.Level);
-
-                damage *= levelScalingMod;
-
                 if (Spell.MetaSpellType == ACE.Entity.Enum.SpellType.EnchantmentProjectile)
                 {
                     // handle EnchantmentProjectile successfully landing on target
@@ -548,7 +537,7 @@ namespace ACE.Server.WorldObjects
                     var perception = targetPlayer.GetCreatureSkill(Skill.AssessCreature);
                     if (perception.AdvancementClass == SkillAdvancementClass.Specialized)
                     {
-                        var skillCheck = (float)perception.Current / (float)attackSkill.Current;
+                        var skillCheck = (float)targetPlayer.GetModdedPerceptionSkill() / (float)attackSkill.Current;
                         var criticalDefenseChance = skillCheck > 1f ? 0.5f : skillCheck * 0.5f;
 
                         if (criticalDefenseChance > ThreadSafeRandom.Next(0f, 1f))
@@ -617,7 +606,7 @@ namespace ACE.Server.WorldObjects
                 if (weapon.WeaponSkill == Skill.WarMagic && sourcePlayer.GetCreatureSkill(Skill.WarMagic).AdvancementClass == SkillAdvancementClass.Specialized && LootGenerationFactory.GetCasterSubType(weapon) == 0)
                     ignoreWardMod -= 0.1f;
 
-            var wardMod = GetWardMod(target, ignoreWardMod);
+            var wardMod = GetWardMod(target, sourceCreature, ignoreWardMod);
 
             //Console.WriteLine($"TargetWard: {target.WardLevel} WardRend: {wardRendingMod} Nullification: {NullificationMod} WardMod: {wardMod}");
 
@@ -648,7 +637,7 @@ namespace ACE.Server.WorldObjects
 
             var attributeMod = 1f;
             if (sourcePlayer != null)
-                attributeMod = sourcePlayer.GetAttributeMod(weapon, true);
+                attributeMod = sourcePlayer.GetAttributeMod(weapon, true, target);
 
             var elementalDamageMod = GetCasterElementalDamageModifier(weapon, sourceCreature, target, Spell.DamageType);
 
@@ -936,10 +925,9 @@ namespace ACE.Server.WorldObjects
             return 1.0f;
         }
 
-        public float GetWardMod(Creature target, float ignoreWardMod)
+        public float GetWardMod(Creature caster, Creature target, float ignoreWardMod)
         {
-            var wardLevel = target.GetWardLevel();
-            //var wardLevel = target.Level * 5;
+            var wardLevel = target.GetWardLevel() * LevelScaling.GetPlayerArmorWardScalar(target, caster);
 
             return SkillFormula.CalcWardMod(wardLevel * ignoreWardMod);
         }

--- a/Source/ACE.Server/WorldObjects/SpellProjectile.cs
+++ b/Source/ACE.Server/WorldObjects/SpellProjectile.cs
@@ -724,7 +724,7 @@ namespace ACE.Server.WorldObjects
                         criticalDamageMod -= 0.2f;
                 }
 
-                weaponResistanceMod = GetWeaponResistanceModifier(weapon, sourceCreature, attackSkill, Spell.DamageType);
+                weaponResistanceMod = GetWeaponResistanceModifier(weapon, sourceCreature, attackSkill, Spell.DamageType, target);
 
                 // if attacker/weapon has IgnoreMagicResist directly, do not transfer to spell projectile
                 // only pass if SpellProjectile has it directly, such as 2637 - Invoking Aun Tanua
@@ -778,7 +778,7 @@ namespace ACE.Server.WorldObjects
 
                 baseDamage = ThreadSafeRandom.Next(Spell.MinDamage, Spell.MaxDamage);
 
-                weaponResistanceMod = GetWeaponResistanceModifier(weapon, sourceCreature, attackSkill, Spell.DamageType);
+                weaponResistanceMod = GetWeaponResistanceModifier(weapon, sourceCreature, attackSkill, Spell.DamageType, target);
 
                 // if attacker/weapon has IgnoreMagicResist directly, do not transfer to spell projectile
                 // only pass if SpellProjectile has it directly, such as 2637 - Invoking Aun Tanua

--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -184,7 +184,7 @@ namespace ACE.Server.WorldObjects
                 // Retrieve caster's secondary attribute mod (1% per 20 attributes)
                 var secondaryAttributeMod = casterCreature.Focus.Current * 0.0005 + 1;
                 
-                magicSkill = (uint)(magicSkill * secondaryAttributeMod);
+                magicSkill = (uint)(magicSkill * secondaryAttributeMod * LevelScaling.GetPlayerAttackSkillScalar(casterCreature, target as Creature));
 
             }
             else if (caster.ItemSpellcraft != null)

--- a/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Magic.cs
@@ -231,7 +231,7 @@ namespace ACE.Server.WorldObjects
                 return false;
 
             // Retrieve target's Magic Defense Skill
-            var difficulty = targetCreature.GetModdedMagicDefSkill();
+            var difficulty = (uint)(targetCreature.GetModdedMagicDefSkill() * LevelScaling.GetPlayerDefenseSkillScalar(casterCreature, targetCreature));
 
             //Console.WriteLine($"{targetCreature.Name} was hit by a spell:\n" +
             //    $" -BaseMagicDef: {targetCreature.GetEffectiveMagicDefense()} -ArmorMod: {armorMagicDefMod} -FinalMagicDef: {difficulty}");
@@ -267,16 +267,6 @@ namespace ACE.Server.WorldObjects
                         resistChanceMod += familiarityPenalty;
                     }
                 }
-
-            }
-            // LEVEL SCALING - If player is scaled, we increase resist chance when they're casting, and reduce when they're target
-            if (player != null && player.EnchantmentManager.HasSpell(5379) && player.Level.HasValue && targetCreature.Level.HasValue && player.Level > targetCreature.Level)
-                resistChanceMod += 0.15f;
-
-            if (targetPlayer != null && targetPlayer.EnchantmentManager.HasSpell(5379) && targetPlayer.Level.HasValue && casterCreature != null && casterCreature.Level.HasValue && targetPlayer.Level > casterCreature.Level)
-            {
-                resistChanceMod -= 0.15f;
-                if (resistChanceMod < 0) resistChanceMod = 0;
             }
             //Console.WriteLine($"{target.Name}.ResistSpell({Name}, {spell.Name}): magicSkill: {magicSkill}, difficulty: {difficulty}");
 
@@ -561,12 +551,16 @@ namespace ACE.Server.WorldObjects
                 //Console.WriteLine("enchantment target player: " + target.Name);
                 Player targetPlayer = target as Player;
 
-                if (addResult.Enchantment.StatModValue < 0 && targetPlayer.GetWardLevel() > 0)
+                var targetPlayerWard = targetPlayer.GetWardLevel();
+
+                if (addResult.Enchantment.StatModValue < 0 && targetPlayerWard > 0)
                 {
                     //Console.WriteLine($"StatModValue Before: {addResult.Enchantment.StatModType} {addResult.Enchantment.StatModValue}\n" +
                     //    $" -Target Ward Level: {targetPlayer.GetWardLevel()}");
 
-                    var wardMod = WorldObjects.SkillFormula.CalcWardMod((float)targetPlayer.GetWardLevel() / 10);
+                    targetPlayerWard = (int)(targetPlayerWard * LevelScaling.GetPlayerArmorWardScalar(player, caster as Creature));
+
+                    var wardMod = WorldObjects.SkillFormula.CalcWardMod((float)targetPlayerWard / 10);
                     
                     addResult.Enchantment.StatModValue *= wardMod;
                     addResult.Enchantment.Duration *= wardMod;
@@ -837,18 +831,10 @@ namespace ACE.Server.WorldObjects
             }
 
             // LEVEL SCALING - Reduces harms against enemies, and restoration for players
-            if (player != null && player.EnchantmentManager.HasSpell(5379) && player.Level.HasValue && targetCreature.Level.HasValue && player.Level > targetCreature.Level)
-            {
-                var scaler = Creature.GetPlayerDamageScaler((int)player.Level, (int)targetCreature.Level);
-                tryBoost = (int)(tryBoost * scaler);
-            }
-            if (targetCreature is Player && targetCreature.EnchantmentManager.HasSpell(5379) && targetCreature.Level.HasValue && this.Level.HasValue && targetCreature.Level > this.Level)
-            {
-                var scaler = Creature.GetMonsterDamageScaler((int)targetCreature.Level, (int)this.Level);
-                tryBoost = (int)(tryBoost * scaler);
-            }
+            var scalar = LevelScaling.GetPlayerBoostSpellScalar(player, targetCreature);
+            tryBoost = (int)(tryBoost * scalar);
 
-                switch (spell.VitalDamageType)
+            switch (spell.VitalDamageType)
             {
                 case DamageType.Mana:
                     boost = targetCreature.UpdateVitalDelta(targetCreature.Mana, tryBoost);
@@ -1230,19 +1216,12 @@ namespace ACE.Server.WorldObjects
             // LEVEL SCALING - Reduce Drain effectiveness vs. monsters, and increase vs. player
             if (spell.TransferFlags.HasFlag(TransferFlags.TargetSource | TransferFlags.CasterDestination))
             {
-                float levelScalingMod = 1f;
-
-                if (player != null && player.EnchantmentManager.HasSpell(5379) && player.Level.HasValue && targetCreature.Level.HasValue && player.Level > targetCreature.Level)
-                    levelScalingMod = Creature.GetPlayerDamageScaler((int)player.Level, (int)targetCreature.Level);
-
-                if (targetPlayer != null && targetPlayer.EnchantmentManager.HasSpell(5379) && targetPlayer.Level.HasValue && creature != null && creature.Level.HasValue && targetPlayer.Level > creature.Level)
-                    levelScalingMod = Creature.GetMonsterDamageScaler((int)targetPlayer.Level, (int)creature.Level);
+                float levelScalingMod = LevelScaling.GetPlayerBoostSpellScalar(player, targetCreature);
 
                 srcVitalChange  = (uint)(srcVitalChange * levelScalingMod);
                 destVitalChange = (uint)(destVitalChange * levelScalingMod);  
 
             }
-
 
             // Apply the change in vitals to the source
             switch (spell.Source)

--- a/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Weapon.cs
@@ -279,7 +279,7 @@ namespace ACE.Server.WorldObjects
 
             if (weapon != null && weapon.HasImbuedEffect(ImbuedEffectType.CriticalStrike))
             {
-                var criticalStrikeBonus = DefaultPhysicalCritFrequency + GetCriticalStrikeMod(skill);
+                var criticalStrikeBonus = DefaultPhysicalCritFrequency + GetCriticalStrikeMod(skill, wielder, target);
 
                 critRate = Math.Max(critRate, criticalStrikeBonus);
             }
@@ -319,7 +319,7 @@ namespace ACE.Server.WorldObjects
             {
                 var isPvP = wielder is Player && target is Player;
 
-                var criticalStrikeMod = DefaultMagicCritFrequency + GetCriticalStrikeMod(skill, isPvP);
+                var criticalStrikeMod = DefaultMagicCritFrequency + GetCriticalStrikeMod(skill, wielder, target, isPvP);
 
                 critRate = Math.Max(critRate, criticalStrikeMod);
             }
@@ -349,7 +349,7 @@ namespace ACE.Server.WorldObjects
 
             if (weapon != null && weapon.HasImbuedEffect(ImbuedEffectType.CripplingBlow))
             {
-                var cripplingBlowMod = DefaultCritDamageMultiplier + GetCripplingBlowMod(skill);
+                var cripplingBlowMod = DefaultCritDamageMultiplier + GetCripplingBlowMod(skill, wielder, target);
 
                 critDamageMod = Math.Max(critDamageMod, cripplingBlowMod); 
             }
@@ -464,7 +464,7 @@ namespace ACE.Server.WorldObjects
         /// <summary>
         /// Returns the resistance modifier or rending modifier
         /// </summary>
-        public static float GetWeaponResistanceModifier(WorldObject weapon, Creature wielder, CreatureSkill skill, DamageType damageType)
+        public static float GetWeaponResistanceModifier(WorldObject weapon, Creature wielder, CreatureSkill skill, DamageType damageType, Creature target)
         {
             float resistMod = DefaultModifier;
 
@@ -483,7 +483,7 @@ namespace ACE.Server.WorldObjects
 
             if (rendDamageType != ImbuedEffectType.Undef && weapon.HasImbuedEffect(rendDamageType) && skill != null)
             {
-                var rendingMod = DefaultModifier + GetRendingMod(skill);
+                var rendingMod = DefaultModifier + GetRendingMod(skill, wielder, target);
 
                 resistMod = Math.Max(resistMod, rendingMod);
             }
@@ -563,12 +563,12 @@ namespace ACE.Server.WorldObjects
         private static float MinCriticalStrikeMod = 0.05f;
         private static float MaxCriticalStrikeMod = 0.1f;
 
-        public static float GetCriticalStrikeMod(CreatureSkill skill, bool isPvP = false)
+        public static float GetCriticalStrikeMod(CreatureSkill skill, Creature wielder, Creature target, bool isPvP = false)
         {
             var baseMod = MinCriticalStrikeMod;
 
             var skillType = GetImbuedSkillType(skill);
-            var baseSkill = GetBaseSkillImbued(skill);
+            var baseSkill = GetBaseSkillImbued(skill) * LevelScaling.GetPlayerAttackSkillScalar(wielder, target);
 
             switch (skillType)
             {
@@ -594,10 +594,10 @@ namespace ACE.Server.WorldObjects
         private static float MinCripplingBlowMod = 0.5f;
         private static float MaxCripplingBlowMod = 1.0f;
 
-        public static float GetCripplingBlowMod(CreatureSkill skill)
+        public static float GetCripplingBlowMod(CreatureSkill skill, Creature wielder, Creature target)
         {
             var skillType = GetImbuedSkillType(skill);
-            var baseSkill = GetBaseSkillImbued(skill);
+            var baseSkill = GetBaseSkillImbued(skill) * LevelScaling.GetPlayerAttackSkillScalar(wielder, target);
 
             var baseMod = MinCripplingBlowMod;
 
@@ -625,10 +625,10 @@ namespace ACE.Server.WorldObjects
         private static float MinRendingMod = 0.15f;
         private static float MaxRendingMod = 0.30f;
 
-        public static float GetRendingMod(CreatureSkill skill)
+        public static float GetRendingMod(CreatureSkill skill, Creature wielder, Creature target)
         {
             var skillType = GetImbuedSkillType(skill);
-            var baseSkill = GetBaseSkillImbued(skill);
+            var baseSkill = GetBaseSkillImbued(skill) * LevelScaling.GetPlayerAttackSkillScalar(wielder, target);
 
             var rendingMod = MinRendingMod;
 
@@ -656,10 +656,10 @@ namespace ACE.Server.WorldObjects
         public static float MinArmorRendingMod = 0.2f;
         public static float MaxArmorRendingMod = 0.4f;
 
-        public static float GetArmorRendingMod(CreatureSkill skill)
+        public static float GetArmorRendingMod(CreatureSkill skill, Creature wielder, Creature target)
         {
             var skillType = GetImbuedSkillType(skill);
-            var baseSkill = GetBaseSkillImbued(skill);
+            var baseSkill = GetBaseSkillImbued(skill) * LevelScaling.GetPlayerAttackSkillScalar(wielder, target);
 
             var armorRendingMod = MinArmorRendingMod;
 


### PR DESCRIPTION
Rework shroud level scaling.
* Refactored into a new class to minimize code in other classes.
* Accurately calculates various stats for scaling, for any character up to level 125 to scale down to any level (min level 10).
   * Health, attack skill, defense skill, attributes, armor, ward, resistance, and life spells.
* Utilizes attribute scaling to scale attack speed and attribute mod for players.
* Utilizes attack skill scaling to scale hit/resist chance and imbue effectiveness for players.
* Utilizes defense skill scaling to scale evade chance and defense skill spec bonus effects for players.
* Utilizes health, armor, ward, and resistance scaling to decrease damage dealt to monsters and increase damage dealt to players.
* Utilizes life spell boost scaling to scale harm, drain, and restoration spells for players.

Note: Currently does not use an additional modifier to make up for the crafting benefits of higher levels. Will need to test and reassess to understand how much of a modifier might be needed. The previous formula for this was: `float gapMod = 1f - (float)(levelGap / 10f) / 12.5f`