### PR TITLE
fix: prevent spells from avoiding collision

### DIFF
--- a/Source/ACE.Server/Physics/PhysicsObj.cs
+++ b/Source/ACE.Server/Physics/PhysicsObj.cs
@@ -394,8 +394,9 @@ namespace ACE.Server.Physics
                     return TransitionState.OK;
                 ethereal = true;
             }
+
             // CUSTOM - Strikethrough: permits strikethrough projectiles to travel cleanly through monsters, even if they're not ethereal
-            if (WeenieObj.WorldObject != null && WeenieObj.WorldObject.Attackable == true)
+            if (WeenieObj.WorldObject != null && WeenieObj.WorldObject.ItemType == ItemType.Creature)
             {
                 if (transition.ObjectInfo.Object.WeenieObj.WorldObject != null && transition.ObjectInfo.Object.WeenieObj.WorldObject is SpellProjectile)
                     ethereal = true;


### PR DESCRIPTION
Spell projectiles now correctly collide with game objects like doors. Only creature item types can be passed through.