### PR TITLE
Player count scaling

### DIFF
--- a/apps/server/WorldObjects/Monster_PlayerScaling.cs
+++ b/apps/server/WorldObjects/Monster_PlayerScaling.cs
@@ -106,16 +106,16 @@ partial class Creature
         }
 
         BaseHealth = Health.MaxValue;
-        BaseHeavyWeaponsSkill = GetCreatureSkill(Skill.HeavyWeapons).Current;
-        BaseDaggerSkill = GetCreatureSkill(Skill.Dagger).Current;
-        BaseStaffSkill = GetCreatureSkill(Skill.Staff).Current;
-        BaseUnarmedSkill = GetCreatureSkill(Skill.UnarmedCombat).Current;
-        BaseBowSkill = GetCreatureSkill(Skill.Bow).Current;
-        BaseThrownWeaponsSkill = GetCreatureSkill(Skill.ThrownWeapon).Current;
-        BaseWarMagicSkill = GetCreatureSkill(Skill.WarMagic).Current;
-        BaseLifeMagicSkill = GetCreatureSkill(Skill.LifeMagic).Current;
-        BasePhysicalDefenseSkill = GetCreatureSkill(Skill.MeleeDefense).Current;
-        BaseMagicDefenseSkill = GetCreatureSkill(Skill.MagicDefense).Current;
+        BaseHeavyWeaponsSkill = GetCreatureSkill(Skill.HeavyWeapons).Base;
+        BaseDaggerSkill = GetCreatureSkill(Skill.Dagger).Base;
+        BaseStaffSkill = GetCreatureSkill(Skill.Staff).Base;
+        BaseUnarmedSkill = GetCreatureSkill(Skill.UnarmedCombat).Base;
+        BaseBowSkill = GetCreatureSkill(Skill.Bow).Base;
+        BaseThrownWeaponsSkill = GetCreatureSkill(Skill.ThrownWeapon).Base;
+        BaseWarMagicSkill = GetCreatureSkill(Skill.WarMagic).Base;
+        BaseLifeMagicSkill = GetCreatureSkill(Skill.LifeMagic).Base;
+        BasePhysicalDefenseSkill = GetCreatureSkill(Skill.MeleeDefense).Base;
+        BaseMagicDefenseSkill = GetCreatureSkill(Skill.MagicDefense).Base;
 
         SkillsSet = true;
     }

--- a/apps/server/WorldObjects/Monster_PlayerScaling.cs
+++ b/apps/server/WorldObjects/Monster_PlayerScaling.cs
@@ -8,31 +8,20 @@ namespace ACE.Server.WorldObjects;
 
 partial class Creature
 {
-    private int LastNumberOfNearbyPlayers = 0;
+    private int LastNumberOfNearbyPlayers;
+
+    private bool SkillsSet;
     private uint BaseHealth;
-    private bool BaseHealthSet = false;
-
     private uint BaseHeavyWeaponsSkill;
-    private bool BaseHeavyWeaponsSkillSet = false;
     private uint BaseDaggerSkill;
-    private bool BaseDaggerSkillSet = false;
     private uint BaseStaffSkill;
-    private bool BaseStaffSkillSet = false;
     private uint BaseUnarmedSkill;
-    private bool BaseUnarmedSkillSet = false;
     private uint BaseBowSkill;
-    private bool BaseBowSkillSet = false;
     private uint BaseThrownWeaponsSkill;
-    private bool BaseThrownWeaponsSkillSet = false;
     private uint BaseWarMagicSkill;
-    private bool BaseWarMagicSkillSet = false;
     private uint BaseLifeMagicSkill;
-    private bool BaseLifeMagicSkillSet = false;
-
     private uint BasePhysicalDefenseSkill;
-    private bool BasePhysicalDefenseSet = false;
     private uint BaseMagicDefenseSkill;
-    private bool BaseMagicDefenseSet = false;
 
     private void HandlePlayerCountScaling()
     {
@@ -111,71 +100,24 @@ partial class Creature
 
     private void SetBaseSkills()
     {
-        if (!BaseHealthSet)
+        if (SkillsSet)
         {
-            BaseHealth = Health.MaxValue;
-            BaseHealthSet = true;
+            return;
         }
 
-        if (!BaseHeavyWeaponsSkillSet)
-        {
-            BaseHeavyWeaponsSkill = GetCreatureSkill(Skill.HeavyWeapons).Current;
-            BaseHeavyWeaponsSkillSet = true;
-        }
+        BaseHealth = Health.MaxValue;
+        BaseHeavyWeaponsSkill = GetCreatureSkill(Skill.HeavyWeapons).Current;
+        BaseDaggerSkill = GetCreatureSkill(Skill.Dagger).Current;
+        BaseStaffSkill = GetCreatureSkill(Skill.Staff).Current;
+        BaseUnarmedSkill = GetCreatureSkill(Skill.UnarmedCombat).Current;
+        BaseBowSkill = GetCreatureSkill(Skill.Bow).Current;
+        BaseThrownWeaponsSkill = GetCreatureSkill(Skill.ThrownWeapon).Current;
+        BaseWarMagicSkill = GetCreatureSkill(Skill.WarMagic).Current;
+        BaseLifeMagicSkill = GetCreatureSkill(Skill.LifeMagic).Current;
+        BasePhysicalDefenseSkill = GetCreatureSkill(Skill.MeleeDefense).Current;
+        BaseMagicDefenseSkill = GetCreatureSkill(Skill.MagicDefense).Current;
 
-        if (!BaseDaggerSkillSet)
-        {
-            BaseDaggerSkill = GetCreatureSkill(Skill.Dagger).Current;
-            BaseDaggerSkillSet = true;
-        }
-
-        if (!BaseStaffSkillSet)
-        {
-            BaseStaffSkill = GetCreatureSkill(Skill.Staff).Current;
-            BaseStaffSkillSet = true;
-        }
-
-        if (!BaseUnarmedSkillSet)
-        {
-            BaseUnarmedSkill = GetCreatureSkill(Skill.UnarmedCombat).Current;
-            BaseUnarmedSkillSet = true;
-        }
-
-        if (!BaseBowSkillSet)
-        {
-            BaseBowSkill = GetCreatureSkill(Skill.Bow).Current;
-            BaseBowSkillSet = true;
-        }
-
-        if (!BaseThrownWeaponsSkillSet)
-        {
-            BaseThrownWeaponsSkill = GetCreatureSkill(Skill.ThrownWeapon).Current;
-            BaseThrownWeaponsSkillSet = true;
-        }
-
-        if (!BaseWarMagicSkillSet)
-        {
-            BaseWarMagicSkill = GetCreatureSkill(Skill.WarMagic).Current;
-            BaseWarMagicSkillSet = true;
-        }
-
-        if (!BaseLifeMagicSkillSet)
-        {
-            BaseLifeMagicSkill = GetCreatureSkill(Skill.LifeMagic).Current;
-            BaseLifeMagicSkillSet = true;
-        }
-
-        if (!BasePhysicalDefenseSet)
-        {
-            BasePhysicalDefenseSkill = GetCreatureSkill(Skill.MeleeDefense).Current;
-            BasePhysicalDefenseSet = true;
-        }
-
-        if (!BaseMagicDefenseSet)
-        {
-            BaseMagicDefenseSkill = GetCreatureSkill(Skill.MagicDefense).Current;
-            BaseMagicDefenseSet = true;
-        }
+        SkillsSet = true;
     }
 
     private void SetNewSkill(uint baseSkill, double multiplier, Skill skillType)

--- a/apps/server/WorldObjects/Monster_PlayerScaling.cs
+++ b/apps/server/WorldObjects/Monster_PlayerScaling.cs
@@ -1,0 +1,202 @@
+﻿using ACE.Entity.Enum;
+using ACE.Entity.Enum.Properties;
+using ACE.Entity.Models;
+using ACE.Server.WorldObjects.Entity;
+using Skill = ACE.Entity.Enum.Skill;
+
+namespace ACE.Server.WorldObjects;
+
+partial class Creature
+{
+    private int LastNumberOfNearbyPlayers = 0;
+    private uint BaseHealth;
+    private bool BaseHealthSet = false;
+
+    private uint BaseHeavyWeaponsSkill;
+    private bool BaseHeavyWeaponsSkillSet = false;
+    private uint BaseDaggerSkill;
+    private bool BaseDaggerSkillSet = false;
+    private uint BaseStaffSkill;
+    private bool BaseStaffSkillSet = false;
+    private uint BaseUnarmedSkill;
+    private bool BaseUnarmedSkillSet = false;
+    private uint BaseBowSkill;
+    private bool BaseBowSkillSet = false;
+    private uint BaseThrownWeaponsSkill;
+    private bool BaseThrownWeaponsSkillSet = false;
+    private uint BaseWarMagicSkill;
+    private bool BaseWarMagicSkillSet = false;
+    private uint BaseLifeMagicSkill;
+    private bool BaseLifeMagicSkillSet = false;
+
+    private uint BasePhysicalDefenseSkill;
+    private bool BasePhysicalDefenseSet = false;
+    private uint BaseMagicDefenseSkill;
+    private bool BaseMagicDefenseSet = false;
+
+    private void HandlePlayerCountScaling()
+    {
+
+        if (!(UseNearbyPlayerScaling ?? false))
+        {
+            return;
+        }
+
+        var numberOfNearbyPlayers = GetAttackTargets().Count;
+
+        if (numberOfNearbyPlayers <= LastNumberOfNearbyPlayers)
+        {
+            return;
+        }
+
+        LastNumberOfNearbyPlayers = numberOfNearbyPlayers;
+
+        var playerThreshold = NearbyPlayerScalingThreshold ?? 0;
+        var extraPlayers = numberOfNearbyPlayers - playerThreshold;
+
+        if (extraPlayers < 1)
+        {
+            return;
+        }
+
+        SetBaseSkills();
+
+        ApplyNearbyPlayerScalingToVitals(extraPlayers);
+
+        ApplyNearbyPlayerScalingToAttack(extraPlayers);
+
+        ApplyNearbyPlayerScalingToDefense(extraPlayers);
+
+        CheckToSpawnPlayerScalingAdds();
+    }
+
+    private void ApplyNearbyPlayerScalingToVitals(int extraPlayers)
+    {
+        var multiplier = (NearbyPlayerVitalsScalingPerExtraPlayer ?? 1.0) * extraPlayers;
+
+        ApplyHealthScaling((multiplier));
+    }
+
+    private void ApplyHealthScaling(double multiplier)
+    {
+        var currentMaxHealth = Health.MaxValue;
+        var currentHealth = Health.Current;
+        var currentHealthPercentage = (double)currentHealth / currentMaxHealth;
+
+        Vitals[PropertyAttribute2nd.MaxHealth].StartingValue = (uint)(BaseHealth + BaseHealth * multiplier);
+        Health.Current = (uint)(Health.MaxValue * currentHealthPercentage);
+    }
+
+    private void ApplyNearbyPlayerScalingToAttack(int extraPlayers)
+    {
+        var multiplier = (NearbyPlayerAttackScalingPerExtraPlayer ?? 1.0) * extraPlayers;
+
+        SetNewSkill(BaseHeavyWeaponsSkill, multiplier, Skill.HeavyWeapons);
+        SetNewSkill(BaseDaggerSkill, multiplier, Skill.Dagger);
+        SetNewSkill(BaseStaffSkill, multiplier, Skill.Staff);
+        SetNewSkill(BaseUnarmedSkill, multiplier, Skill.UnarmedCombat);
+        SetNewSkill(BaseBowSkill, multiplier, Skill.Bow);
+        SetNewSkill(BaseThrownWeaponsSkill, multiplier, Skill.ThrownWeapon);
+        SetNewSkill(BaseWarMagicSkill, multiplier, Skill.WarMagic);
+        SetNewSkill(BaseLifeMagicSkill, multiplier, Skill.LifeMagic);
+    }
+
+    private void ApplyNearbyPlayerScalingToDefense(int extraPlayers)
+    {
+        var multiplier = (NearbyPlayerDefenseScalingPerExtraPlayer ?? 1.0) * extraPlayers;
+
+        SetNewSkill(BasePhysicalDefenseSkill, multiplier, Skill.MeleeDefense);
+        SetNewSkill(BaseMagicDefenseSkill, multiplier, Skill.MagicDefense);
+    }
+
+    private void SetBaseSkills()
+    {
+        if (!BaseHealthSet)
+        {
+            BaseHealth = Health.MaxValue;
+            BaseHealthSet = true;
+        }
+
+        if (!BaseHeavyWeaponsSkillSet)
+        {
+            BaseHeavyWeaponsSkill = GetCreatureSkill(Skill.HeavyWeapons).Current;
+            BaseHeavyWeaponsSkillSet = true;
+        }
+
+        if (!BaseDaggerSkillSet)
+        {
+            BaseDaggerSkill = GetCreatureSkill(Skill.Dagger).Current;
+            BaseDaggerSkillSet = true;
+        }
+
+        if (!BaseStaffSkillSet)
+        {
+            BaseStaffSkill = GetCreatureSkill(Skill.Staff).Current;
+            BaseStaffSkillSet = true;
+        }
+
+        if (!BaseUnarmedSkillSet)
+        {
+            BaseUnarmedSkill = GetCreatureSkill(Skill.UnarmedCombat).Current;
+            BaseUnarmedSkillSet = true;
+        }
+
+        if (!BaseBowSkillSet)
+        {
+            BaseBowSkill = GetCreatureSkill(Skill.Bow).Current;
+            BaseBowSkillSet = true;
+        }
+
+        if (!BaseThrownWeaponsSkillSet)
+        {
+            BaseThrownWeaponsSkill = GetCreatureSkill(Skill.ThrownWeapon).Current;
+            BaseThrownWeaponsSkillSet = true;
+        }
+
+        if (!BaseWarMagicSkillSet)
+        {
+            BaseWarMagicSkill = GetCreatureSkill(Skill.WarMagic).Current;
+            BaseWarMagicSkillSet = true;
+        }
+
+        if (!BaseLifeMagicSkillSet)
+        {
+            BaseLifeMagicSkill = GetCreatureSkill(Skill.LifeMagic).Current;
+            BaseLifeMagicSkillSet = true;
+        }
+
+        if (!BasePhysicalDefenseSet)
+        {
+            BasePhysicalDefenseSkill = GetCreatureSkill(Skill.MeleeDefense).Current;
+            BasePhysicalDefenseSet = true;
+        }
+
+        if (!BaseMagicDefenseSet)
+        {
+            BaseMagicDefenseSkill = GetCreatureSkill(Skill.MagicDefense).Current;
+            BaseMagicDefenseSet = true;
+        }
+    }
+
+    private void SetNewSkill(uint baseSkill, double multiplier, Skill skillType)
+    {
+        var newSkill = (uint)(baseSkill + baseSkill * multiplier);
+        var propertiesSkill = new PropertiesSkill()
+        {
+            InitLevel = newSkill,
+            SAC = SkillAdvancementClass.Trained
+        };
+
+        Skills[skillType] = new CreatureSkill(this, skillType, propertiesSkill);
+    }
+
+    private void CheckToSpawnPlayerScalingAdds()
+    {
+        if (NearbyPlayerScalingAddWcid == null)
+        {
+            return;
+        }
+
+        // TODO: reference NearbyPlayerScalingAddWcid to spawn extra creatures
+    }
+}

--- a/apps/server/WorldObjects/Monster_Tick.cs
+++ b/apps/server/WorldObjects/Monster_Tick.cs
@@ -57,6 +57,8 @@ partial class Creature
             return;
         }
 
+        HandlePlayerCountScaling();
+
         HandleFindTarget();
 
         CheckMissHome(); // tickrate?

--- a/apps/server/WorldObjects/WorldObject.cs
+++ b/apps/server/WorldObjects/WorldObject.cs
@@ -1591,6 +1591,54 @@ public abstract partial class WorldObject : IActor
         }
     }
 
+    public double? NearbyPlayerVitalsScalingPerExtraPlayer
+    {
+        get => GetProperty(PropertyFloat.NearbyPlayerVitalsScalingPerExtraPlayer);
+        set
+        {
+            if (!value.HasValue)
+            {
+                RemoveProperty(PropertyFloat.NearbyPlayerVitalsScalingPerExtraPlayer);
+            }
+            else
+            {
+                SetProperty(PropertyFloat.NearbyPlayerVitalsScalingPerExtraPlayer, value.Value);
+            }
+        }
+    }
+
+    public double? NearbyPlayerAttackScalingPerExtraPlayer
+    {
+        get => GetProperty(PropertyFloat.NearbyPlayerAttackScalingPerExtraPlayer);
+        set
+        {
+            if (!value.HasValue)
+            {
+                RemoveProperty(PropertyFloat.NearbyPlayerAttackScalingPerExtraPlayer);
+            }
+            else
+            {
+                SetProperty(PropertyFloat.NearbyPlayerAttackScalingPerExtraPlayer, value.Value);
+            }
+        }
+    }
+
+    public double? NearbyPlayerDefenseScalingPerExtraPlayer
+    {
+        get => GetProperty(PropertyFloat.NearbyPlayerDefenseScalingPerExtraPlayer);
+        set
+        {
+            if (!value.HasValue)
+            {
+                RemoveProperty(PropertyFloat.NearbyPlayerDefenseScalingPerExtraPlayer);
+            }
+            else
+            {
+                SetProperty(PropertyFloat.NearbyPlayerDefenseScalingPerExtraPlayer, value.Value);
+            }
+        }
+    }
+
     public bool? CannotBreakStealth
     {
         get => GetProperty(PropertyBool.CannotBreakStealth);
@@ -1635,6 +1683,22 @@ public abstract partial class WorldObject : IActor
             else
             {
                 SetProperty(PropertyBool.MenhirManaHotspot, value.Value);
+            }
+        }
+    }
+
+    public bool? UseNearbyPlayerScaling
+    {
+        get => GetProperty(PropertyBool.UseNearbyPlayerScaling) ?? false;
+        set
+        {
+            if (!value.HasValue)
+            {
+                RemoveProperty(PropertyBool.UseNearbyPlayerScaling);
+            }
+            else
+            {
+                SetProperty(PropertyBool.UseNearbyPlayerScaling, value.Value);
             }
         }
     }

--- a/apps/server/WorldObjects/WorldObject_Properties.cs
+++ b/apps/server/WorldObjects/WorldObject_Properties.cs
@@ -8843,4 +8843,52 @@ partial class WorldObject
             }
         }
     }
+
+    public int? NearbyPlayerScalingThreshold
+    {
+        get => GetProperty(PropertyInt.NearbyPlayerScalingThreshold);
+        set
+        {
+            if (!value.HasValue)
+            {
+                RemoveProperty(PropertyInt.NearbyPlayerScalingThreshold);
+            }
+            else
+            {
+                SetProperty(PropertyInt.NearbyPlayerScalingThreshold, value.Value);
+            }
+        }
+    }
+
+    public int? NearbyPlayerScalingExtraPlayersPerAdd
+    {
+        get => GetProperty(PropertyInt.NearbyPlayerScalingExtraPlayersPerAdd);
+        set
+        {
+            if (!value.HasValue)
+            {
+                RemoveProperty(PropertyInt.NearbyPlayerScalingExtraPlayersPerAdd);
+            }
+            else
+            {
+                SetProperty(PropertyInt.NearbyPlayerScalingExtraPlayersPerAdd, value.Value);
+            }
+        }
+    }
+
+    public int? NearbyPlayerScalingAddWcid
+    {
+        get => GetProperty(PropertyInt.NearbyPlayerScalingAddWcid);
+        set
+        {
+            if (!value.HasValue)
+            {
+                RemoveProperty(PropertyInt.NearbyPlayerScalingAddWcid);
+            }
+            else
+            {
+                SetProperty(PropertyInt.NearbyPlayerScalingAddWcid, value.Value);
+            }
+        }
+    }
 }

--- a/libs/entity/Enum/Properties/PropertyBool.cs
+++ b/libs/entity/Enum/Properties/PropertyBool.cs
@@ -227,6 +227,7 @@ public enum PropertyBool : ushort
     MutableQuestItem = 147,
     StruckByUnshrouded = 148,
     MenhirManaHotspot = 149,
+    UseNearbyPlayerScaling = 150,
 
     /* custom */
     [ServerOnly]

--- a/libs/entity/Enum/Properties/PropertyFloat.cs
+++ b/libs/entity/Enum/Properties/PropertyFloat.cs
@@ -232,6 +232,9 @@ public enum PropertyFloat : ushort
     StaminaCostReductionMod = 191,
     RankContribution = 192,
     SworeAllegiance = 193,
+    NearbyPlayerVitalsScalingPerExtraPlayer = 194,
+    NearbyPlayerAttackScalingPerExtraPlayer = 195,
+    NearbyPlayerDefenseScalingPerExtraPlayer = 196,
 
     [ServerOnly]
     PCAPRecordedWorkmanship = 8004,

--- a/libs/entity/Enum/Properties/PropertyInt.cs
+++ b/libs/entity/Enum/Properties/PropertyInt.cs
@@ -818,6 +818,9 @@ public enum PropertyInt : ushort
     CombatFocusSkillSpellRemoved = 459,
     CombatFocusSkillSpellAdded = 460,
     StackableSpellType = 461,
+    NearbyPlayerScalingThreshold = 462,
+    NearbyPlayerScalingExtraPlayersPerAdd = 463,
+    NearbyPlayerScalingAddWcid = 464,
 
     [ServerOnly]
     PCAPRecordedAutonomousMovement = 8007,


### PR DESCRIPTION
- Optional settings for monsters to dynamically scale their stats if multiple players are nearby. Can set:
   - Threshold for how many players must be nearby before scaling starts.
   - How much vitals/attack/defense will be scaled per extra player nearby.
   - TODO: Allow additional monsters to spawn when scaling a monster.
- Occurs on monster generation and continues to check for new nearby players on every monster tick.
- Monsters can only scale upward, when more players appear nearby (not downward when players disappear).