### PR TITLE
feat: upgrade kits

### DIFF
--- a/apps/server/Entity/Confirmation.cs
+++ b/apps/server/Entity/Confirmation.cs
@@ -189,6 +189,10 @@ public class Confirmation_CraftInteration : Confirmation
         {
             CombatFocusAlterationGem.UseObjectOnTarget(player, source, target, true);
         }
+        else if (source.WeenieType == WeenieType.UpgradeKit)
+        {
+            UpgradeKit.UseObjectOnTarget(player, source, target, true);
+        }
         else
         {
             RecipeManager.UseObjectOnTarget(player, source, target, true);

--- a/apps/server/Factories/LootGenerationFactory.cs
+++ b/apps/server/Factories/LootGenerationFactory.cs
@@ -906,6 +906,7 @@ public static partial class LootGenerationFactory
     public static void MutateQuestItem(WorldObject wo)
     {
         wo.SetProperty(PropertyBool.MutableQuestItem, false);
+        //wo.SetProperty(PropertyBool.UpgradeableQuestItem, true);
 
         var tier = GetTierFromWieldDifficulty(wo.WieldDifficulty ?? 50);
         var lootQuality = (float)(wo.LootQualityMod ?? 0.0f);

--- a/apps/server/Factories/LootGenerationFactory.cs
+++ b/apps/server/Factories/LootGenerationFactory.cs
@@ -2741,9 +2741,9 @@ public static partial class LootGenerationFactory
         }
     }
 
-    public static int GetTierFromWieldDifficulty(int tier)
+    public static int GetTierFromWieldDifficulty(int wieldDifficulty)
     {
-        switch (tier)
+        switch (wieldDifficulty)
         {
             case 50:
                 return 1;
@@ -2763,6 +2763,54 @@ public static partial class LootGenerationFactory
                 return 8;
             default:
                 return 0;
+        }
+    }
+
+    public static int GetRequiredLevelPerTier(int tier)
+    {
+        switch (tier)
+        {
+            case 1:
+                return 1;
+            case 2:
+                return 10;
+            case 3:
+                return 20;
+            case 4:
+                return 30;
+            case 5:
+                return 40;
+            case 6:
+                return 50;
+            case 7:
+                return 75;
+            case 8:
+                return 100;
+            default:
+                return 1;
+        }
+    }
+
+    public static int GetTierFromRequiredLevel(int requiredLevel)
+    {
+        switch (requiredLevel)
+        {
+            case < 10:
+                return 1;
+            case 20:
+                return 2;
+            case 30:
+                return 3;
+            case 40:
+                return 4;
+            case 50:
+                return 5;
+            case 75:
+                return 6;
+            case 100:
+                return 7;
+            default:
+                return 8;
         }
     }
 

--- a/apps/server/Factories/LootGenerationFactory_Jewelry.cs
+++ b/apps/server/Factories/LootGenerationFactory_Jewelry.cs
@@ -117,7 +117,7 @@ public static partial class LootGenerationFactory
         var qualityMod = td.LootQualityMod != 0.0f ? td.LootQualityMod : 0.0f;
 
         // Roll Ward
-        var minWard = GetMaxValueOfTier(tier) / 2;
+        var minWard = GetMaxValueOfTier(tier);
         wo.WardLevel = (int)(minWard * GetDiminishingRoll(td) + minWard);
         var maxWardRollPercentile = (float)wo.WardLevel / (GetMaxValueOfTier(8));
 

--- a/apps/server/Factories/LootTables.cs
+++ b/apps/server/Factories/LootTables.cs
@@ -3,11 +3,14 @@ using System.Collections.Generic;
 using ACE.Entity.Enum;
 using ACE.Server.Factories.Tables.Cantrips;
 using ACE.Server.WorldObjects;
+using Serilog;
 
 namespace ACE.Server.Factories;
 
 public static class LootTables
 {
+    private static readonly ILogger _log = Log.ForContext(typeof(LootTables));
+
     /// <summary>
     /// A mapping of MaterialTypes to value modifiers
     /// </summary>
@@ -3799,6 +3802,12 @@ public static class LootTables
 
     public static int GetMeleeSubtypeDamageRange(WeaponSubtype weaponSubtype, int tier)
     {
+        if (tier > 7)
+        {
+            _log.Error("GetMeleeSubtypeDamageRange({WeaponSubtype}, {Tier}) - Tier should not be greater than 7.", weaponSubtype, tier);
+            return 0;
+        }
+
         switch (weaponSubtype)
         {
             case WeaponSubtype.AxeLarge:
@@ -3845,8 +3854,68 @@ public static class LootTables
         }
     }
 
+     public static int GetMeleeSubtypeMinimumDamage(WeaponSubtype weaponSubtype, int tier)
+    {
+        if (tier > 7)
+        {
+            _log.Error("GetMeleeSubtypeMinimumDamage({WeaponSubtype}, {Tier}) - Tier should not be greater than 7.", weaponSubtype, tier);
+            return 0;
+        }
+
+        switch (weaponSubtype)
+        {
+            case WeaponSubtype.AxeLarge:
+                return AxeLargeMinDamage[tier];
+            case WeaponSubtype.AxeMedium:
+                return AxeMediumMinDamage[tier];
+            case WeaponSubtype.AxeSmall:
+                return AxeSmallMinDamage[tier];
+            case WeaponSubtype.DaggerLarge:
+                return DaggerLargeMinDamage[tier];
+            case WeaponSubtype.DaggerSmall:
+                return DaggerSmallMinDamage[tier];
+            case WeaponSubtype.MaceLarge:
+                return MaceLargeMinDamage[tier];
+            case WeaponSubtype.MaceMedium:
+                return MaceMediumMinDamage[tier];
+            case WeaponSubtype.MaceSmall:
+                return MaceSmallMinDamage[tier];
+            case WeaponSubtype.SpearLarge:
+                return SpearLargeMinDamage[tier];
+            case WeaponSubtype.SpearMedium:
+                return SpearMediumMinDamage[tier];
+            case WeaponSubtype.SpearSmall:
+                return SpearSmallMinDamage[tier];
+            case WeaponSubtype.StaffLarge:
+                return StaffLargeMinDamage[tier];
+            case WeaponSubtype.StaffMedium:
+                return StaffMediumMinDamage[tier];
+            case WeaponSubtype.StaffSmall:
+                return StaffSmallMinDamage[tier];
+            case WeaponSubtype.SwordLarge:
+                return SwordLargeMinDamage[tier];
+            case WeaponSubtype.SwordMedium:
+                return SwordMediumMinDamage[tier];
+            case WeaponSubtype.SwordSmall:
+                return SwordSmallMinDamage[tier];
+            case WeaponSubtype.Ua:
+                return UaMinDamage[tier];
+            default:
+            {
+                Console.WriteLine("Error: GetMeleeSubtypeMinimumDamage() - Incorrect Weapon Subtype");
+                return 0;
+            }
+        }
+    }
+
     public static float GetMissileCasterSubtypeDamageRange(WeaponSubtype weaponSubtype, int tier)
     {
+        if (tier > 7)
+        {
+            _log.Error("GetMissileCasterSubtypeDamageRange({WeaponSubtype}, {Tier}) - Tier should not be greater than 7.", weaponSubtype, tier);
+            return 0;
+        }
+
         switch (weaponSubtype)
         {
             case WeaponSubtype.AtlatlLarge:

--- a/apps/server/Factories/LootTables.cs
+++ b/apps/server/Factories/LootTables.cs
@@ -475,28 +475,64 @@ public static class LootTables
         Caster
     };
 
-    // DARALET DAMAGE MUTATION VALUES
+    // Mana Rates [slots][tier]
+    public static readonly float[][] QuestItemManaRate =
+    [
+        [0.002083f, 0.002083f, 0.004167f, 0.008333f, 0.016667f, 0.033333f, 0.066667f, 0.125f],
+        [0.004167f, 0.004167f, 0.008333f, 0.016667f, 0.033333f, 0.066667f, 0.133333f, 0.25f],
+        [0.00625f, 0.00625f, 0.0125f, 0.025f, 0.05f, 0.1f, 0.2f, 0.375f],
+        [0.008333f, 0.008333f, 0.016667f, 0.033333f, 0.066667f, 0.133333f, 0.266667f, 0.5f],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0.014583f, 0.014583f, 0.029167f, 0.058333f, 0.116667f, 0.233333f, 0.466667f, 0.875f],
+        [0.016667f, 0.016667f, 0.033333f, 0.066667f, 0.133333f, 0.266667f, 0.533333f, 1.0f]
+    ];
+
+    // Total Mana [slots][tier]
+    public static readonly int[][] QuestItemTotalMana =
+    [
+        [15, 15, 30, 60, 120, 240, 480, 900],
+        [30, 30, 60, 120, 240, 480, 960, 1800],
+        [45, 45, 90, 180, 360, 720, 1440, 2700],
+        [60, 60, 120, 240, 480, 960, 1920, 3600],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [105, 105, 210, 420, 840, 1680, 3360, 6300],
+        [120, 120, 240, 480, 960, 1920, 3840, 7200]
+    ];
+
+    // DARALET MUTATION VALUES
     //  0|125|175|200|215|230|250|270
 
+    // Gear Mods
+    // T0 (50) | T1 (125) | T2 (175) | T3 (200) | T4 (215) | T5 (230) | T6 (250)    | T7 (270)
+    // 10%-20% | 11%-21%  | 12%-22%  | 13%-23%  | 14%-24%  | 15%-25%  | 17.5%-27.5% | 20%-30%
+
+    public const float WeaponBaseDefenseMod = 0.1f;
+    public const float WeaponDefenseModRollRange = 0.1f;
+    public static readonly float[] WeaponDefenseModBonusPerTier = [0.0f, 0.01f, 0.02f, 0.03f, 0.04f, 0.05f, 0.075f, 0.1f];
+
+    public const float WeaponBaseOffenseMod = 0.1f;
+    public const float WeaponOffenseModRollRange = 0.1f;
+    public static readonly float[] WeaponOffenseModBonusPerTier = [0.0f, 0.01f, 0.02f, 0.03f, 0.04f, 0.05f, 0.075f, 0.1f];
+
+    public const float WeaponBaseSkillMod = 0.1f;
+    public const float WeaponSkillModRollRange = 0.1f;
+    public static readonly float[] WeaponSkillModBonusPerTier = [0.0f, 0.01f, 0.02f, 0.03f, 0.04f, 0.05f, 0.075f, 0.1f];
+
+    public const float ArmorBaseSkillMod = 0.1f;
+    public const float ArmorSkillModRollRange = 0.1f;
+    public static readonly float[] ArmorSkillModBonusPerTier = [0.0f, 0.01f, 0.02f, 0.03f, 0.04f, 0.05f, 0.075f, 0.1f];
+
+    // Jewelry Ward Level per Tier
+    public static readonly int[] JewelryBaseWardLeverPerTier = [0, 10, 20, 30, 40, 50, 75, 100, 126];
+
+    // Jewelry Rating per Tier
+    public static readonly int[] JewelryBaseRatingPerTier = [0, 1, 2, 3, 4, 5, 6, 7, 8];
+    public static readonly int[] JewelryRatingRollRangePerTier = [0, 1, 2, 3, 4, 5, 6, 7, 8];
+
     // Axe - Large (Battle Axe, Silifi, Ono)
-    public static readonly int[] AxeLargeWcids =
-    {
-        301,
-        3750,
-        3751,
-        3752,
-        3753,
-        344,
-        3865,
-        3866,
-        3867,
-        3868,
-        336,
-        3842,
-        3843,
-        3844,
-        3845
-    };
+    public static readonly int[] AxeLargeWcids = { 301, 3750, 3751, 3752, 3753, 344, 3865, 3866, 3867, 3868, 336, 3842, 3843, 3844, 3845 };
     public static readonly int[] AxeLargeMaxDamage = { 9, 17, 24, 34, 49, 72, 106, 152 };
     public static readonly int[] AxeLargeMinDamage = { 6, 12, 18, 25, 37, 54, 79, 114 };
 
@@ -3935,6 +3971,38 @@ public static class LootTables
             default:
             {
                 Console.WriteLine("Error: GetMissileCasterSubtypeDamageRange() - Incorrect Weapon Subtype");
+                return 0;
+            }
+        }
+    }
+
+    public static float GetMissileCasterSubtypeMinimumDamage(WeaponSubtype weaponSubtype, int tier)
+    {
+        if (tier > 7)
+        {
+            _log.Error("GetMissileCasterSubtypeMinimumDamage({WeaponSubtype}, {Tier}) - Tier should not be greater than 7.", weaponSubtype, tier);
+            return 0;
+        }
+
+        switch (weaponSubtype)
+        {
+            case WeaponSubtype.AtlatlLarge:
+                return AtlatlLargeMinDamageMod[tier];
+            case WeaponSubtype.AtlatlSmall:
+                return AtlatlSmallMinDamageMod[tier];
+            case WeaponSubtype.BowLarge:
+                return BowLargeMinDamageMod[tier];
+            case WeaponSubtype.BowSmall:
+                return BowSmallMinDamageMod[tier];
+            case WeaponSubtype.CrossbowLarge:
+                return CrossbowLargeMinDamageMod[tier];
+            case WeaponSubtype.CrossbowSmall:
+                return CrossbowSmallMinDamageMod[tier];
+            case WeaponSubtype.Caster:
+                return CasterMinDamageMod[tier];
+            default:
+            {
+                Console.WriteLine("Error: GetMissileCasterSubtypeMinimumDamage() - Incorrect Weapon Subtype");
                 return 0;
             }
         }

--- a/apps/server/Factories/WorldObjectFactory.cs
+++ b/apps/server/Factories/WorldObjectFactory.cs
@@ -157,6 +157,8 @@ public static class WorldObjectFactory
                 return new RetainingChisel(weenie, guid);
             case WeenieType.CombatFocusAlterationGem:
                 return new CombatFocusAlterationGem(weenie, guid);
+            case WeenieType.UpgradeKit:
+                return new UpgradeKit(weenie, guid);
             default:
                 return new GenericObject(weenie, guid);
         }
@@ -290,6 +292,8 @@ public static class WorldObjectFactory
                 return new RetainingChisel(biota);
             case WeenieType.CombatFocusAlterationGem:
                 return new CombatFocusAlterationGem(biota);
+            case WeenieType.UpgradeKit:
+                return new UpgradeKit(biota);
             default:
                 return new GenericObject(biota);
         }

--- a/apps/server/WorldObjects/Container.cs
+++ b/apps/server/WorldObjects/Container.cs
@@ -722,7 +722,7 @@ public partial class Container : WorldObject
                 : null;
         }
 
-        if (this is Player && worldObject.MutableQuestItem == true)
+        if (this is Player && worldObject.MutableQuestItem)
         {
             LootGenerationFactory.MutateQuestItem(worldObject);
         }

--- a/apps/server/WorldObjects/Managers/EmoteManager.cs
+++ b/apps/server/WorldObjects/Managers/EmoteManager.cs
@@ -3191,7 +3191,8 @@ public class EmoteManager
             1054002, // Sanguine Crystal
             1054003, // Scourging Stone
             1053972, // Tailoring Kit
-            1053973  // Tailoring Pattern
+            1053973, // Tailoring Pattern
+            1054004  // Upgrade Kit
         };
 
         //numRewards *= GetCapstoneModifier(); // TODO: allow this to scale up when a fellowship has difficulty modifiers set

--- a/apps/server/WorldObjects/UpgradeKit.cs
+++ b/apps/server/WorldObjects/UpgradeKit.cs
@@ -77,7 +77,7 @@ public class UpgradeKit : Stackable
             if (
                 !player.ConfirmationManager.EnqueueSend(
                     new Confirmation_CraftInteration(player.Guid, source.Guid, target.Guid),
-                    $"This will upgrade {target.Name} to your current wield tier ({PlayerTierWieldDifficulty((player))})."
+                    $"This will upgrade {target.Name} to your current wield tier. Its wield difficulty will be increased to {PlayerTierWieldDifficulty((player))}."
                 )
             )
             {
@@ -120,7 +120,7 @@ public class UpgradeKit : Stackable
                         ChatMessageType.Craft
                     )
                 );
-                player.TryConsumeFromInventoryWithNetworking(source);
+                player.TryConsumeFromInventoryWithNetworking(source, 1);
             }
         );
 

--- a/apps/server/WorldObjects/UpgradeKit.cs
+++ b/apps/server/WorldObjects/UpgradeKit.cs
@@ -36,7 +36,7 @@ public class UpgradeKit : Stackable
         SetEphemeralValues();
     }
 
-    private void SetEphemeralValues() { }
+    private static void SetEphemeralValues() { }
 
     public override void HandleActionUseOnTarget(Player player, WorldObject target)
     {
@@ -60,7 +60,7 @@ public class UpgradeKit : Stackable
         if (!target.UpgradeableQuestItem)
         {
             player.Session.Network.EnqueueSend(
-                new GameMessageSystemChat($"Only certain quest items can be upgraded.", ChatMessageType.Craft)
+                new GameMessageSystemChat("Only certain quest items can be upgraded.", ChatMessageType.Craft)
             );
             player.SendUseDoneEvent();
             return;
@@ -118,12 +118,12 @@ public class UpgradeKit : Stackable
             player,
             () =>
             {
-                if (!UpgradeItem(player, source, target))
+                if (!UpgradeItem(player, target))
                 {
                     player.EnqueueBroadcast(new GameMessageUpdateObject(target));
                     player.Session.Network.EnqueueSend(
                         new GameMessageSystemChat(
-                            $"The crafting attempt encountered an error. Please report.",
+                            "The crafting attempt encountered an error. Please report.",
                             ChatMessageType.Broadcast
                         )
                     );
@@ -157,7 +157,7 @@ public class UpgradeKit : Stackable
         player.NextUseTime = DateTime.UtcNow.AddSeconds(animTime);
     }
 
-    private static bool UpgradeItem(Player player, WorldObject source, WorldObject target)
+    private static bool UpgradeItem(Player player, WorldObject target)
     {
         if (target.ItemType != ItemType.Jewelry)
         {
@@ -273,25 +273,17 @@ public class UpgradeKit : Stackable
         var targetWieldAttribute = (PropertyAttribute)target.WieldSkillType;
         var playerBaseAttributeLevel = player.Attributes[targetWieldAttribute].Base;
 
-        switch (playerBaseAttributeLevel)
+        return playerBaseAttributeLevel switch
         {
-            case >= 270:
-                return 270;
-            case >= 250:
-                return 250;
-            case >= 230:
-                return 230;
-            case >= 215:
-                return 215;
-            case >= 200:
-                return 200;
-            case >= 175:
-                return 175;
-            case >= 125:
-                return 125;
-            default:
-                return 50;
-        }
+            >= 270 => 270,
+            >= 250 => 250,
+            >= 230 => 230,
+            >= 215 => 215,
+            >= 200 => 200,
+            >= 175 => 175,
+            >= 125 => 125,
+            _ => 50
+        };
     }
 
     private static int GetRequiredLevelFromPlayerTier(Player player)
@@ -460,44 +452,29 @@ public class UpgradeKit : Stackable
 
         if (target.ArmorStyle != null)
         {
-            switch ((ArmorStyle)target.ArmorStyle)
+            armorStyleBaseArmorLevel = (ArmorStyle)target.ArmorStyle switch
             {
-                case ACE.Entity.Enum.ArmorStyle.Amuli:
-                case ACE.Entity.Enum.ArmorStyle.Chiran:
-                case ACE.Entity.Enum.ArmorStyle.OlthoiAmuli:
-                case ACE.Entity.Enum.ArmorStyle.Leather:
-                case ACE.Entity.Enum.ArmorStyle.Yoroi:
-                case ACE.Entity.Enum.ArmorStyle.Lorica:
-                case ACE.Entity.Enum.ArmorStyle.Buckler:
-                case ACE.Entity.Enum.ArmorStyle.SmallShield:
-                    armorStyleBaseArmorLevel = 75;
-                    break;
-                case ACE.Entity.Enum.ArmorStyle.StuddedLeather:
-                case ACE.Entity.Enum.ArmorStyle.Koujia:
-                case ACE.Entity.Enum.ArmorStyle.OlthoiKoujia:
-                    armorStyleBaseArmorLevel = 90;
-                    break;
-                case ACE.Entity.Enum.ArmorStyle.Chainmail:
-                case ACE.Entity.Enum.ArmorStyle.Scalemail:
-                case ACE.Entity.Enum.ArmorStyle.Nariyid:
-                case ACE.Entity.Enum.ArmorStyle.StandardShield:
-                    armorStyleBaseArmorLevel = 100;
-                    break;
-                case ACE.Entity.Enum.ArmorStyle.LargeShield:
-                    armorStyleBaseArmorLevel = 105;
-                    break;
-                case ACE.Entity.Enum.ArmorStyle.Platemail:
-                case ACE.Entity.Enum.ArmorStyle.Celdon:
-                case ACE.Entity.Enum.ArmorStyle.OlthoiCeldon:
-                case ACE.Entity.Enum.ArmorStyle.TowerShield:
-                    armorStyleBaseArmorLevel = 110;
-                    break;
-                case ACE.Entity.Enum.ArmorStyle.Covenant:
-                case ACE.Entity.Enum.ArmorStyle.OlthoiArmor:
-                case ACE.Entity.Enum.ArmorStyle.CovenantShield:
-                    armorStyleBaseArmorLevel = 125;
-                    break;
-            }
+                ACE.Entity.Enum.ArmorStyle.Amuli or ACE.Entity.Enum.ArmorStyle.Chiran
+                    or ACE.Entity.Enum.ArmorStyle.OlthoiAmuli or ACE.Entity.Enum.ArmorStyle.Leather
+                    or ACE.Entity.Enum.ArmorStyle.Yoroi or ACE.Entity.Enum.ArmorStyle.Lorica
+                    or ACE.Entity.Enum.ArmorStyle.Buckler or ACE.Entity.Enum.ArmorStyle.SmallShield
+                    => 75,
+                ACE.Entity.Enum.ArmorStyle.StuddedLeather or ACE.Entity.Enum.ArmorStyle.Koujia
+                    or ACE.Entity.Enum.ArmorStyle.OlthoiKoujia
+                    => 90,
+                ACE.Entity.Enum.ArmorStyle.Chainmail or ACE.Entity.Enum.ArmorStyle.Scalemail
+                    or ACE.Entity.Enum.ArmorStyle.Nariyid or ACE.Entity.Enum.ArmorStyle.StandardShield
+                    => 100,
+                ACE.Entity.Enum.ArmorStyle.LargeShield
+                    => 105,
+                ACE.Entity.Enum.ArmorStyle.Platemail or ACE.Entity.Enum.ArmorStyle.Celdon
+                    or ACE.Entity.Enum.ArmorStyle.OlthoiCeldon or ACE.Entity.Enum.ArmorStyle.TowerShield
+                    => 110,
+                ACE.Entity.Enum.ArmorStyle.Covenant or ACE.Entity.Enum.ArmorStyle.OlthoiArmor
+                    or ACE.Entity.Enum.ArmorStyle.CovenantShield
+                    => 125,
+                _ => armorStyleBaseArmorLevel
+            };
         }
 
         var currentLevel = target.ArmorLevel.Value;
@@ -521,42 +498,28 @@ public class UpgradeKit : Stackable
 
         if (target.ArmorStyle != null)
         {
-            switch ((ArmorStyle)target.ArmorStyle)
+            armorStyleBaseWardLevel = (ArmorStyle)target.ArmorStyle switch
             {
-                case ACE.Entity.Enum.ArmorStyle.CovenantShield:
-                    armorStyleBaseWardLevel = 10;
-                    break;
-                case ACE.Entity.Enum.ArmorStyle.TowerShield:
-                    armorStyleBaseWardLevel = 8;
-                    break;
-                case ACE.Entity.Enum.ArmorStyle.Amuli:
-                case ACE.Entity.Enum.ArmorStyle.Chiran:
-                case ACE.Entity.Enum.ArmorStyle.OlthoiAmuli:
-                case ACE.Entity.Enum.ArmorStyle.LargeShield:
-                    armorStyleBaseWardLevel = 7;
-                    break;
-                case ACE.Entity.Enum.ArmorStyle.StandardShield:
-                    armorStyleBaseWardLevel = 6;
-                    break;
-                case ACE.Entity.Enum.ArmorStyle.Buckler:
-                case ACE.Entity.Enum.ArmorStyle.SmallShield:
-                    armorStyleBaseWardLevel = 5;
-                    break;
-                case ACE.Entity.Enum.ArmorStyle.Leather:
-                case ACE.Entity.Enum.ArmorStyle.StuddedLeather:
-                case ACE.Entity.Enum.ArmorStyle.Koujia:
-                case ACE.Entity.Enum.ArmorStyle.OlthoiKoujia:
-                case ACE.Entity.Enum.ArmorStyle.Chainmail:
-                case ACE.Entity.Enum.ArmorStyle.Scalemail:
-                case ACE.Entity.Enum.ArmorStyle.Nariyid:
-                case ACE.Entity.Enum.ArmorStyle.Platemail:
-                case ACE.Entity.Enum.ArmorStyle.Celdon:
-                case ACE.Entity.Enum.ArmorStyle.OlthoiCeldon:
-                case ACE.Entity.Enum.ArmorStyle.Covenant:
-                case ACE.Entity.Enum.ArmorStyle.OlthoiArmor:
-                    armorStyleBaseWardLevel = 5;
-                    break;
-            }
+                ACE.Entity.Enum.ArmorStyle.CovenantShield
+                    => 10,
+                ACE.Entity.Enum.ArmorStyle.TowerShield
+                    => 8,
+                ACE.Entity.Enum.ArmorStyle.Amuli or ACE.Entity.Enum.ArmorStyle.Chiran
+                    or ACE.Entity.Enum.ArmorStyle.OlthoiAmuli or ACE.Entity.Enum.ArmorStyle.LargeShield
+                    => 7,
+                ACE.Entity.Enum.ArmorStyle.StandardShield
+                    => 6,
+                ACE.Entity.Enum.ArmorStyle.Buckler or ACE.Entity.Enum.ArmorStyle.SmallShield
+                    => 5,
+                ACE.Entity.Enum.ArmorStyle.Leather or ACE.Entity.Enum.ArmorStyle.StuddedLeather
+                    or ACE.Entity.Enum.ArmorStyle.Koujia or ACE.Entity.Enum.ArmorStyle.OlthoiKoujia
+                    or ACE.Entity.Enum.ArmorStyle.Chainmail or ACE.Entity.Enum.ArmorStyle.Scalemail
+                    or ACE.Entity.Enum.ArmorStyle.Nariyid or ACE.Entity.Enum.ArmorStyle.Platemail
+                    or ACE.Entity.Enum.ArmorStyle.Celdon or ACE.Entity.Enum.ArmorStyle.OlthoiCeldon
+                    or ACE.Entity.Enum.ArmorStyle.Covenant or ACE.Entity.Enum.ArmorStyle.OlthoiArmor
+                    => 5,
+                _ => armorStyleBaseWardLevel
+            };
         }
 
         var currentLevel = target.WardLevel.Value;

--- a/apps/server/WorldObjects/UpgradeKit.cs
+++ b/apps/server/WorldObjects/UpgradeKit.cs
@@ -270,8 +270,8 @@ public class UpgradeKit : Stackable
             return 0;
         }
 
-        var targetWieldAttribrute = (PropertyAttribute)target.WieldSkillType;
-        var playerBaseAttributeLevel = player.Attributes[targetWieldAttribrute].Base;
+        var targetWieldAttribute = (PropertyAttribute)target.WieldSkillType;
+        var playerBaseAttributeLevel = player.Attributes[targetWieldAttribute].Base;
 
         switch (playerBaseAttributeLevel)
         {

--- a/apps/server/WorldObjects/UpgradeKit.cs
+++ b/apps/server/WorldObjects/UpgradeKit.cs
@@ -1,0 +1,154 @@
+﻿using System;
+using ACE.Entity;
+using ACE.Entity.Enum;
+using ACE.Entity.Models;
+using ACE.Server.Entity;
+using ACE.Server.Entity.Actions;
+using ACE.Server.Factories;
+using ACE.Server.Managers;
+using ACE.Server.Network.GameMessages.Messages;
+using Serilog;
+
+namespace ACE.Server.WorldObjects;
+
+public class UpgradeKit : Stackable
+{
+    private static readonly ILogger _log = Log.ForContext(typeof(UpgradeKit));
+
+    /// <summary>
+    /// A new biota be created taking all of its values from weenie.
+    /// </summary>
+    public UpgradeKit(Weenie weenie, ObjectGuid guid)
+        : base(weenie, guid)
+    {
+        SetEphemeralValues();
+    }
+
+    /// <summary>
+    /// Restore a WorldObject from the database.
+    /// </summary>
+    public UpgradeKit(Biota biota)
+        : base(biota)
+    {
+        SetEphemeralValues();
+    }
+
+    private void SetEphemeralValues() { }
+
+    public override void HandleActionUseOnTarget(Player player, WorldObject target)
+    {
+        UseObjectOnTarget(player, this, target);
+    }
+
+    public static void UseObjectOnTarget(Player player, WorldObject source, WorldObject target, bool confirmed = false)
+    {
+        if (player.IsBusy)
+        {
+            player.SendUseDoneEvent(WeenieError.YoureTooBusy);
+            return;
+        }
+
+        if (!RecipeManager.VerifyUse(player, source, target, true))
+        {
+            player.SendUseDoneEvent(WeenieError.YouDoNotPassCraftingRequirements);
+            return;
+        }
+
+        if (!target.UpgradeableQuestItem)
+        {
+            player.Session.Network.EnqueueSend(
+                new GameMessageSystemChat($"Only certain quest items can be upgraded.", ChatMessageType.Craft)
+            );
+            player.SendUseDoneEvent();
+            return;
+        }
+
+        if (target.WieldDifficulty >= PlayerTierWieldDifficulty((player)))
+        {
+            player.Session.Network.EnqueueSend(
+                new GameMessageSystemChat($"The item has already been upgraded to your current wield tier.", ChatMessageType.Craft)
+            );
+            player.SendUseDoneEvent();
+            return;
+        }
+
+        if (!confirmed)
+        {
+            if (
+                !player.ConfirmationManager.EnqueueSend(
+                    new Confirmation_CraftInteration(player.Guid, source.Guid, target.Guid),
+                    $"This will upgrade {target.Name} to your current wield tier ({PlayerTierWieldDifficulty((player))})."
+                )
+            )
+            {
+                player.SendUseDoneEvent(WeenieError.ConfirmationInProgress);
+            }
+            else
+            {
+                player.SendUseDoneEvent();
+            }
+
+            return;
+        }
+
+        var actionChain = new ActionChain();
+
+        var animTime = 0.0f;
+
+        player.IsBusy = true;
+
+        if (player.CombatMode != CombatMode.NonCombat)
+        {
+            var stanceTime = player.SetCombatMode(CombatMode.NonCombat);
+            actionChain.AddDelaySeconds(stanceTime);
+
+            animTime += stanceTime;
+        }
+
+        animTime += player.EnqueueMotion(actionChain, MotionCommand.ClapHands);
+
+        actionChain.AddAction(
+            player,
+            () =>
+            {
+                UpgradeItem(player, source, target);
+
+                player.EnqueueBroadcast(new GameMessageUpdateObject(target));
+                player.Session.Network.EnqueueSend(
+                    new GameMessageSystemChat(
+                        $"You upgrade {target.Name} to a more powerful version.",
+                        ChatMessageType.Craft
+                    )
+                );
+                player.TryConsumeFromInventoryWithNetworking(source);
+            }
+        );
+
+        player.EnqueueMotion(actionChain, MotionCommand.Ready);
+
+        actionChain.AddAction(
+            player,
+            () =>
+            {
+                player.IsBusy = false;
+            }
+        );
+
+        actionChain.EnqueueChain();
+
+        player.NextUseTime = DateTime.UtcNow.AddSeconds(animTime);
+    }
+
+    public static void UpgradeItem(Player player, WorldObject source, WorldObject target)
+    {
+        target.WieldDifficulty = PlayerTierWieldDifficulty((player));
+    }
+
+    private static int PlayerTierWieldDifficulty(Player player)
+    {
+        var playerTier = player.GetPlayerTier(player.Level ?? 1);
+        var playerTierWieldDiff = LootGenerationFactory.GetWieldDifficultyPerTier(playerTier);
+
+        return playerTierWieldDiff;
+    }
+}

--- a/apps/server/WorldObjects/UpgradeKit.cs
+++ b/apps/server/WorldObjects/UpgradeKit.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using ACE.Entity;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
@@ -6,6 +7,7 @@ using ACE.Entity.Models;
 using ACE.Server.Entity;
 using ACE.Server.Entity.Actions;
 using ACE.Server.Factories;
+using ACE.Server.Factories.Tables;
 using ACE.Server.Managers;
 using ACE.Server.Network.GameMessages.Messages;
 using Serilog;
@@ -64,7 +66,7 @@ public class UpgradeKit : Stackable
             return;
         }
 
-        if (target.WieldDifficulty >= PlayerTierWieldDifficulty((player)))
+        if (target.WieldDifficulty >= GetWieldDifficultyFromPlayerTier((player)))
         {
             player.Session.Network.EnqueueSend(
                 new GameMessageSystemChat($"The item has already been upgraded to your current wield tier.", ChatMessageType.Craft)
@@ -75,10 +77,14 @@ public class UpgradeKit : Stackable
 
         if (!confirmed)
         {
+            var wieldReq = target.ItemType == ItemType.Jewelry
+                ? GetRequiredLevelFromPlayerTier(player)
+                : GetWieldDifficultyFromPlayerTier(player);
+            var wieldReqType = target.ItemType == ItemType.Jewelry ? "Required Level" : "Wield Difficulty";
             if (
                 !player.ConfirmationManager.EnqueueSend(
                     new Confirmation_CraftInteration(player.Guid, source.Guid, target.Guid),
-                    $"This will upgrade {target.Name} to your current wield tier. Its wield difficulty will be increased to {PlayerTierWieldDifficulty((player))}."
+                    $"This will upgrade {target.Name} to your current wield tier. Its {wieldReqType} will be increased to {wieldReq}."
                 )
             )
             {
@@ -112,16 +118,27 @@ public class UpgradeKit : Stackable
             player,
             () =>
             {
-                UpgradeItem(player, source, target);
-
-                player.EnqueueBroadcast(new GameMessageUpdateObject(target));
-                player.Session.Network.EnqueueSend(
-                    new GameMessageSystemChat(
-                        $"You upgrade {target.Name} to a more powerful version.",
-                        ChatMessageType.Craft
-                    )
-                );
-                player.TryConsumeFromInventoryWithNetworking(source, 1);
+                if (!UpgradeItem(player, source, target))
+                {
+                    player.EnqueueBroadcast(new GameMessageUpdateObject(target));
+                    player.Session.Network.EnqueueSend(
+                        new GameMessageSystemChat(
+                            $"The crafting attempt encountered an error. Please report.",
+                            ChatMessageType.Broadcast
+                        )
+                    );
+                }
+                else
+                {
+                    player.EnqueueBroadcast(new GameMessageUpdateObject(target));
+                    player.Session.Network.EnqueueSend(
+                        new GameMessageSystemChat(
+                            $"You upgrade {target.Name} to a more powerful version.",
+                            ChatMessageType.Broadcast
+                        )
+                    );
+                    player.TryConsumeFromInventoryWithNetworking(source, 1);
+                }
             }
         );
 
@@ -140,48 +157,531 @@ public class UpgradeKit : Stackable
         player.NextUseTime = DateTime.UtcNow.AddSeconds(animTime);
     }
 
-    public static void UpgradeItem(Player player, WorldObject source, WorldObject target)
+    private static bool UpgradeItem(Player player, WorldObject source, WorldObject target)
     {
-        var currentWieldDifficulty = target.WieldDifficulty ?? 50;
-        var newWieldDifficulty = PlayerTierWieldDifficulty((player));
-
-        var currentTier = LootGenerationFactory.GetTierFromWieldDifficulty(currentWieldDifficulty) - 1;
-        var newTier = LootGenerationFactory.GetTierFromWieldDifficulty(newWieldDifficulty) - 1;
-
-        target.SetProperty(PropertyInt.WieldDifficulty, newWieldDifficulty);
-
-        // Weapons
-        if (target.ItemType is ItemType.Weapon or ItemType.MissileWeapon or ItemType.MeleeWeapon or ItemType.Caster)
+        if (target.ItemType != ItemType.Jewelry)
         {
-            if (target.WeaponSubtype == null)
+            var currentWieldDifficulty = target.WieldDifficulty ?? 50;
+            var newWieldDifficulty = GetWieldDifficultyFromPlayerTier((player));
+
+            var currentTier = LootGenerationFactory.GetTierFromWieldDifficulty(currentWieldDifficulty) - 1;
+            var newTier = LootGenerationFactory.GetTierFromWieldDifficulty(newWieldDifficulty) - 1;
+
+            // Weapons
+            if (target.ItemType is ItemType.Weapon or ItemType.MissileWeapon or ItemType.MeleeWeapon or ItemType.Caster)
             {
-                _log.Error($"MutateQuestItem() - WeaponSubType is null for ({target.Name})");
-                return;
+                if (target.WeaponSubtype == null)
+                {
+                    _log.Error(
+                        $"MutateQuestItem() - WeaponSubType is null for ({target.Name}). Weapon upgrade aborted.");
+                    return false;
+                }
+
+                var weaponSubtype = (LootTables.WeaponSubtype)target.WeaponSubtype;
+
+                ScaleUpDamage(target, weaponSubtype, currentTier, newTier);
+                ScaleUpDamageMod(target, weaponSubtype, currentTier, newTier);
+                ScaleUpElementalDamageMod(target, weaponSubtype, currentTier, newTier);
+                ScaleUpWeaponOffense(target, currentTier, newTier);
+                ScaleUpWeaponPhysicalDefense(target, currentTier, newTier);
+                ScaleUpWeaponMagicDefense(target, currentTier, newTier);
+                ScaleUpWeaponSkillMod(PropertyFloat.WeaponLifeMagicMod, target, currentTier, newTier);
+                ScaleUpWeaponSkillMod(PropertyFloat.WeaponWarMagicMod, target, currentTier, newTier);
             }
 
-            if (target.Damage != null)
+            // Armor
+            if (target.WeenieType is WeenieType.Clothing || target.ItemType == ItemType.Armor)
             {
-                var currentBaseStat = target.Damage.Value;
-                var currentTierMinimum = LootTables.GetMeleeSubtypeMinimumDamage((LootTables.WeaponSubtype)target.WeaponSubtype, currentTier);
-                var currentRange = LootTables.GetMeleeSubtypeDamageRange((LootTables.WeaponSubtype)target.WeaponSubtype, currentTier);
-                var currentRoll = currentBaseStat - currentTierMinimum;
+                ScaleUpArmorLevel(target, currentTier, newTier);
+                ScaleUpWardLevel(target, currentTier, newTier);
 
-                var currentPercentile = (float)currentRoll / currentRange;
-
-                var newTierMinimum = LootTables.GetMeleeSubtypeMinimumDamage((LootTables.WeaponSubtype)target.WeaponSubtype, newTier);
-                var newTierRange = LootTables.GetMeleeSubtypeDamageRange((LootTables.WeaponSubtype)target.WeaponSubtype, newTier);
-                var percentileAddition = newTierRange * currentPercentile;
-                var final = Convert.ToInt32(newTierMinimum + percentileAddition);
-
-                target.SetProperty(PropertyInt.Damage, final);
+                ScaleUpArmorSkillMod(PropertyFloat.ArmorAttackMod, target, currentTier, newTier);
+                ScaleUpArmorSkillMod(PropertyFloat.ArmorDeceptionMod, target, currentTier, newTier);
+                ScaleUpArmorSkillMod(PropertyFloat.ArmorDualWieldMod, target, currentTier, newTier);
+                ScaleUpArmorSkillMod(PropertyFloat.ArmorHealthMod, target, currentTier, newTier);
+                ScaleUpArmorSkillMod(PropertyFloat.ArmorHealthRegenMod, target, currentTier, newTier);
+                ScaleUpArmorSkillMod(PropertyFloat.ArmorLifeMagicMod, target, currentTier, newTier);
+                ScaleUpArmorSkillMod(PropertyFloat.ArmorMagicDefMod, target, currentTier, newTier);
+                ScaleUpArmorSkillMod(PropertyFloat.ArmorManaMod, target, currentTier, newTier);
+                ScaleUpArmorSkillMod(PropertyFloat.ArmorManaRegenMod, target, currentTier, newTier);
+                ScaleUpArmorSkillMod(PropertyFloat.ArmorPerceptionMod, target, currentTier, newTier);
+                ScaleUpArmorSkillMod(PropertyFloat.ArmorPhysicalDefMod, target, currentTier, newTier);
+                ScaleUpArmorSkillMod(PropertyFloat.ArmorRunMod, target, currentTier, newTier);
+                ScaleUpArmorSkillMod(PropertyFloat.ArmorShieldMod, target, currentTier, newTier);
+                ScaleUpArmorSkillMod(PropertyFloat.ArmorStaminaMod, target, currentTier, newTier);
+                ScaleUpArmorSkillMod(PropertyFloat.ArmorStaminaRegenMod, target, currentTier, newTier);
+                ScaleUpArmorSkillMod(PropertyFloat.ArmorThieveryMod, target, currentTier, newTier);
+                ScaleUpArmorSkillMod(PropertyFloat.ArmorTwohandedCombatMod, target, currentTier, newTier);
+                ScaleUpArmorSkillMod(PropertyFloat.ArmorWarMagicMod, target, currentTier, newTier);
             }
+
+            // Wield Difficulty
+            target.SetProperty(PropertyInt.WieldDifficulty, newWieldDifficulty);
+
+            // Spells
+            ScaleUpSpells(target, currentTier, newTier);
+
+            // Item Mana
+            ScaleUpItemMana(target, newTier);
         }
+
+        // Jewelry
+        else
+        {
+            var currentRequiredLevel = target.WieldDifficulty ?? 1;
+            var newRequiredLevel = GetRequiredLevelFromPlayerTier((player));
+
+            var currentTier = LootGenerationFactory.GetTierFromRequiredLevel(currentRequiredLevel);
+            var newTier = LootGenerationFactory.GetTierFromRequiredLevel(newRequiredLevel);
+
+            ScaleUpJewelryWardLevel(target, currentTier, newTier);
+            ScaleUpJewelryRating(PropertyInt.GearMaxHealth, target, currentTier, newTier);
+            ScaleUpJewelryRating(PropertyInt.GearMaxStamina, target, currentTier, newTier);
+            ScaleUpJewelryRating(PropertyInt.GearMaxMana, target, currentTier, newTier);
+            ScaleUpJewelryRating(PropertyInt.GearCritDamage, target, currentTier, newTier);
+            ScaleUpJewelryRating(PropertyInt.GearCritResist, target, currentTier, newTier);
+            ScaleUpJewelryRating(PropertyInt.GearDamage, target, currentTier, newTier);
+            ScaleUpJewelryRating(PropertyInt.GearDamageResist, target, currentTier, newTier);
+
+            // Wield Difficulty
+            target.SetProperty(PropertyInt.WieldDifficulty, newRequiredLevel);
+
+            // Spells
+            ScaleUpSpells(target, currentTier, newTier);
+
+            // Item Mana
+            ScaleUpItemMana(target, newTier);
+        }
+
+        return true;
     }
 
-    private static int PlayerTierWieldDifficulty(Player player)
+    private static int GetWieldDifficultyFromPlayerTier(Player player)
     {
         var playerTier = player.GetPlayerTier(player.Level ?? 1);
 
         return LootGenerationFactory.GetWieldDifficultyPerTier(playerTier);
+    }
+
+    private static int GetRequiredLevelFromPlayerTier(Player player)
+    {
+        var playerTier = player.GetPlayerTier(player.Level ?? 1);
+
+        return LootGenerationFactory.GetRequiredLevelPerTier(playerTier);
+    }
+
+    private static void ScaleUpDamage(WorldObject target, LootTables.WeaponSubtype weaponSubtype, int currentTier, int newTier)
+    {
+        if (target.Damage == null)
+        {
+            return;
+        }
+
+        var currentBaseStat = target.Damage.Value;
+        var currentTierMinimum = LootTables.GetMeleeSubtypeMinimumDamage(weaponSubtype, currentTier);
+        var currentRange = LootTables.GetMeleeSubtypeDamageRange(weaponSubtype, currentTier);
+        var currentRoll = currentBaseStat - currentTierMinimum;
+        var rollPercentile = (float)currentRoll / currentRange;
+
+        var newTierMinimum = LootTables.GetMeleeSubtypeMinimumDamage(weaponSubtype, newTier);
+        var newTierRange = LootTables.GetMeleeSubtypeDamageRange(weaponSubtype, newTier);
+        var amountAboveMinimum = newTierRange * rollPercentile;
+        var final = Convert.ToInt32(newTierMinimum + amountAboveMinimum);
+
+        target.SetProperty(PropertyInt.Damage, final);
+    }
+
+    private static void ScaleUpDamageMod(WorldObject target, LootTables.WeaponSubtype weaponSubtype, int currentTier, int newTier)
+    {
+        if (target.DamageMod == null)
+        {
+            return;
+        }
+
+        var currentBaseStat = target.DamageMod.Value;
+        var currentTierMinimum = LootTables.GetMissileCasterSubtypeMinimumDamage(weaponSubtype, currentTier);
+        var currentRange = LootTables.GetMissileCasterSubtypeDamageRange(weaponSubtype, currentTier);
+        var currentRoll = currentBaseStat - currentTierMinimum;
+        var rollPercentile = (float)currentRoll / currentRange;
+
+        var newTierMinimum = LootTables.GetMissileCasterSubtypeMinimumDamage(weaponSubtype, newTier);
+        var newTierRange = LootTables.GetMissileCasterSubtypeDamageRange(weaponSubtype, newTier);
+        var amountAboveMinimum = newTierRange * rollPercentile;
+        var final = newTierMinimum + amountAboveMinimum;
+
+        target.SetProperty(PropertyFloat.DamageMod, final);
+    }
+
+    private static void ScaleUpElementalDamageMod(WorldObject target, LootTables.WeaponSubtype weaponSubtype, int currentTier, int newTier)
+    {
+        if (target.ElementalDamageMod == null || target.WeaponRestorationSpellsMod == null)
+        {
+            return;
+        }
+
+        var magicSkill = target.WieldSkillType2 == 34 ? Skill.WarMagic : Skill.LifeMagic;
+        var elementalDamageMod = target.ElementalDamageMod.Value;
+        var restorationSpellMod = target.WeaponRestorationSpellsMod.Value;
+
+        var currentBaseStat = magicSkill == Skill.WarMagic ? elementalDamageMod : restorationSpellMod;
+        var currentTierMinimum = LootTables.GetMissileCasterSubtypeMinimumDamage(weaponSubtype, currentTier);
+        var currentRange = LootTables.GetMissileCasterSubtypeDamageRange(weaponSubtype, currentTier);
+        var currentRoll = currentBaseStat - currentTierMinimum;
+        var rollPercentile = (float)currentRoll / currentRange;
+
+        var newTierMinimum = LootTables.GetMissileCasterSubtypeMinimumDamage(weaponSubtype, newTier);
+        var newTierRange = LootTables.GetMissileCasterSubtypeDamageRange(weaponSubtype, newTier);
+        var amountAboveMinimum = newTierRange * rollPercentile;
+        var final = newTierMinimum + amountAboveMinimum;
+
+        if (magicSkill == Skill.WarMagic)
+        {
+            target.SetProperty(PropertyFloat.ElementalDamageMod, final);
+            target.SetProperty(PropertyFloat.WeaponRestorationSpellsMod, 1 + (final - 1) / 2);
+        }
+        else
+        {
+            target.SetProperty(PropertyFloat.WeaponRestorationSpellsMod, final);
+            target.SetProperty(PropertyFloat.ElementalDamageMod, 1 + (final - 1) / 2);
+        }
+    }
+
+    private static void ScaleUpWeaponOffense(WorldObject target, int currentTier, int newTier)
+    {
+        var currentStat = target.WeaponOffense;
+
+        if (currentStat == null)
+        {
+            return;
+        }
+
+        var currentTierBonus = LootTables.WeaponOffenseModBonusPerTier[currentTier];
+        var newTierBonus = LootTables.WeaponOffenseModBonusPerTier[newTier];
+        var difference = newTierBonus - currentTierBonus;
+
+        var final = currentStat.Value + difference;
+
+        target.SetProperty(PropertyFloat.WeaponOffense, final);
+    }
+
+    private static void ScaleUpWeaponPhysicalDefense(WorldObject target, int currentTier, int newTier)
+    {
+        var currentStat = target.WeaponPhysicalDefense;
+
+        if (currentStat == null)
+        {
+            return;
+        }
+
+        var currentTierBonus = LootTables.WeaponDefenseModBonusPerTier[currentTier];
+        var newTierBonus = LootTables.WeaponDefenseModBonusPerTier[newTier];
+        var difference = newTierBonus - currentTierBonus;
+
+        var final = currentStat.Value + difference;
+
+        target.SetProperty(PropertyFloat.WeaponPhysicalDefense, final);
+    }
+
+    private static void ScaleUpWeaponMagicDefense(WorldObject target, int currentTier, int newTier)
+    {
+        var currentStat = target.WeaponMagicalDefense;
+
+        if (currentStat == null)
+        {
+            return;
+        }
+
+        var currentTierBonus = LootTables.WeaponDefenseModBonusPerTier[currentTier];
+        var newTierBonus = LootTables.WeaponDefenseModBonusPerTier[newTier];
+        var difference = newTierBonus - currentTierBonus;
+
+        var final = currentStat.Value + difference;
+
+        target.SetProperty(PropertyFloat.WeaponMagicalDefense, final);
+    }
+
+    private static void ScaleUpWeaponSkillMod(PropertyFloat property, WorldObject target, int currentTier, int newTier)
+    {
+        var currentStat = target.GetProperty(property);
+
+        if (currentStat == null)
+        {
+            return;
+        }
+
+        var currentTierBonus = LootTables.WeaponSkillModBonusPerTier[currentTier];
+        var newTierBonus = LootTables.WeaponSkillModBonusPerTier[newTier];
+        var difference = newTierBonus - currentTierBonus;
+
+        var final = currentStat.Value + difference;
+
+        target.SetProperty(property, final);
+    }
+
+    private static void ScaleUpArmorLevel(WorldObject target, int currentTier, int newTier)
+    {
+        if (target.ArmorLevel == null)
+        {
+            return;
+        }
+
+        var armorStyleBaseArmorLevel = 50;
+
+        if (target.ArmorStyle != null)
+        {
+            switch ((ArmorStyle)target.ArmorStyle)
+            {
+                case ACE.Entity.Enum.ArmorStyle.Amuli:
+                case ACE.Entity.Enum.ArmorStyle.Chiran:
+                case ACE.Entity.Enum.ArmorStyle.OlthoiAmuli:
+                case ACE.Entity.Enum.ArmorStyle.Leather:
+                case ACE.Entity.Enum.ArmorStyle.Yoroi:
+                case ACE.Entity.Enum.ArmorStyle.Lorica:
+                case ACE.Entity.Enum.ArmorStyle.Buckler:
+                case ACE.Entity.Enum.ArmorStyle.SmallShield:
+                    armorStyleBaseArmorLevel = 75;
+                    break;
+                case ACE.Entity.Enum.ArmorStyle.StuddedLeather:
+                case ACE.Entity.Enum.ArmorStyle.Koujia:
+                case ACE.Entity.Enum.ArmorStyle.OlthoiKoujia:
+                    armorStyleBaseArmorLevel = 90;
+                    break;
+                case ACE.Entity.Enum.ArmorStyle.Chainmail:
+                case ACE.Entity.Enum.ArmorStyle.Scalemail:
+                case ACE.Entity.Enum.ArmorStyle.Nariyid:
+                case ACE.Entity.Enum.ArmorStyle.StandardShield:
+                    armorStyleBaseArmorLevel = 100;
+                    break;
+                case ACE.Entity.Enum.ArmorStyle.LargeShield:
+                    armorStyleBaseArmorLevel = 105;
+                    break;
+                case ACE.Entity.Enum.ArmorStyle.Platemail:
+                case ACE.Entity.Enum.ArmorStyle.Celdon:
+                case ACE.Entity.Enum.ArmorStyle.OlthoiCeldon:
+                case ACE.Entity.Enum.ArmorStyle.TowerShield:
+                    armorStyleBaseArmorLevel = 110;
+                    break;
+                case ACE.Entity.Enum.ArmorStyle.Covenant:
+                case ACE.Entity.Enum.ArmorStyle.OlthoiArmor:
+                case ACE.Entity.Enum.ArmorStyle.CovenantShield:
+                    armorStyleBaseArmorLevel = 125;
+                    break;
+            }
+        }
+
+        var currentLevel = target.ArmorLevel.Value;
+        var currentTierMinimum = armorStyleBaseArmorLevel * Math.Clamp(currentTier, 1, 7);
+        var rolledAmount = currentLevel - currentTierMinimum;
+
+        var newTierMinimum = armorStyleBaseArmorLevel * Math.Clamp(newTier, 1, 7);
+        var final = newTierMinimum + rolledAmount;
+
+        target.SetProperty(PropertyInt.ArmorLevel, final);
+    }
+
+    private static void ScaleUpWardLevel(WorldObject target, int currentTier, int newTier)
+    {
+        if (target.WardLevel == null)
+        {
+            return;
+        }
+
+        var armorStyleBaseWardLevel = 10;
+
+        if (target.ArmorStyle != null)
+        {
+            switch ((ArmorStyle)target.ArmorStyle)
+            {
+                case ACE.Entity.Enum.ArmorStyle.CovenantShield:
+                    armorStyleBaseWardLevel = 10;
+                    break;
+                case ACE.Entity.Enum.ArmorStyle.TowerShield:
+                    armorStyleBaseWardLevel = 8;
+                    break;
+                case ACE.Entity.Enum.ArmorStyle.Amuli:
+                case ACE.Entity.Enum.ArmorStyle.Chiran:
+                case ACE.Entity.Enum.ArmorStyle.OlthoiAmuli:
+                case ACE.Entity.Enum.ArmorStyle.LargeShield:
+                    armorStyleBaseWardLevel = 7;
+                    break;
+                case ACE.Entity.Enum.ArmorStyle.StandardShield:
+                    armorStyleBaseWardLevel = 6;
+                    break;
+                case ACE.Entity.Enum.ArmorStyle.Buckler:
+                case ACE.Entity.Enum.ArmorStyle.SmallShield:
+                    armorStyleBaseWardLevel = 5;
+                    break;
+                case ACE.Entity.Enum.ArmorStyle.Leather:
+                case ACE.Entity.Enum.ArmorStyle.StuddedLeather:
+                case ACE.Entity.Enum.ArmorStyle.Koujia:
+                case ACE.Entity.Enum.ArmorStyle.OlthoiKoujia:
+                case ACE.Entity.Enum.ArmorStyle.Chainmail:
+                case ACE.Entity.Enum.ArmorStyle.Scalemail:
+                case ACE.Entity.Enum.ArmorStyle.Nariyid:
+                case ACE.Entity.Enum.ArmorStyle.Platemail:
+                case ACE.Entity.Enum.ArmorStyle.Celdon:
+                case ACE.Entity.Enum.ArmorStyle.OlthoiCeldon:
+                case ACE.Entity.Enum.ArmorStyle.Covenant:
+                case ACE.Entity.Enum.ArmorStyle.OlthoiArmor:
+                    armorStyleBaseWardLevel = 5;
+                    break;
+            }
+        }
+
+        var currentLevel = target.WardLevel.Value;
+        var currentTierMinimum = armorStyleBaseWardLevel * Math.Clamp(currentTier, 1, 7);
+        var rolledAmount = currentLevel - currentTierMinimum;
+
+        var newTierMinimum = armorStyleBaseWardLevel * Math.Clamp(newTier, 1, 7);
+        var final = newTierMinimum + rolledAmount;
+
+        target.SetProperty(PropertyInt.WardLevel, final);
+    }
+
+    private static void ScaleUpArmorSkillMod(PropertyFloat property, WorldObject target, int currentTier, int newTier)
+    {
+        var currentStat = target.GetProperty(property);
+
+        if (currentStat == null)
+        {
+            return;
+        }
+
+        var currentTierBonus = LootTables.ArmorSkillModBonusPerTier[currentTier];
+        var newTierBonus = LootTables.ArmorSkillModBonusPerTier[newTier];
+        var difference = newTierBonus - currentTierBonus;
+
+        var final = currentStat.Value + difference;
+
+        target.SetProperty(property, final);
+    }
+
+    private static void ScaleUpJewelryWardLevel(WorldObject target, int currentTier, int newTier)
+    {
+        var currentBaseStat = target.GetProperty(PropertyInt.WardLevel);
+
+        if (currentBaseStat == null)
+        {
+            return;
+        }
+
+        var jewelryBaseWardLevelPerTier = LootTables.JewelryBaseWardLeverPerTier;
+
+        var currentBaseLevelFromTier = jewelryBaseWardLevelPerTier[currentTier];
+        var currentRange = jewelryBaseWardLevelPerTier[currentTier + 1] - jewelryBaseWardLevelPerTier[currentTier];
+        var currentRoll = currentBaseStat - currentBaseLevelFromTier;
+
+        var rollPercentile = (float)currentRoll / currentRange;
+
+        var newTierRange = jewelryBaseWardLevelPerTier[newTier + 1] - jewelryBaseWardLevelPerTier[newTier];
+        var amountAboveMinimum = newTierRange * rollPercentile;
+
+        var newBaseLevelFromTier = jewelryBaseWardLevelPerTier[newTier];
+        var final = Convert.ToInt32(newBaseLevelFromTier + amountAboveMinimum);
+
+        target.SetProperty(PropertyInt.WardLevel, final);
+    }
+
+    private static void ScaleUpJewelryRating(PropertyInt property, WorldObject target, int currentTier, int newTier)
+    {
+        var currentBaseStat = target.GetProperty(property);
+
+        if (currentBaseStat == null)
+        {
+            return;
+        }
+
+        var jewelryBaseRatingPerTier = LootTables.JewelryBaseRatingPerTier;
+
+        var currentBaseLevelFromTier = jewelryBaseRatingPerTier[currentTier];
+        var currentRange = currentBaseLevelFromTier;
+        var currentRoll = currentBaseStat - currentBaseLevelFromTier;
+
+        var rollPercentile = (float)currentRoll / currentRange;
+
+        var newTierRange = jewelryBaseRatingPerTier[newTier];
+        var amountAboveMinimum = newTierRange * rollPercentile;
+
+        var newBaseLevelFromTier = jewelryBaseRatingPerTier[newTier];
+        
+        var final = Convert.ToInt32(newBaseLevelFromTier + amountAboveMinimum);
+
+        target.SetProperty(property, final);
+    }
+
+    private static void ScaleUpItemMana(WorldObject target, int newTier)
+    {
+        var slots = 1;
+
+        if (target.IsTwoHanded || target.WeenieType == WeenieType.MissileLauncher)
+        {
+            slots = 2;
+        }
+        else if (target.ArmorSlots != null)
+        {
+            slots = target.ArmorSlots.Value;
+        }
+
+        var manaRate = LootTables.QuestItemManaRate[slots - 1][newTier];
+        target.SetProperty(PropertyFloat.ManaRate, manaRate);
+
+        var totalMana = LootTables.QuestItemTotalMana[slots - 1][newTier];
+        target.SetProperty(PropertyInt.ItemMaxMana, totalMana);
+        target.SetProperty(PropertyInt.ItemCurMana, totalMana);
+    }
+
+    private static void ScaleUpSpells(WorldObject target, int currentTier, int newTier)
+    {
+        if (newTier is < 3 or > 7)
+        {
+            return;
+        }
+
+        if (currentTier % 2 == 0 && newTier == currentTier + 1)
+        {
+            return;
+        }
+
+        var spellBook = target.Biota.PropertiesSpellBook;
+
+        if (spellBook == null)
+        {
+            return;
+        }
+
+        var spellsToRemove = new List<int>();
+        var spellsToAdd = new List<int>();
+
+        foreach (var spellId in spellBook.Keys)
+        {
+            spellsToRemove.Add(spellId);
+
+            var minimumLevelSpellId = SpellLevelProgression.GetLevel1SpellId((SpellId)spellId);
+
+            switch (newTier)
+            {
+                case 3:
+                case 4:
+                    spellsToAdd.Add((int)SpellLevelProgression.GetSpellAtLevel(minimumLevelSpellId, 2, true));
+                    break;
+                case 5:
+                case 6:
+                    spellsToAdd.Add((int)SpellLevelProgression.GetSpellAtLevel(minimumLevelSpellId, 3, true));
+                    break;
+                case 7:
+                    spellsToAdd.Add((int)SpellLevelProgression.GetSpellAtLevel(minimumLevelSpellId, 4, true));
+                    break;
+            }
+        }
+
+        foreach (var spellId in spellsToRemove)
+        {
+            target.Biota.TryRemoveKnownSpell(spellId, target.BiotaDatabaseLock);
+        }
+
+        foreach (var spellId in spellsToAdd)
+        {
+            target.Biota.GetOrAddKnownSpell(spellId, target.BiotaDatabaseLock, out _);
+        }
     }
 }

--- a/apps/server/WorldObjects/WorldObject.cs
+++ b/apps/server/WorldObjects/WorldObject.cs
@@ -1703,18 +1703,34 @@ public abstract partial class WorldObject : IActor
         }
     }
 
-    public bool? MutableQuestItem
+    public bool MutableQuestItem
     {
-        get => GetProperty(PropertyBool.MutableQuestItem);
+        get => GetProperty(PropertyBool.MutableQuestItem) ?? false;
         set
         {
-            if (!value.HasValue)
+            if (!value)
             {
                 RemoveProperty(PropertyBool.MutableQuestItem);
             }
             else
             {
-                SetProperty(PropertyBool.MutableQuestItem, value.Value);
+                SetProperty(PropertyBool.MutableQuestItem, value);
+            }
+        }
+    }
+
+    public bool UpgradeableQuestItem
+    {
+        get => GetProperty(PropertyBool.UpgradeableQuestItem) ?? false;
+        set
+        {
+            if (!value)
+            {
+                RemoveProperty(PropertyBool.UpgradeableQuestItem);
+            }
+            else
+            {
+                SetProperty(PropertyBool.UpgradeableQuestItem, value);
             }
         }
     }

--- a/libs/entity/Enum/ArmorStyle.cs
+++ b/libs/entity/Enum/ArmorStyle.cs
@@ -20,5 +20,11 @@ public enum ArmorStyle
     OlthoiCeldon,
     OlthoiAmuli,
     OlthoiKoujia,
-    OlthoiArmor
+    OlthoiArmor,
+    Buckler,
+    SmallShield,
+    StandardShield,
+    LargeShield,
+    TowerShield,
+    CovenantShield
 };

--- a/libs/entity/Enum/Properties/PropertyBool.cs
+++ b/libs/entity/Enum/Properties/PropertyBool.cs
@@ -231,6 +231,7 @@ public enum PropertyBool : ushort
     IsBankContainer = 151,
     ShroudKillXpReward = 152,
     IsPlayerTierChest = 153,
+    UpgradeableQuestItem = 154,
 
     /* custom */
     [ServerOnly]

--- a/libs/entity/Enum/WeenieType.cs
+++ b/libs/entity/Enum/WeenieType.cs
@@ -82,5 +82,6 @@ public enum WeenieType : uint
     SpellTransference,
     RetainingChisel,
     TailoringKit,
-    CombatFocusAlterationGem
+    CombatFocusAlterationGem,
+    UpgradeKit
 }


### PR DESCRIPTION
- A new item that can be earned through completing capstone dungeons.
- Can be used on quest gear items that have the 'UpgradeableQuestItem' flag. (mostly capstone quest gear)
- If the player can wield a higher tier version of the quest item, it will be upgraded to the highest possible tier the player can wield.
- All stats on the item scale up to the new tier, retaining the "roll qualities" that the item mutated to when the player picked it up initially.
   - Includes damage, damage mod, elemental damage mod, resto mod, armor level, ward level, attack/defense mods, skill mods, ratings, and spells.
   - Also sets the correct total mana and mana rate for the new tier.
   - TODO: Scale spellcraft.
- Add and refactor some code in the Loottable class.