### PR TITLE
feat: spell stacking system (difficulty pushing)

### DIFF
--- a/Source/ACE.Entity/Enum/EmoteType.cs
+++ b/Source/ACE.Entity/Enum/EmoteType.cs
@@ -147,5 +147,6 @@ namespace ACE.Entity.Enum
         CapstoneCacheReward           = 10009,
         AssignCapstoneDungeon         = 10010,
         AwardNoContribSkillXP         = 10011,
+        BroadcastSpellStacks          = 10012,
     }
 }

--- a/Source/ACE.Entity/Enum/Properties/PropertyInt.cs
+++ b/Source/ACE.Entity/Enum/Properties/PropertyInt.cs
@@ -650,6 +650,7 @@ namespace ACE.Entity.Enum.Properties
         CombatFocusAttributeSpellAdded          = 458,
         CombatFocusSkillSpellRemoved            = 459,
         CombatFocusSkillSpellAdded              = 460,
+        StackableSpellType                      = 461,
 
 
         [ServerOnly]

--- a/Source/ACE.Entity/Enum/SpellCategory.cs
+++ b/Source/ACE.Entity/Enum/SpellCategory.cs
@@ -748,5 +748,10 @@ namespace ACE.Entity.Enum
         WardRaising = 751,
         WardLowering = 752,
         CampfireRested = 753,
+        OlthoiStaminaPenalty = 754,
+        OlthoiManaPenalty = 755,
+        OlthoiHealthPenalty = 756,
+        OlthoiPhysicalDefensePenalty = 757,
+        OlthoiAcidVulnerability = 758,
     }
 }

--- a/Source/ACE.Entity/Enum/SpellId.cs
+++ b/Source/ACE.Entity/Enum/SpellId.cs
@@ -6378,6 +6378,11 @@ namespace ACE.Entity.Enum
         CampfireRest1,
         CampfireRest2,
         CampfireRest3,
+        OlthoiStaminaDebuff,
+        OlthoiManaDebuff,
+        OlthoiDefenseDebuff,
+        OlthoiAcidVulnerability,
+        OlthoiHealthDebuff,
 
         NumSpells = 8192,
 

--- a/Source/ACE.Entity/Models/PropertiesEnchantmentRegistry.cs
+++ b/Source/ACE.Entity/Models/PropertiesEnchantmentRegistry.cs
@@ -22,5 +22,6 @@ namespace ACE.Entity.Models
         public uint StatModKey { get; set; }
         public float StatModValue { get; set; }
         public EquipmentSet SpellSetId { get; set; }
+        public uint SpellStacks { get; set; }
     }
 }

--- a/Source/ACE.Server/Entity/DamageHistoryInfo.cs
+++ b/Source/ACE.Server/Entity/DamageHistoryInfo.cs
@@ -2,6 +2,7 @@ using System;
 
 using ACE.Entity;
 using ACE.Server.WorldObjects;
+using ACE.Server.WorldObjects.Managers;
 
 namespace ACE.Server.Entity
 {
@@ -24,6 +25,8 @@ namespace ACE.Server.Entity
 
         public int Level;
 
+        public Player Player;
+
         public DamageHistoryInfo(WorldObject attacker, float totalDamage = 0.0f)
         {
             Attacker = new WeakReference<WorldObject>(attacker);
@@ -31,6 +34,7 @@ namespace ACE.Server.Entity
             Guid = attacker.Guid;
             Name = attacker.Name;
             Level = attacker.Level ?? 1;
+            Player = attacker as Player;
 
             IsOlthoiPlayer = attacker is Player player && player.IsOlthoiPlayer;
 

--- a/Source/ACE.Server/Factories/Tables/StackableSpellTables.cs
+++ b/Source/ACE.Server/Factories/Tables/StackableSpellTables.cs
@@ -1,0 +1,39 @@
+using ACE.Entity.Enum;
+
+namespace ACE.Server.Factories.Tables
+{
+    public static class StackableSpellTables
+    {
+        public enum StackableSpellType
+        {
+            None,
+            OlthoiNorth
+        }
+
+        public static SpellId[] OlthoiNorthDebuffs =
+        {
+            SpellId.OlthoiStaminaDebuff,
+            SpellId.OlthoiManaDebuff,
+            SpellId.OlthoiHealthDebuff,
+            SpellId.OlthoiDefenseDebuff,
+            SpellId.OlthoiAcidVulnerability
+        };
+
+        public static uint[] OlthoiNorthCreatureWcids =
+        {
+            2036000, // worker
+            2036001, // soldier
+            2036002, // noble
+            2036003, // lancer
+            2036004, // grub
+            2036005, // eviscerator
+            2036050, // worker (niffis)
+            2036051, // worker (gromnie)
+            2036052, // sea gromnie
+            2036053, // worker (wanderer) 
+            2036054, // soldier (wanderer)
+            2036055, // noble (wanderer)
+            2036056, // lancer (wanderer)
+        };
+    }
+}

--- a/Source/ACE.Server/Network/Structure/Enchantment.cs
+++ b/Source/ACE.Server/Network/Structure/Enchantment.cs
@@ -28,6 +28,7 @@ namespace ACE.Server.Network.Structure
         public uint StatModKey;
         public float StatModValue;
         public uint SpellSetID;     // only sent if HasSpellSetID = true
+        public uint SpellStacks;
 
         // not sent in network structure
         public WorldObject Target;
@@ -75,6 +76,7 @@ namespace ACE.Server.Network.Structure
             CasterGuid = entry.CasterObjectId;
             StatModValue = entry.StatModValue;
             SpellSetID = (uint)entry.SpellSetId;
+            SpellStacks = entry.SpellStacks;
             Target = target;
             EnchantmentMask = (EnchantmentMask)entry.EnchantmentCategory;
         }
@@ -109,6 +111,7 @@ namespace ACE.Server.Network.Structure
             DegradeModifier = spell.DegradeModifier;
             DegradeLimit = spell.DegradeLimit;
             StatModValue = entry.StatModValue;
+            SpellStacks = entry.SpellStacks;
 
             if (spell._spell != null)
             {
@@ -131,6 +134,7 @@ namespace ACE.Server.Network.Structure
             StatModType = (EnchantmentTypeFlags)entry.StatModType;
             StatModKey = entry.StatModKey;
             StatModValue = entry.StatModValue;
+            SpellStacks = entry.SpellStacks;
         }
 
         public string GetInfo()
@@ -148,6 +152,7 @@ namespace ACE.Server.Network.Structure
             info += $"StatModType: {StatModType}\n";
             info += $"StatModKey: {StatModKey}\n";
             info += $"StatModValue: {StatModValue}\n";
+            info += $"SpellStacks: {SpellStacks}\n";
             info += "---------";
 
             return info;

--- a/Source/ACE.Server/WorldObjects/Creature_Equipment.cs
+++ b/Source/ACE.Server/WorldObjects/Creature_Equipment.cs
@@ -1145,10 +1145,10 @@ namespace ACE.Server.WorldObjects
                         modifier = createList.GetSetModifier(i, dropRateMod);
                     }
 
-                    var probability = shadeOrProbability * (item.WeenieClassId != 0 ? modifier.TrophyMod : modifier.NoneMod);
+                    var probability = (float)Math.Round(shadeOrProbability * (item.WeenieClassId != 0 ? modifier.TrophyMod : modifier.NoneMod), 4);
 
                     totalProbability += probability;
-
+                    //Console.WriteLine($"Modifier: {modifier}, Prob: {probability}, TotalProb: {totalProbability}");
                     if (rngSelected || rng >= totalProbability)
                         continue;
 

--- a/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
+++ b/Source/ACE.Server/WorldObjects/Managers/EmoteManager.cs
@@ -325,7 +325,14 @@ namespace ACE.Server.WorldObjects.Managers
                         {
                             var spellTarget = GetSpellTarget(spell, targetObject);
 
-                            WorldObject.TryCastSpell_WithRedirects(spell, spellTarget, WorldObject);
+                            if(emote.Message != null && emote.Message == "noresist")
+                            {
+                                WorldObject.TryCastSpell_WithRedirects(spell, spellTarget, WorldObject, null, false, false, false);
+                            }
+                            else
+                            {
+                                WorldObject.TryCastSpell_WithRedirects(spell, spellTarget, WorldObject);
+                            }
                         }
                     }
                     break;
@@ -1000,7 +1007,8 @@ namespace ACE.Server.WorldObjects.Managers
                 case EmoteType.LocalBroadcast:
 
                     message = Replace(emote.Message, WorldObject, targetObject, emoteSet.Quest);
-                    WorldObject.EnqueueBroadcast(new GameMessageSystemChat(message, ChatMessageType.Broadcast));
+                    var range = emote.Amount ?? WorldObject.LocalBroadcastRange;
+                    WorldObject.EnqueueBroadcast(new GameMessageSystemChat(message, ChatMessageType.Broadcast), (float)range);
                     break;
 
                 case EmoteType.LocalSignal:
@@ -1282,10 +1290,12 @@ namespace ACE.Server.WorldObjects.Managers
 
                     var name = WorldObject.CreatureType == CreatureType.Olthoi ? WorldObject.Name + "&" : WorldObject.Name;
 
+                    range = emote.Amount ?? WorldObject.LocalBroadcastRange;
+
                     if (emote.Extent > 0)
-                        WorldObject.EnqueueBroadcast(new GameMessageHearRangedSpeech(message, name, WorldObject.Guid.Full, emote.Extent, ChatMessageType.Emote), WorldObject.LocalBroadcastRange);
+                        WorldObject.EnqueueBroadcast(new GameMessageHearRangedSpeech(message, name, WorldObject.Guid.Full, emote.Extent, ChatMessageType.Emote), (float)range);
                     else
-                        WorldObject.EnqueueBroadcast(new GameMessageHearSpeech(message, name, WorldObject.Guid.Full, ChatMessageType.Emote), WorldObject.LocalBroadcastRange);
+                        WorldObject.EnqueueBroadcast(new GameMessageHearSpeech(message, name, WorldObject.Guid.Full, ChatMessageType.Emote), range);
                     break;
 
                 case EmoteType.SetAltRacialSkills:
@@ -1721,6 +1731,14 @@ namespace ACE.Server.WorldObjects.Managers
                         }
                         else
                             player.Session.Network.EnqueueSend(new GameMessageSystemChat($"Failed to train {((NewSkillNames)emote.Stat).ToSentence()}!", ChatMessageType.Advancement));
+                    }
+                    break;
+
+                case EmoteType.BroadcastSpellStacks:
+
+                    if (player != null)
+                    {
+                        player.GetAllSpellStacks();
                     }
                     break;
 

--- a/Source/ACE.Server/WorldObjects/Player_Spells.cs
+++ b/Source/ACE.Server/WorldObjects/Player_Spells.cs
@@ -618,5 +618,57 @@ namespace ACE.Server.WorldObjects
 
             return false;
         }
+
+        public void GetAllSpellStacks()
+        {
+            GetOlthoiNorthSpellStacks(true);
+        }
+
+        public uint GetOlthoiNorthSpellStacks(bool withMessage = false)
+        {
+            uint totalStacks = 0;
+
+            var msg = "Olthoi North Modifiers - ";
+
+            var olthoiStaminaDebuff = EnchantmentManager.GetEnchantment((uint)SpellId.OlthoiStaminaDebuff); // stamaina and mana
+            if (olthoiStaminaDebuff != null)
+            {
+                var staminaDebuff = olthoiStaminaDebuff.SpellStacks + 1;
+                totalStacks += staminaDebuff;
+                msg += $" Stamina/Mana: -{staminaDebuff}%";
+            }
+
+            var olthoiHealthDebuff = EnchantmentManager.GetEnchantment((uint)SpellId.OlthoiHealthDebuff);
+            if (olthoiHealthDebuff != null)
+            {
+                var healthDebuff = olthoiHealthDebuff.SpellStacks + 1;
+                totalStacks += healthDebuff;
+                msg += $" Health: -{healthDebuff}%";
+            }
+
+            var olthoiDefenseDebuff = EnchantmentManager.GetEnchantment((uint)SpellId.OlthoiDefenseDebuff);
+            if (olthoiDefenseDebuff != null)
+            {
+                var physicalDefenseDebuff = olthoiDefenseDebuff.SpellStacks + 1;
+                totalStacks += physicalDefenseDebuff;
+                msg += $" Physical Defense: -{physicalDefenseDebuff}%";
+            }
+
+            var olthoiAcidDebuff = EnchantmentManager.GetEnchantment((uint)SpellId.OlthoiAcidVulnerability);
+            if (olthoiAcidDebuff != null)
+            {
+                var acidResistanceDebuff = olthoiAcidDebuff.SpellStacks + 1;
+                totalStacks += acidResistanceDebuff;
+                msg += $" Acid Vulnerability: +{acidResistanceDebuff}%.";
+            }
+
+            msg += $"\nTotal discovery bonus: +{ totalStacks}% ";
+
+            if (withMessage)
+            {
+                Session.Network.EnqueueSend(new GameMessageSystemChat(msg, ChatMessageType.Broadcast));
+            }
+            return totalStacks;
+        }
     }
 }

--- a/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
+++ b/Source/ACE.Server/WorldObjects/WorldObject_Properties.cs
@@ -15,6 +15,7 @@ using ACE.Server.Entity;
 using ACE.Server.Managers;
 using ACE.Server.Network.Structure;
 using ACE.Server.Physics.Extensions;
+using static ACE.Server.Factories.Tables.StackableSpellTables;
 
 namespace ACE.Server.WorldObjects
 {
@@ -4211,6 +4212,12 @@ namespace ACE.Server.WorldObjects
         {
             get => GetProperty(PropertyInstanceId.BankAccountId);
             set { if (!value.HasValue) RemoveProperty(PropertyInstanceId.BankAccountId); else SetProperty(PropertyInstanceId.BankAccountId, value.Value); }
+        }
+
+        public StackableSpellType StackableSpellType
+        {
+            get => (StackableSpellType)(GetProperty(PropertyInt.StackableSpellType) ?? 0);
+            set { if (value == 0) RemoveProperty(PropertyInt.StackableSpellType); else SetProperty(PropertyInt.StackableSpellType, (int)value); }
         }
     }
 }


### PR DESCRIPTION
Adds a system that allows players to increase the difficulty of a region for themselves, while also providing better rewards.

- Allow certain buffs/debuffs to stack their effects when applied on top of each other.
- Stacks of spells are tracked in the spell registry.
- Stackable debuff spells last 1 hour and persist through death.
- Monster 'Create Tables' can now be affected by a killer's current debuff stacks.
- Implemented for Olthoi North enemies.
   - Using acid dropped by each worker/soldier/lancer/noble applies a unique stackable debuff.
   - The more debuffs a player has, the higher chances that each item in an olthoi's create table will drop.
   - Also increases xp gained from killing olthoi and chances to spawn special olthoi.