### PR TITLE
feat: make menhir hotspot easier to identify

### DIFF
--- a/Source/ACE.Entity/Enum/Properties/PropertyBool.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyBool.cs
@@ -189,6 +189,7 @@ namespace ACE.Entity.Enum.Properties
         CampfireHotspot                  = 146,
         MutableQuestItem                 = 147,
         StruckByUnshrouded               = 148,
+        MenhirManaHotspot                = 149,
 
         /* custom */
         [ServerOnly]

--- a/Source/ACE.Server/WorldObjects/EmpoweredScarab.cs
+++ b/Source/ACE.Server/WorldObjects/EmpoweredScarab.cs
@@ -319,7 +319,7 @@ namespace ACE.Server.WorldObjects
                 if (isWielded)
                 {
                     player.Session.Network.EnqueueSend(new GameMessageSystemChat($"Your mana scarab gains a charge!", ChatMessageType.Magic));
-                    player.EnqueueBroadcast(new GameMessageScript(player.Guid, PlayScript.PortalStorm));
+                    player.EnqueueBroadcast(new GameMessageScript(player.Guid, PlayScript.RestrictionEffectBlue));
                 }
             }
             else
@@ -327,7 +327,7 @@ namespace ACE.Server.WorldObjects
                 if (isWielded)
                 {
                     player.Session.Network.EnqueueSend(new GameMessageSystemChat($"Your mana scarab gains a charge, it is now fully charged!", ChatMessageType.Magic));
-                    player.EnqueueBroadcast(new GameMessageScript(player.Guid, PlayScript.HealthUpBlue));
+                    player.EnqueueBroadcast(new GameMessageScript(player.Guid, PlayScript.PortalStorm));
                 }
             }
         }

--- a/Source/ACE.Server/WorldObjects/Hotspot.cs
+++ b/Source/ACE.Server/WorldObjects/Hotspot.cs
@@ -201,7 +201,7 @@ namespace ACE.Server.WorldObjects
                 creature.HotspotImmunityTimestamp = currentTime + immunityTime;
             }
             
-            if (player != null)
+            if (player != null && MenhirManaHotspot == true)
                 player.RechargeEmpoweredScarabs(this);
             
             if (player != null && CampfireHotspot == true)

--- a/Source/ACE.Server/WorldObjects/WorldObject.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject.cs
@@ -1208,6 +1208,12 @@ namespace ACE.Server.WorldObjects
             set { if (!value.HasValue) RemoveProperty(PropertyBool.CampfireHotspot); else SetProperty(PropertyBool.CampfireHotspot, value.Value); }
         }
 
+        public bool? MenhirManaHotspot
+        {
+            get => GetProperty(PropertyBool.MenhirManaHotspot);
+            set { if (!value.HasValue) RemoveProperty(PropertyBool.MenhirManaHotspot); else SetProperty(PropertyBool.MenhirManaHotspot, value.Value); }
+        }
+
         public bool? MutableQuestItem
         {
             get => GetProperty(PropertyBool.MutableQuestItem);


### PR DESCRIPTION
- If player has carrying an empowered scarab and standing on the hotspot, a particle effect will flash every 3 seconds.
- While empowered scarab recharge is occurring, the flashing will occur more frequently.