### PR TITLE
feat: add appropriate xp rewards for shrouded players

### DIFF
--- a/apps/server/Managers/PropertyManager.cs
+++ b/apps/server/Managers/PropertyManager.cs
@@ -1267,6 +1267,7 @@ public static class DefaultPropertyManager
             )
         ),
         ("max_level", new Property<long>(275, "Set the max character level.")),
+        ("soft_level_cap", new Property<long>(50, "Set the 'soft' level cap (current highest possible level of monsters)")),
         ("monster_visual_awareness_range", new Property<long>(30, "Set outdoors monster visual range.")),
         (
             "landblock_minimum_spawn_density",

--- a/apps/server/WorldObjects/Creature_Death.cs
+++ b/apps/server/WorldObjects/Creature_Death.cs
@@ -290,6 +290,34 @@ partial class Creature
                     playerDamager.EarnBossKillXP(Level, BossKillXpMonsterMax, BossKillXpPlayerMax, playerDamager);
                 }
             }
+            // Monsters with ShroudKillXpReward set can grant the killer(s) xp as if the monster was the same level as
+            // the player. The player must be <= the monster level OR shrouded.
+            else if (ShroudKillXpReward == true)
+            {
+                var monsterLevel = Level ?? 1;
+
+                if (playerDamager.Fellowship != null)
+                {
+                    foreach (var member in playerDamager.Fellowship.GetFellowshipMembers().Values)
+                    {
+                        var memberLevel = member.Level ?? 1;
+
+                        if (memberLevel <= monsterLevel || member.IsShrouded())
+                        {
+                            member.EarnShroudKillXp(playerDamager, killXpMod);
+                        }
+                    }
+                }
+                else
+                {
+                    var playerLevel = playerDamager.Level ?? 1;
+
+                    if (playerLevel <= monsterLevel || playerDamager.IsShrouded())
+                    {
+                        playerDamager.EarnShroudKillXp(playerDamager, killXpMod);
+                    }
+                }
+            }
             else
             {
                 playerDamager.EarnXP((long)Math.Round(totalXP), XpType.Kill, Level, ShareType.All, WeenieClassId);

--- a/apps/server/WorldObjects/Player_Spells.cs
+++ b/apps/server/WorldObjects/Player_Spells.cs
@@ -824,4 +824,22 @@ partial class Player
         }
         return totalStacks;
     }
+
+    public bool IsShrouded()
+    {
+        var enchantments = Biota
+            .PropertiesEnchantmentRegistry.Clone(BiotaDatabaseLock)
+            .Where(i => i.Duration == -1 && i.SpellId != (int)SpellId.Vitae)
+            .ToList();
+
+        foreach (var enchantment in enchantments)
+        {
+            if (enchantment.SpellId == (int)SpellId.CurseWeakness1)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/apps/server/WorldObjects/WorldObject_Properties.cs
+++ b/apps/server/WorldObjects/WorldObject_Properties.cs
@@ -7262,6 +7262,22 @@ partial class WorldObject
         }
     }
 
+    public bool? ShroudKillXpReward
+    {
+        get => GetProperty(PropertyBool.ShroudKillXpReward);
+        set
+        {
+            if (!value.HasValue)
+            {
+                RemoveProperty(PropertyBool.ShroudKillXpReward);
+            }
+            else
+            {
+                SetProperty(PropertyBool.ShroudKillXpReward, value.Value);
+            }
+        }
+    }
+
     public bool? UseLegacyThreatSystem
     {
         get => GetProperty(PropertyBool.UseLegacyThreatSystem);

--- a/libs/entity/Enum/Properties/PropertyBool.cs
+++ b/libs/entity/Enum/Properties/PropertyBool.cs
@@ -229,6 +229,7 @@ public enum PropertyBool : ushort
     MenhirManaHotspot = 149,
     UseNearbyPlayerScaling = 150,
     IsBankContainer = 151,
+    ShroudKillXpReward = 152,
 
     /* custom */
     [ServerOnly]


### PR DESCRIPTION
- Allow monsters to have a ShroudedKillXpReward bool set. If true, shrouded players earn xp as if the monster was the level of the player.
- Caps at current soft level cap of 50.
- Refactor some of the Xp calculation code.
   - Move overlevelPenalty mod into XpType.Kill block.
   - Move altBonus and regionalDebuffBonus mods to after monster kill xp cap calculations. This also allows them to apply to quest xp gains.