### PR TITLE
feat: add player tier setting for chests

### DIFF
--- a/apps/server/WorldObjects/Chest.cs
+++ b/apps/server/WorldObjects/Chest.cs
@@ -217,8 +217,23 @@ public partial class Chest : Container, Lock
             return;
         }
 
-        // open chest
-        Open(player);
+        if (IsPlayerTierChest && player.IsShrouded())
+        {
+            var baseTier = Tier ?? 1;
+
+            Tier = player.GetPlayerTier(player.Level ?? 1);
+
+            Reset(ResetTimestamp);
+
+            Open(player);
+
+            Tier = baseTier;
+        }
+        else
+        {
+            // open chest
+            Open(player);
+        }
     }
 
     public override void Open(Player player)

--- a/apps/server/WorldObjects/WorldObject_Properties.cs
+++ b/apps/server/WorldObjects/WorldObject_Properties.cs
@@ -7278,6 +7278,22 @@ partial class WorldObject
         }
     }
 
+    public bool IsPlayerTierChest
+    {
+        get => GetProperty(PropertyBool.IsPlayerTierChest) ?? false;
+        set
+        {
+            if (!value)
+            {
+                RemoveProperty(PropertyBool.IsPlayerTierChest);
+            }
+            else
+            {
+                SetProperty(PropertyBool.IsPlayerTierChest, value);
+            }
+        }
+    }
+
     public bool? UseLegacyThreatSystem
     {
         get => GetProperty(PropertyBool.UseLegacyThreatSystem);

--- a/libs/entity/Enum/Properties/PropertyBool.cs
+++ b/libs/entity/Enum/Properties/PropertyBool.cs
@@ -230,6 +230,7 @@ public enum PropertyBool : ushort
     UseNearbyPlayerScaling = 150,
     IsBankContainer = 151,
     ShroudKillXpReward = 152,
+    IsPlayerTierChest = 153,
 
     /* custom */
     [ServerOnly]


### PR DESCRIPTION
- Allow chests with this setting enabled to always provide loot of the player's tier.
   - Primarily for content areas that make use of Shrouding.