### PR TITLE
Spell stack bonus for fellowships

### DIFF
--- a/apps/server/WorldObjects/Creature_Death.cs
+++ b/apps/server/WorldObjects/Creature_Death.cs
@@ -1280,7 +1280,6 @@ partial class Creature
 
         if (olthoiNorthDebuffStacks > 0 && StackableSpellType == StackableSpellTables.StackableSpellType.OlthoiNorth)
         {
-            Console.WriteLine(1.0f + ((float)olthoiNorthDebuffStacks / 100));
             return 1.0f + ((float)olthoiNorthDebuffStacks / 100);
         }
 

--- a/apps/server/WorldObjects/Creature_Death.cs
+++ b/apps/server/WorldObjects/Creature_Death.cs
@@ -1248,8 +1248,39 @@ partial class Creature
         }
 
         var olthoiNorthDebuffStacks = killer.Player.GetOlthoiNorthSpellStacks(false);
+
+        var fellowshipCount = 0;
+
+        // If killer is in a fellowship, use average spell stack bonus of each fellow that contributed to the kill
+        if (killer.Player.Fellowship != null)
+        {
+            fellowshipCount = killer.Player.Fellowship.FellowshipMembers.Count;
+
+            if (fellowshipCount > 1)
+            {
+                var fellowshipMembers = killer.Player.Fellowship.GetFellowshipMembers().Values;
+
+                foreach (var fellow in fellowshipMembers)
+                {
+                    if (!DamageHistory.HasDamager(fellow))
+                    {
+                        fellowshipCount--;
+                        continue;
+                    }
+
+                    if (fellow != killer.Player)
+                    {
+                        olthoiNorthDebuffStacks += fellow.GetOlthoiNorthSpellStacks((false));
+                    }
+                }
+
+                olthoiNorthDebuffStacks = (uint)(olthoiNorthDebuffStacks / fellowshipCount);
+            }
+        }
+
         if (olthoiNorthDebuffStacks > 0 && StackableSpellType == StackableSpellTables.StackableSpellType.OlthoiNorth)
         {
+            Console.WriteLine(1.0f + ((float)olthoiNorthDebuffStacks / 100));
             return 1.0f + ((float)olthoiNorthDebuffStacks / 100);
         }
 


### PR DESCRIPTION
- When killing enemies that can have drop bonuses due to player debuff stacks, use average debuff stacks of all players in the fellowship who contributed to the kill.