### PR TITLE
feat: update dungeon instancing system

### DIFF
--- a/ACE.sln.DotSettings
+++ b/ACE.sln.DotSettings
@@ -1,0 +1,3 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=landblocks/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=lugian/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/apps/server/Command/Handlers/AdminCommands.cs
+++ b/apps/server/Command/Handlers/AdminCommands.cs
@@ -2604,34 +2604,32 @@ public static class AdminCommands
                     {
                         var landblock = LandblockManager.GetLandblock(instance, false);
 
-                        var permittedPlayers = "";
-                        foreach (var playerName in landblock.CapstonePlayers.Keys)
-                        {
-                            if (landblock.CapstonePlayers.TryGetValue(playerName, out var timer))
-                            {
-                                if (timer != 0)
-                                {
-                                    var convertedTime = (timer + 60 - Time.GetUnixTime()) / 60;
-                                    permittedPlayers += $"{playerName} ({Math.Round(convertedTime, 1)} min.), ";
-                                }
-                                else
-                                {
-                                    permittedPlayers += $"{playerName}, ";
-                                }
-                            }
-                        }
                         var activePlayers = "";
                         foreach (var activePlayer in landblock.ActivePlayers)
                         {
                             activePlayers += $"{activePlayer.Name}, ";
                         }
 
+                        var fellowshipPlayers = "";
+                        var landblockFellowship = landblock.CapstoneFellowship;
+                        var landblockFellowshipCount = 0;
+                        if (landblockFellowship != null)
+                        {
+                            foreach (var fellow in landblockFellowship.GetFellowshipMembers())
+                            {
+                                fellowshipPlayers += $"{fellow.Value.Name}, ";
+                                landblockFellowshipCount++;
+                            }
+                        }
+
                         instanceNum++;
-                        var dormant = landblock.IsDormant ? "|    Dormant" : "";
+                        var dormant = landblock.IsDormant ? $"| Dormant: {Math.Round(landblock.timeDormant.TotalMinutes, 1)} min." : "";
                         var uptime = landblock.CapstoneUptime / 60;
-                        var lockout = landblock.CapstoneLockout ? "|   Locked" : "";
                         session.Player.SendMessage(
-                            $"----------{dungeonName}----------\nInstance Number: {instanceNum}   |  Uptime: {Math.Round(uptime, 1)} min.   {dormant}     {lockout}\nPermitted Players ({landblock.CapstonePlayers.Count}): {permittedPlayers} \nActive Players ({landblock.ActivePlayers.Count}): {activePlayers} ",
+                            $"----------{dungeonName}----------\n" +
+                            $"Instance Number: {instanceNum} ({landblock.Id}) | Uptime: {Math.Round(uptime, 1)} min.   {dormant}\n" +
+                            $"Active Players ({landblock.ActivePlayers.Count}): {activePlayers}\n" +
+                            $"Players in Fellowship ({landblockFellowshipCount}): {fellowshipPlayers}",
                             ChatMessageType.System
                         );
                     }

--- a/apps/server/Entity/Fellowship.cs
+++ b/apps/server/Entity/Fellowship.cs
@@ -441,6 +441,18 @@ public class Fellowship
 
                     member.Fellowship = null;
                     member.FellowedWithPatron = false;
+
+                    if (member.CurrentLandblock.IsFellowshipRequired())
+                    {
+                        member.Session.Network.EnqueueSend(
+                            new GameMessageSystemChat(
+                                "This area requires a fellowship. Teleporting home.",
+                                ChatMessageType.Broadcast
+                            )
+                        );
+
+                        WorldManager.ThreadSafeTeleport(member, member.Sanctuary);
+                    }
                 }
             }
             else
@@ -466,6 +478,18 @@ public class Fellowship
                         ChatMessageType.Broadcast
                     )
                 );
+
+                if (player.CurrentLandblock.IsFellowshipRequired())
+                {
+                    player.Session.Network.EnqueueSend(
+                        new GameMessageSystemChat(
+                            "This area requires a fellowship. Teleporting home.",
+                            ChatMessageType.Broadcast
+                        )
+                    );
+
+                    WorldManager.ThreadSafeTeleport(player, player.Sanctuary);
+                }
 
                 var fellowshipMembers = GetFellowshipMembers();
 
@@ -536,6 +560,18 @@ public class Fellowship
 
             player.Fellowship = null;
             player.FellowedWithPatron = false;
+
+            if (player.CurrentLandblock.IsFellowshipRequired())
+            {
+                player.Session.Network.EnqueueSend(
+                    new GameMessageSystemChat(
+                        "This area requires a fellowship. Teleporting home.",
+                        ChatMessageType.Broadcast
+                    )
+                );
+
+                WorldManager.ThreadSafeTeleport(player, player.Sanctuary);
+            }
 
             CalculateXPSharing();
             UpdateAllMembers();

--- a/apps/server/Entity/Landblock.cs
+++ b/apps/server/Entity/Landblock.cs
@@ -69,6 +69,7 @@ public class Landblock : IActor
     public bool CreateWorldObjectsCompleted { get; private set; }
 
     private DateTime lastActiveTime;
+    public TimeSpan timeDormant;
 
     /// <summary>
     /// Dormant landblocks suppress Monster AI ticking and physics processing
@@ -174,14 +175,9 @@ public class Landblock : IActor
             return PlayerList;
         }
     }
-    public Dictionary<string, double> CapstonePlayers = new Dictionary<string, double>();
 
-    public bool CapstoneLockout = false;
-
-    public static int CapstoneMax = 10;
-
-    public static readonly double CapstoneSeatHolder = 600;
-
+    public Fellowship CapstoneFellowship;
+    public Dictionary<string, double> CapstonePlayers = new();
     public double CapstoneUptime = 0;
 
     public List<uint> PlayerAccountIds = new List<uint>();
@@ -680,50 +676,11 @@ public class Landblock : IActor
                 }
             }
 
-            // Check and update capstone player list and check for lockout
             if (CapstoneTeleportLocations.Keys.Contains(Id))
             {
                 CapstoneUptime += 5;
-
-                foreach (var playerName in CapstonePlayers.Keys)
-                {
-                    if (CapstonePlayers.TryGetValue(playerName, out var timer))
-                    {
-                        var activePlayers = new List<string> { };
-
-                        foreach (var activePlayer in players)
-                        {
-                            activePlayers.Add(activePlayer.Name);
-                        }
-
-                        if (!activePlayers.Contains(playerName))
-                        {
-                            if (timer == 0)
-                            {
-                                CapstonePlayers[playerName] = Time.GetUnixTime();
-                            }
-                            else if (timer + CapstoneSeatHolder < Time.GetUnixTime())
-                            {
-                                CapstonePlayers.Remove(playerName);
-                            }
-                        }
-                    }
-                }
-                if (CapstoneLockout == false)
-                {
-                    foreach (var wo in worldObjects.Values)
-                    {
-                        if (wo.DungeonLockout.HasValue)
-                        {
-                            if (wo.DungeonLockout == true)
-                            {
-                                CapstoneLockout = true;
-                                break;
-                            }
-                        }
-                    }
-                }
             }
+
             foreach (var player in players)
             {
                 if (player.PatronAccountId != null)
@@ -762,6 +719,8 @@ public class Landblock : IActor
 
             //log.Info($"Landblock {Id.ToString()}.Tick({currentUnixTime}).Landblock_Tick_Heartbeat: thisHeartBeat: {thisHeartBeat.ToString()} | lastHeartBeat: {lastHeartBeat.ToString()} | worldObjects.Count: {worldObjects.Count()}");
             lastHeartBeat = thisHeartBeat;
+
+            timeDormant = lastHeartBeat - lastActiveTime;
         }
         ServerPerformanceMonitor.AddToCumulativeEvent(
             ServerPerformanceMonitor.CumulativeEventHistoryType.Landblock_Tick_Heartbeat,
@@ -1531,6 +1490,9 @@ public class Landblock : IActor
             }
         }
 
+        // clear capstone fellowships
+        CapstoneFellowship = null;
+
         ProcessPendingWorldObjectAdditionsAndRemovals();
 
         actionQueue.Clear();
@@ -1794,252 +1756,145 @@ public class Landblock : IActor
     {
         var dungeonLandblocks = CapstoneDungeonLists(dungeonName);
 
-        if (dungeonLandblocks != null)
+        if (dungeonLandblocks == null)
         {
-            if (player.Fellowship != null)
-            {
-                var fellow = player.Fellowship;
+            return;
+        }
 
-                if (fellow.CapstoneDungeon.HasValue && dungeonLandblocks.Contains((LandblockId)fellow.CapstoneDungeon))
-                {
-                    var landblock = LandblockManager.GetLandblock((LandblockId)fellow.CapstoneDungeon, false);
+        if (player.Fellowship == null)
+        {
+            player.Session.Network.EnqueueSend(
+                new GameMessageSystemChat(
+                    $"You must be in a fellowship to enter this dungeon.",
+                    ChatMessageType.Broadcast
+                )
+            );
 
-                    if (landblock.CapstonePlayers.Keys.Contains(player.Name))
-                    {
-                        CapstoneTeleport(player, landblock);
-                    }
-                    else if (landblock.CapstoneLockout == false)
-                    {
-                        var openSlots = landblock.CapstonePlayers.Keys.Count >= CapstoneMax ? false : true;
+            return;
+        }
 
-                        if (openSlots)
-                        {
-                            CapstoneTeleport(player, landblock);
-                        }
-                        else
-                        {
-                            player.Session.Network.EnqueueSend(
-                                new GameMessageSystemChat(
-                                    $"You cannot join your fellowship at this time, as their instance of the dungeon is full. You may choose to either leave your fellowship and try again or wait for a slot to open, up to ten minutes after a player leaves the dungeon.",
-                                    ChatMessageType.Broadcast
-                                )
-                            );
-                        }
-                    }
-                }
-                else
-                {
-                    FindOpenInstanceFellowship(player, dungeonLandblocks, dungeonName);
-                }
-            }
-            // No Fellowship
-            else
-            {
-                if (player.CapstoneDungeon.HasValue && dungeonLandblocks.Contains((LandblockId)player.CapstoneDungeon))
-                {
-                    var landblock = LandblockManager.GetLandblock((LandblockId)player.CapstoneDungeon, false);
+        var fellowship = player.Fellowship;
 
-                    if (landblock.CapstonePlayers.Keys.Contains(player.Name))
-                    {
-                        CapstoneTeleport(player, landblock);
-                    }
-                    else if (landblock.CapstonePlayers.Count < CapstoneMax && landblock.CapstoneLockout == false)
-                    {
-                        CapstoneTeleport(player, landblock);
-                    }
-                    else
-                    {
-                        FindOpenInstance(player, dungeonLandblocks);
-                    }
-                }
-                else
-                {
-                    FindOpenInstance(player, dungeonLandblocks);
-                }
-            }
+        if (fellowship.CapstoneDungeon.HasValue && dungeonLandblocks.Contains((LandblockId)fellowship.CapstoneDungeon))
+        {
+            var landblock = LandblockManager.GetLandblock((LandblockId)fellowship.CapstoneDungeon, false);
+
+            CapstoneTeleport(player, landblock);
+        }
+        else
+        {
+            FindOpenInstanceFellowship(player, dungeonLandblocks, dungeonName);
         }
     }
 
-    public static void FindOpenInstance(Player player, List<LandblockId> dungeonLandblocks)
-    {
-        foreach (var landblockId in dungeonLandblocks)
-        {
-            var landblock = LandblockManager.GetLandblock(landblockId, false);
-
-            if (landblock.CapstoneLockout)
-            {
-                continue;
-            }
-
-            if (landblock.CapstonePlayers.Count < CapstoneMax)
-            {
-                CapstoneTeleport(player, landblock);
-                return;
-            }
-        }
-        player.Session.Network.EnqueueSend(
-            new GameMessageSystemChat(
-                $"Unfortunately, there are no open slots in any instance of this dungeon. That's a lot of players, wow! Sorry, but wow!",
-                ChatMessageType.Broadcast
-            )
-        );
-        return;
-    }
-
-    public static void FindOpenInstanceFellowship(
+    private static void FindOpenInstanceFellowship(
         Player player,
         List<LandblockId> dungeonLandblocks,
         string dungeonName
     )
     {
-        var fellow = player.Fellowship;
-        var fellowCount = fellow.FellowshipMembers.Count;
+        var fellowship = player.Fellowship;
 
         foreach (var landblockId in dungeonLandblocks)
         {
             var landblock = LandblockManager.GetLandblock(landblockId, false);
 
-            if (landblock.CapstoneLockout)
+            if (landblock.CapstoneFellowship != null)
             {
                 continue;
             }
 
-            if (landblock.CapstonePlayers.Count + fellowCount <= CapstoneMax)
-            {
-                fellow.CapstoneDungeon = landblock.Id;
+            landblock.CapstoneFellowship = fellowship;
+            fellowship.CapstoneDungeon = landblockId;
 
-                var fellowMembers = fellow.GetFellowshipMembers();
-                foreach (var member in fellowMembers.Values)
-                {
-                    if (landblock.CapstonePlayers.Keys.Contains(member.Name))
-                    {
-                        continue;
-                    }
-
-                    landblock.CapstonePlayers.Add(member.Name, Time.GetUnixTime());
-
-                    if (member.Guid != player.Guid)
-                    {
-                        member.Session.Network.EnqueueSend(
-                            new GameMessageSystemChat(
-                                $"{player.Name} has entered {dungeonName}. If you join them in the next ten minutes, you will be guaranteed a place in the same instance. After the time limit has expired, another player may take your slot.",
-                                ChatMessageType.Broadcast
-                            )
-                        );
-                    }
-                }
-                CapstoneTeleport(player, landblock);
-                break;
-            }
-        }
-        if (fellow.CapstoneDungeon == null)
-        {
-            player.Session.Network.EnqueueSend(
-                new GameMessageSystemChat(
-                    $"There are no instances of this dungeon with enough open slots to fit your entire fellowship.",
-                    ChatMessageType.Broadcast
-                )
-            );
+            CapstoneTeleport(player, landblock);
             return;
         }
+
+        player.Session.Network.EnqueueSend(
+            new GameMessageSystemChat(
+                $"There are no free instances of this dungeon available at the moment.",
+                ChatMessageType.Broadcast
+            )
+        );
+
+        WorldManager.ThreadSafeTeleport(player, player.Sanctuary);
     }
 
     public static void CapstoneTeleport(Player player, Landblock landblock)
     {
-        if (!landblock.CapstonePlayers.Keys.Contains(player.Name))
-        {
-            landblock.CapstonePlayers.Add(player.Name, 0);
-        }
-
-        if (landblock.CapstonePlayers.Keys.Contains(player.Name) && landblock.CapstonePlayers[player.Name] > 0)
-        {
-            landblock.CapstonePlayers[player.Name] = 0;
-        }
-
-        // checks active instances of this dungeon and player's previous capstone, and removes them from permitted list
-        // this is to prevent potential griefing (however unlikely) and ensure slots open speedily
-        /* if (player.CapstoneDungeon.HasValue)
-             dungeonLandblocks.Add((LandblockId)player.CapstoneDungeon);
-
-         foreach (var landblockId in dungeonLandblocks)
-         {
-             if (landblockId != landblock.Id && LandblockManager.IsLoaded(landblockId))
-             {
-                 var otherDungeon = LandblockManager.GetLandblock(landblockId, false);
-                 if (otherDungeon.CapstonePlayers.Keys.Contains(player))
-                     otherDungeon.CapstonePlayers.Remove(player);
-             }
-         } */
         player.CapstoneDungeon = landblock.Id;
 
-        if (CapstoneTeleportLocations.TryGetValue(landblock.Id, out var destination))
+        if (!CapstoneTeleportLocations.TryGetValue(landblock.Id, out var destination))
         {
-            WorldObject.AdjustDungeon(destination);
-            WorldManager.ThreadSafeTeleport(player, destination);
+            return;
         }
+
+        WorldObject.AdjustDungeon(destination);
+        WorldManager.ThreadSafeTeleport(player, destination);
     }
 
     public static List<LandblockId> CapstoneDungeonLists(string dungeonName)
     {
-        var dungeonLandblocks = new uint[] { };
+        uint[] dungeonLandblocks;
 
         switch (dungeonName)
         {
             //T0
             case "Glenden Wood Dungeon":
-                dungeonLandblocks = new uint[] { 0x01E3, 0x13FE, 0x13FD, 0x13FC, 0x13FB, 0x13FA };
+                dungeonLandblocks = [0x01E3, 0x13FE, 0x13FD, 0x13FC, 0x13FB, 0x13FA];
                 break;
             case "Green Mire Grave":
-                dungeonLandblocks = new uint[] { 0x01E5, 0x09FE, 0x09FD, 0x09FC, 0x09FB, 0x09FA };
+                dungeonLandblocks = [0x01E5, 0x09FE, 0x09FD, 0x09FC, 0x09FB, 0x09FA];
                 break;
             case "Sand Shallow":
-                dungeonLandblocks = new uint[] { 0x02A0, 0x0EFE, 0x0EFD, 0x0EFC, 0x0EFB, 0x0EFA };
+                dungeonLandblocks = [0x02A0, 0x0EFE, 0x0EFD, 0x0EFC, 0x0EFB, 0x0EFA];
                 break;
             // T1
             case "Manse of Panderlou":
-                dungeonLandblocks = new uint[] { 0x01ED, 0x14FE, 0x14FD, 0x14FC, 0x14FB, 0x14FA };
+                dungeonLandblocks = [0x01ED, 0x14FE, 0x14FD, 0x14FC, 0x14FB, 0x14FA];
                 break;
             case "Smugglers Hideaway":
-                dungeonLandblocks = new uint[] { 0x014E, 0x0AFE, 0x0AFD, 0x0AFC, 0x0AFB, 0x0AFA };
+                dungeonLandblocks = [0x014E, 0x0AFE, 0x0AFD, 0x0AFC, 0x0AFB, 0x0AFA];
                 break;
             case "Halls of the Helm":
-                dungeonLandblocks = new uint[] { 0x01CC, 0x0FFE, 0x0FFD, 0x0FFC, 0x0FFB, 0x0FFA };
+                dungeonLandblocks = [0x01CC, 0x0FFE, 0x0FFD, 0x0FFC, 0x0FFB, 0x0FFA];
                 break;
             // T2
             case "Colier Mine":
-                dungeonLandblocks = new uint[] { 0x01AE, 0x18FE, 0x18FD, 0x18FC, 0x18FB, 0x18FA };
+                dungeonLandblocks = [0x01AE, 0x18FE, 0x18FD, 0x18FC, 0x18FB, 0x18FA];
                 break;
             case "Empyrean Garrison":
-                dungeonLandblocks = new uint[] { 0x0161, 0x0BFE, 0x0BFD, 0x0BFC, 0x0BFB, 0x0BFA };
+                dungeonLandblocks = [0x0161, 0x0BFE, 0x0BFD, 0x0BFC, 0x0BFB, 0x0BFA];
                 break;
             case "Grievous Vault":
-                dungeonLandblocks = new uint[] { 0x0189, 0x10FE, 0x10FD, 0x10FC, 0x10FB, 0x10FA };
+                dungeonLandblocks = [0x0189, 0x10FE, 0x10FD, 0x10FC, 0x10FB, 0x10FA];
                 break;
             // T3
             case "Folthid Cellar":
-                dungeonLandblocks = new uint[] { 0x013B, 0x19FE, 0x19FD, 0x19FC, 0x19FB, 0x19FA };
+                dungeonLandblocks = [0x013B, 0x19FE, 0x19FD, 0x19FC, 0x19FB, 0x19FA];
                 break;
             case "Mines of Despair":
-                dungeonLandblocks = new uint[] { 0x0188, 0x0CFE, 0x0CFD, 0x0CFC, 0x0CFB, 0x0CFA };
+                dungeonLandblocks = [0x0188, 0x0CFE, 0x0CFD, 0x0CFC, 0x0CFB, 0x0CFA];
                 break;
             case "Beyond the Mines":
-                dungeonLandblocks = new uint[] { 0x02AB, 0x0DFE, 0x0DFD, 0x0DFC, 0x0DFB, 0x0DFA };
+                dungeonLandblocks = [0x02AB, 0x0DFE, 0x0DFD, 0x0DFC, 0x0DFB, 0x0DFA];
                 break;
             case "Gredaline Consulate":
-                dungeonLandblocks = new uint[] { 0x029B, 0x11FE, 0x11FD, 0x11FC, 0x11FB, 0x11FA };
+                dungeonLandblocks = [0x029B, 0x11FE, 0x11FD, 0x11FC, 0x11FB, 0x11FA];
                 break;
             // T4
             case "Mage Academy":
-                dungeonLandblocks = new uint[] { 0x0139, 0x15FE, 0x15FD, 0x15FC, 0x15FB, 0x15FA };
+                dungeonLandblocks = [0x0139, 0x15FE, 0x15FD, 0x15FC, 0x15FB, 0x15FA];
                 break;
             case "Lugian Mines":
-                dungeonLandblocks = new uint[] { 0x02E9, 0x16FE, 0x16FD, 0x16FC, 0x16FB, 0x16FA };
+                dungeonLandblocks = [0x02E9, 0x16FE, 0x16FD, 0x16FC, 0x16FB, 0x16FA];
                 break;
             case "Lugian Mines2":
-                dungeonLandblocks = new uint[] { 0x02E7, 0x17FE, 0x17FD, 0x17FC, 0x17FB, 0x17FA };
+                dungeonLandblocks = [0x02E7, 0x17FE, 0x17FD, 0x17FC, 0x17FB, 0x17FA];
                 break;
             case "Mountain Fortress":
-                dungeonLandblocks = new uint[] { 0x011C, 0x12FE, 0x12FD, 0x12FC, 0x12FB, 0x12FA };
+                dungeonLandblocks = [0x011C, 0x12FE, 0x12FD, 0x12FC, 0x12FB, 0x12FA];
                 break;
             default:
                 return null;
@@ -2058,7 +1913,7 @@ public class Landblock : IActor
         return null;
     }
 
-    public static Dictionary<LandblockId, Position> CapstoneTeleportLocations = new Dictionary<LandblockId, Position>
+    public static readonly Dictionary<LandblockId, Position> CapstoneTeleportLocations = new()
     {
         // Glenden Wood Dungeon
         { new LandblockId(0x01E3 << 16 | 0xFFFF), new Position(0x01E303B9, 159.847f, -165.469f, 6.005f, 0, 0, 0, 1) },
@@ -2068,10 +1923,7 @@ public class Landblock : IActor
         { new LandblockId(0x13FB << 16 | 0xFFFF), new Position(0x13FB30B9, 159.847f, -165.469f, 6.005f, 0, 0, 0, 1) },
         { new LandblockId(0x13FA << 16 | 0xFFFF), new Position(0x13FA30B9, 159.847f, -165.469f, 6.005f, 0, 0, 0, 1) },
         // Green Mire Grave   0x09FE020F [80.487862 -79.122993 0.005000] -0.000000 0.000000 0.000000 1.000000
-        {
-            new LandblockId(0x01E5 << 16 | 0xFFFF),
-            new Position(0x01E5020F, 80.1099f, -80.136284f, 0.005f, 0, 0, 1, 0)
-        },
+        { new LandblockId(0x01E5 << 16 | 0xFFFF), new Position(0x01E5020F, 80.1099f, -80.136284f, 0.005f, 0, 0, 1, 0) },
         { new LandblockId(0x09FE << 16 | 0xFFFF), new Position(0x09FE020F, 80.1099f, -80.136284f, 0.005f, 0, 0, 1, 0) },
         { new LandblockId(0x09FD << 16 | 0xFFFF), new Position(0x09FD020F, 80.1099f, -80.136284f, 0.005f, 0, 0, 1, 0) },
         { new LandblockId(0x09FC << 16 | 0xFFFF), new Position(0x09FC020F, 80.1099f, -80.136284f, 0.005f, 0, 0, 1, 0) },
@@ -2085,30 +1937,12 @@ public class Landblock : IActor
         { new LandblockId(0x0EFB << 16 | 0xFFFF), new Position(0x0EFB02F5, 290f, -340f, 0.005f, 0f, 0f, 0f, 1f) },
         { new LandblockId(0x0EFA << 16 | 0xFFFF), new Position(0x0EFA02F5, 290f, -340f, 0.005f, 0f, 0f, 0f, 1f) },
         // Manse of Panderlou 0x01ED, 0x14FE, 0x14FD, 0x14FC, 0x14FB, 0x14FA
-        {
-            new LandblockId(0x01ED << 16 | 0xFFFF),
-            new Position(0x01ED0310, 120.1193f, -3.697473f, 12.004999f, 0f, 0f, -1f, 0f)
-        },
-        {
-            new LandblockId(0x14FE << 16 | 0xFFFF),
-            new Position(0x14FE0310, 120.1193f, -3.697473f, 12.004999f, 0f, 0f, -1f, 0f)
-        },
-        {
-            new LandblockId(0x14FD << 16 | 0xFFFF),
-            new Position(0x14FD0310, 120.1193f, -3.697473f, 12.004999f, 0f, 0f, -1f, 0f)
-        },
-        {
-            new LandblockId(0x14FC << 16 | 0xFFFF),
-            new Position(0x14FC0310, 120.1193f, -3.697473f, 12.004999f, 0f, 0f, -1f, 0f)
-        },
-        {
-            new LandblockId(0x14FB << 16 | 0xFFFF),
-            new Position(0x14FB0310, 120.1193f, -3.697473f, 12.004999f, 0f, 0f, -1f, 0f)
-        },
-        {
-            new LandblockId(0x14FA << 16 | 0xFFFF),
-            new Position(0x14FA0310, 120.1193f, -3.697473f, 12.004999f, 0f, 0f, -1f, 0f)
-        },
+        { new LandblockId(0x01ED << 16 | 0xFFFF), new Position(0x01ED0310, 120.1193f, -3.697473f, 12.004999f, 0f, 0f, -1f, 0f) },
+        { new LandblockId(0x14FE << 16 | 0xFFFF), new Position(0x14FE0310, 120.1193f, -3.697473f, 12.004999f, 0f, 0f, -1f, 0f) },
+        { new LandblockId(0x14FD << 16 | 0xFFFF), new Position(0x14FD0310, 120.1193f, -3.697473f, 12.004999f, 0f, 0f, -1f, 0f) },
+        { new LandblockId(0x14FC << 16 | 0xFFFF), new Position(0x14FC0310, 120.1193f, -3.697473f, 12.004999f, 0f, 0f, -1f, 0f) },
+        { new LandblockId(0x14FB << 16 | 0xFFFF), new Position(0x14FB0310, 120.1193f, -3.697473f, 12.004999f, 0f, 0f, -1f, 0f) },
+        { new LandblockId(0x14FA << 16 | 0xFFFF), new Position(0x14FA0310, 120.1193f, -3.697473f, 12.004999f, 0f, 0f, -1f, 0f) },
         // Smuggler's Hideaway  0x014E, 0x0AFE, 0x0AFD, 0x0AFC, 0x0AFB, 0x0AFA
         { new LandblockId(0x014E << 16 | 0xFFFF), new Position(0x014E025C, 190f, -10f, 0f, 0f, 0f, -1f, 0f) },
         { new LandblockId(0x0AFE << 16 | 0xFFFF), new Position(0x0AFE025C, 190f, -10f, 0f, 0f, 0f, -1f, 0f) },
@@ -2131,80 +1965,26 @@ public class Landblock : IActor
         { new LandblockId(0x18FB << 16 | 0xFFFF), new Position(0x18FB032C, 76.59f, -97.36f, 0f, 0f, 0f, 0f, 1f) },
         { new LandblockId(0x18FA << 16 | 0xFFFF), new Position(0x18FA032C, 76.59f, -97.36f, 0f, 0f, 0f, 0f, 1f) },
         // Empyrean Garrison  0x0161, 0x0BFE, 0x0BFD, 0x0BFC, 0x0BFB, 0x0BFA
-        {
-            new LandblockId(0x0161 << 16 | 0xFFFF),
-            new Position(0x01610264, 80f, -80f, 0f, 0f, 0f, -0.707107f, -0.707107f)
-        },
-        {
-            new LandblockId(0x0BFE << 16 | 0xFFFF),
-            new Position(0x0BFE0264, 80f, -80f, 0f, 0f, 0f, -0.707107f, -0.707107f)
-        },
-        {
-            new LandblockId(0x0BFD << 16 | 0xFFFF),
-            new Position(0x0BFD0264, 80f, -80f, 0f, 0f, 0f, -0.707107f, -0.707107f)
-        },
-        {
-            new LandblockId(0x0BFC << 16 | 0xFFFF),
-            new Position(0x0BFC0264, 80f, -80f, 0f, 0f, 0f, -0.707107f, -0.707107f)
-        },
-        {
-            new LandblockId(0x0BFB << 16 | 0xFFFF),
-            new Position(0x0BFB0264, 80f, -80f, 0f, 0f, 0f, -0.707107f, -0.707107f)
-        },
-        {
-            new LandblockId(0x0BFA << 16 | 0xFFFF),
-            new Position(0x0BFA0264, 80f, -80f, 0f, 0f, 0f, -0.707107f, -0.707107f)
-        },
+        { new LandblockId(0x0161 << 16 | 0xFFFF), new Position(0x01610264, 80f, -80f, 0f, 0f, 0f, -0.707107f, -0.707107f) },
+        { new LandblockId(0x0BFE << 16 | 0xFFFF), new Position(0x0BFE0264, 80f, -80f, 0f, 0f, 0f, -0.707107f, -0.707107f) },
+        { new LandblockId(0x0BFD << 16 | 0xFFFF), new Position(0x0BFD0264, 80f, -80f, 0f, 0f, 0f, -0.707107f, -0.707107f) },
+        { new LandblockId(0x0BFC << 16 | 0xFFFF), new Position(0x0BFC0264, 80f, -80f, 0f, 0f, 0f, -0.707107f, -0.707107f) },
+        { new LandblockId(0x0BFB << 16 | 0xFFFF), new Position(0x0BFB0264, 80f, -80f, 0f, 0f, 0f, -0.707107f, -0.707107f) },
+        { new LandblockId(0x0BFA << 16 | 0xFFFF), new Position(0x0BFA0264, 80f, -80f, 0f, 0f, 0f, -0.707107f, -0.707107f) },
         // Grievous Vault 0x0189, 0x10FE, 0x10FD, 0x10FC, 0x10FB, 0x10FA
-        {
-            new LandblockId(0x0189 << 16 | 0xFFFF),
-            new Position(0x01890321, 139.792f, -66.582f, 6.005f, 0f, 0f, -1f, 0f)
-        },
-        {
-            new LandblockId(0x10FE << 16 | 0xFFFF),
-            new Position(0x10FE0321, 139.792f, -66.582f, 6.005f, 0f, 0f, -1f, 0f)
-        },
-        {
-            new LandblockId(0x10FD << 16 | 0xFFFF),
-            new Position(0x10FD0321, 139.792f, -66.582f, 6.005f, 0f, 0f, -1f, 0f)
-        },
-        {
-            new LandblockId(0x10FC << 16 | 0xFFFF),
-            new Position(0x10FC0321, 139.792f, -66.582f, 6.005f, 0f, 0f, -1f, 0f)
-        },
-        {
-            new LandblockId(0x10FB << 16 | 0xFFFF),
-            new Position(0x10FB0321, 139.792f, -66.582f, 6.005f, 0f, 0f, -1f, 0f)
-        },
-        {
-            new LandblockId(0x10FA << 16 | 0xFFFF),
-            new Position(0x10FA0321, 139.792f, -66.582f, 6.005f, 0f, 0f, -1f, 0f)
-        },
+        { new LandblockId(0x0189 << 16 | 0xFFFF), new Position(0x01890321, 139.792f, -66.582f, 6.005f, 0f, 0f, -1f, 0f) },
+        { new LandblockId(0x10FE << 16 | 0xFFFF), new Position(0x10FE0321, 139.792f, -66.582f, 6.005f, 0f, 0f, -1f, 0f) },
+        { new LandblockId(0x10FD << 16 | 0xFFFF), new Position(0x10FD0321, 139.792f, -66.582f, 6.005f, 0f, 0f, -1f, 0f) },
+        { new LandblockId(0x10FC << 16 | 0xFFFF), new Position(0x10FC0321, 139.792f, -66.582f, 6.005f, 0f, 0f, -1f, 0f) },
+        { new LandblockId(0x10FB << 16 | 0xFFFF), new Position(0x10FB0321, 139.792f, -66.582f, 6.005f, 0f, 0f, -1f, 0f) },
+        { new LandblockId(0x10FA << 16 | 0xFFFF), new Position(0x10FA0321, 139.792f, -66.582f, 6.005f, 0f, 0f, -1f, 0f) },
         // Folthid Cellar 0x013B, 0x19FE, 0x19FD, 0x19FC, 0x19FB, 0x19FA
-        {
-            new LandblockId(0x013B << 16 | 0xFFFF),
-            new Position(0x013B0336, 62.5684F, -109.99126F, 0.005F, 0, 0, -0.707107f, 0.707107f)
-        },
-        {
-            new LandblockId(0x19FE << 16 | 0xFFFF),
-            new Position(0x19FE0336, 62.5684F, -109.99126F, 0.005F, 0, 0, -0.707107f, 0.707107f)
-        },
-        {
-            new LandblockId(0x19FD << 16 | 0xFFFF),
-            new Position(0x19FD0336, 62.5684F, -109.99126F, 0.005F, 0, 0, -0.707107f, 0.707107f)
-        },
-        {
-            new LandblockId(0x19FC << 16 | 0xFFFF),
-            new Position(0x19FC0336, 62.5684F, -109.99126F, 0.005F, 0, 0, -0.707107f, 0.707107f)
-        },
-        {
-            new LandblockId(0x19FB << 16 | 0xFFFF),
-            new Position(0x19FB0336, 62.5684F, -109.99126F, 0.005F, 0, 0, -0.707107f, 0.707107f)
-        },
-        {
-            new LandblockId(0x19FA << 16 | 0xFFFF),
-            new Position(0x19FA0336, 62.5684F, -109.99126F, 0.005F, 0, 0, -0.707107f, 0.707107f)
-        },
+        { new LandblockId(0x013B << 16 | 0xFFFF), new Position(0x013B0336, 62.5684F, -109.99126F, 0.005F, 0, 0, -0.707107f, 0.707107f) },
+        { new LandblockId(0x19FE << 16 | 0xFFFF), new Position(0x19FE0336, 62.5684F, -109.99126F, 0.005F, 0, 0, -0.707107f, 0.707107f) },
+        { new LandblockId(0x19FD << 16 | 0xFFFF), new Position(0x19FD0336, 62.5684F, -109.99126F, 0.005F, 0, 0, -0.707107f, 0.707107f) },
+        { new LandblockId(0x19FC << 16 | 0xFFFF), new Position(0x19FC0336, 62.5684F, -109.99126F, 0.005F, 0, 0, -0.707107f, 0.707107f) },
+        { new LandblockId(0x19FB << 16 | 0xFFFF), new Position(0x19FB0336, 62.5684F, -109.99126F, 0.005F, 0, 0, -0.707107f, 0.707107f) },
+        { new LandblockId(0x19FA << 16 | 0xFFFF), new Position(0x19FA0336, 62.5684F, -109.99126F, 0.005F, 0, 0, -0.707107f, 0.707107f) },
         // Mines of Despair 0x0188, 0x0CFE, 0x0CFD, 0x0CFC, 0x0CFB, 0x0CFA
         { new LandblockId(0x0188 << 16 | 0xFFFF), new Position(0x01880307, 30f, -70f, 0f, 0f, 0f, 0f, 1f) },
         { new LandblockId(0x0CFE << 16 | 0xFFFF), new Position(0x0CFE0307, 30f, -70f, 0f, 0f, 0f, 0f, 1f) },
@@ -2213,55 +1993,19 @@ public class Landblock : IActor
         { new LandblockId(0x0CFB << 16 | 0xFFFF), new Position(0x0CFB0307, 30f, -70f, 0f, 0f, 0f, 0f, 1f) },
         { new LandblockId(0x0CFA << 16 | 0xFFFF), new Position(0x0CFA0307, 30f, -70f, 0f, 0f, 0f, 0f, 1f) },
         // Beyond the Mines of Despair  0x02AB, 0x0DFE, 0x0DFD, 0x0DFC, 0x0DFB, 0x0DFA
-        {
-            new LandblockId(0x02AB << 16 | 0xFFFF),
-            new Position(0x02AB0160, 110f, -10f, 0f, 0f, 0f, -0.707107f, 0.707107f)
-        },
-        {
-            new LandblockId(0x0DFE << 16 | 0xFFFF),
-            new Position(0x0DFE0160, 110f, -10f, 0f, 0f, 0f, -0.707107f, 0.707107f)
-        },
-        {
-            new LandblockId(0x0DFD << 16 | 0xFFFF),
-            new Position(0x0DFD0160, 110f, -10f, 0f, 0f, 0f, -0.707107f, 0.707107f)
-        },
-        {
-            new LandblockId(0x0DFC << 16 | 0xFFFF),
-            new Position(0x0DFC0160, 110f, -10f, 0f, 0f, 0f, -0.707107f, 0.707107f)
-        },
-        {
-            new LandblockId(0x0DFB << 16 | 0xFFFF),
-            new Position(0x0DFB0160, 110f, -10f, 0f, 0f, 0f, -0.707107f, 0.707107f)
-        },
-        {
-            new LandblockId(0x0DFA << 16 | 0xFFFF),
-            new Position(0x0DFA0160, 110f, -10f, 0f, 0f, 0f, -0.707107f, 0.707107f)
-        },
+        { new LandblockId(0x02AB << 16 | 0xFFFF), new Position(0x02AB0160, 110f, -10f, 0f, 0f, 0f, -0.707107f, 0.707107f) },
+        { new LandblockId(0x0DFE << 16 | 0xFFFF), new Position(0x0DFE0160, 110f, -10f, 0f, 0f, 0f, -0.707107f, 0.707107f) },
+        { new LandblockId(0x0DFD << 16 | 0xFFFF), new Position(0x0DFD0160, 110f, -10f, 0f, 0f, 0f, -0.707107f, 0.707107f) },
+        { new LandblockId(0x0DFC << 16 | 0xFFFF), new Position(0x0DFC0160, 110f, -10f, 0f, 0f, 0f, -0.707107f, 0.707107f) },
+        { new LandblockId(0x0DFB << 16 | 0xFFFF), new Position(0x0DFB0160, 110f, -10f, 0f, 0f, 0f, -0.707107f, 0.707107f) },
+        { new LandblockId(0x0DFA << 16 | 0xFFFF), new Position(0x0DFA0160, 110f, -10f, 0f, 0f, 0f, -0.707107f, 0.707107f) },
         // Gredaline Consulate   0x029B, 0x11FE, 0x11FD, 0x11FC, 0x11FB, 0x11FA
-        {
-            new LandblockId(0x029B << 16 | 0xFFFF),
-            new Position(0x029B0317, 279.8409f, -292.3339f, 6.005f, 0f, 0f, 1f, 0f)
-        },
-        {
-            new LandblockId(0x11FE << 16 | 0xFFFF),
-            new Position(0x11FE0317, 279.8409f, -292.3339f, 6.005f, 0f, 0f, 1f, 0f)
-        },
-        {
-            new LandblockId(0x11FD << 16 | 0xFFFF),
-            new Position(0x11FD0317, 279.8409f, -292.3339f, 6.005f, 0f, 0f, 1f, 0f)
-        },
-        {
-            new LandblockId(0x11FC << 16 | 0xFFFF),
-            new Position(0x11FC0317, 279.8409f, -292.3339f, 6.005f, 0f, 0f, 1f, 0f)
-        },
-        {
-            new LandblockId(0x11FB << 16 | 0xFFFF),
-            new Position(0x11FB0317, 279.8409f, -292.3339f, 6.005f, 0f, 0f, 1f, 0f)
-        },
-        {
-            new LandblockId(0x11FA << 16 | 0xFFFF),
-            new Position(0x11FA0317, 279.8409f, -292.3339f, 6.005f, 0f, 0f, 1f, 0f)
-        },
+        { new LandblockId(0x029B << 16 | 0xFFFF), new Position(0x029B0317, 279.8409f, -292.3339f, 6.005f, 0f, 0f, 1f, 0f) },
+        { new LandblockId(0x11FE << 16 | 0xFFFF), new Position(0x11FE0317, 279.8409f, -292.3339f, 6.005f, 0f, 0f, 1f, 0f) },
+        { new LandblockId(0x11FD << 16 | 0xFFFF), new Position(0x11FD0317, 279.8409f, -292.3339f, 6.005f, 0f, 0f, 1f, 0f) },
+        { new LandblockId(0x11FC << 16 | 0xFFFF), new Position(0x11FC0317, 279.8409f, -292.3339f, 6.005f, 0f, 0f, 1f, 0f) },
+        { new LandblockId(0x11FB << 16 | 0xFFFF), new Position(0x11FB0317, 279.8409f, -292.3339f, 6.005f, 0f, 0f, 1f, 0f) },
+        { new LandblockId(0x11FA << 16 | 0xFFFF), new Position(0x11FA0317, 279.8409f, -292.3339f, 6.005f, 0f, 0f, 1f, 0f) },
         // Mage Academy 0x0139, 0x15FE, 0x15FD, 0x15FC, 0x15FB, 0x15FA
         { new LandblockId(0x0139 << 16 | 0xFFFF), new Position(0x01390396, 40f, -60f, 6f, 0f, 0f, -1f, 0f) },
         { new LandblockId(0x15FE << 16 | 0xFFFF), new Position(0x15FE0396, 40f, -60f, 6f, 0f, 0f, -1f, 0f) },
@@ -2270,81 +2014,53 @@ public class Landblock : IActor
         { new LandblockId(0x15FB << 16 | 0xFFFF), new Position(0x15FB0396, 40f, -60f, 6f, 0f, 0f, -1f, 0f) },
         { new LandblockId(0x15FA << 16 | 0xFFFF), new Position(0x15FA0396, 40f, -60f, 6f, 0f, 0f, -1f, 0f) },
         // Lugian Mines 0x02E9, 0x16FE, 0x16FD, 0x16FC, 0x16FB, 0x16FA
-        {
-            new LandblockId(0x02E9 << 16 | 0xFFFF),
-            new Position(0x02E9010E, 70.0493f, -480.134f, -11.995f, 0f, 0f, -0.701483f, 0.712686f)
-        },
-        {
-            new LandblockId(0x16FE << 16 | 0xFFFF),
-            new Position(0x16FE010E, 70.0493f, -480.134f, -11.995f, 0f, 0f, -0.701483f, 0.712686f)
-        },
-        {
-            new LandblockId(0x16FD << 16 | 0xFFFF),
-            new Position(0x16FD010E, 70.0493f, -480.134f, -11.995f, 0f, 0f, -0.701483f, 0.712686f)
-        },
-        {
-            new LandblockId(0x16FC << 16 | 0xFFFF),
-            new Position(0x16FC010E, 70.0493f, -480.134f, -11.995f, 0f, 0f, -0.701483f, 0.712686f)
-        },
-        {
-            new LandblockId(0x16FB << 16 | 0xFFFF),
-            new Position(0x16FB010E, 70.0493f, -480.134f, -11.995f, 0f, 0f, -0.701483f, 0.712686f)
-        },
-        {
-            new LandblockId(0x16FA << 16 | 0xFFFF),
-            new Position(0x16FA010E, 70.0493f, -480.134f, -11.995f, 0f, 0f, -0.701483f, 0.712686f)
-        },
+        { new LandblockId(0x02E9 << 16 | 0xFFFF), new Position(0x02E9010E, 70.0493f, -480.134f, -11.995f, 0f, 0f, -0.701483f, 0.712686f) },
+        { new LandblockId(0x16FE << 16 | 0xFFFF), new Position(0x16FE010E, 70.0493f, -480.134f, -11.995f, 0f, 0f, -0.701483f, 0.712686f) },
+        { new LandblockId(0x16FD << 16 | 0xFFFF), new Position(0x16FD010E, 70.0493f, -480.134f, -11.995f, 0f, 0f, -0.701483f, 0.712686f) },
+        { new LandblockId(0x16FC << 16 | 0xFFFF), new Position(0x16FC010E, 70.0493f, -480.134f, -11.995f, 0f, 0f, -0.701483f, 0.712686f) },
+        { new LandblockId(0x16FB << 16 | 0xFFFF), new Position(0x16FB010E, 70.0493f, -480.134f, -11.995f, 0f, 0f, -0.701483f, 0.712686f) },
+        { new LandblockId(0x16FA << 16 | 0xFFFF), new Position(0x16FA010E, 70.0493f, -480.134f, -11.995f, 0f, 0f, -0.701483f, 0.712686f) },
         // Deeper into Lugian Mines 0x02E7, 0x17FE, 0x17FD, 0x17FC, 0x17FB, 0x17FA
-        {
-            new LandblockId(0x02E7 << 16 | 0xFFFF),
-            new Position(0x02E70282, 509.92538f, -13.700772f, 12.004999f, 0f, 0f, 1f, 0f)
-        },
-        {
-            new LandblockId(0x17FE << 16 | 0xFFFF),
-            new Position(0x17FE0282, 509.92538f, -13.700772f, 12.004999f, 0f, 0f, 1f, 0f)
-        },
-        {
-            new LandblockId(0x17FD << 16 | 0xFFFF),
-            new Position(0x17FD0282, 509.92538f, -13.700772f, 12.004999f, 0f, 0f, 1f, 0f)
-        },
-        {
-            new LandblockId(0x17FC << 16 | 0xFFFF),
-            new Position(0x17FC0282, 509.92538f, -13.700772f, 12.004999f, 0f, 0f, 1f, 0f)
-        },
-        {
-            new LandblockId(0x17FB << 16 | 0xFFFF),
-            new Position(0x17FB0282, 509.92538f, -13.700772f, 12.004999f, 0f, 0f, 1f, 0f)
-        },
-        {
-            new LandblockId(0x17FA << 16 | 0xFFFF),
-            new Position(0x17FA0282, 509.92538f, -13.700772f, 12.004999f, 0f, 0f, 1f, 0f)
-        },
+        { new LandblockId(0x02E7 << 16 | 0xFFFF), new Position(0x02E70282, 509.92538f, -13.700772f, 12.004999f, 0f, 0f, 1f, 0f) },
+        { new LandblockId(0x17FE << 16 | 0xFFFF), new Position(0x17FE0282, 509.92538f, -13.700772f, 12.004999f, 0f, 0f, 1f, 0f) },
+        { new LandblockId(0x17FD << 16 | 0xFFFF), new Position(0x17FD0282, 509.92538f, -13.700772f, 12.004999f, 0f, 0f, 1f, 0f) },
+        { new LandblockId(0x17FC << 16 | 0xFFFF), new Position(0x17FC0282, 509.92538f, -13.700772f, 12.004999f, 0f, 0f, 1f, 0f) },
+        { new LandblockId(0x17FB << 16 | 0xFFFF), new Position(0x17FB0282, 509.92538f, -13.700772f, 12.004999f, 0f, 0f, 1f, 0f) },
+        { new LandblockId(0x17FA << 16 | 0xFFFF), new Position(0x17FA0282, 509.92538f, -13.700772f, 12.004999f, 0f, 0f, 1f, 0f) },
         // Mountain Fortress 0x011C, 0x12FE, 0x12FD, 0x12FC, 0x12FB, 0x12FA
-        {
-            new LandblockId(0x011C << 16 | 0xFFFF),
-            new Position(0x011C030F, 100.572f, -160.084f, 0.005f, 0f, 0f, 0.711837f, 0.702345f)
-        },
-        {
-            new LandblockId(0x12FE << 16 | 0xFFFF),
-            new Position(0x12FE030F, 100.572f, -160.084f, 0.005f, 0f, 0f, 0.711837f, 0.702345f)
-        },
-        {
-            new LandblockId(0x12FD << 16 | 0xFFFF),
-            new Position(0x12FD030F, 100.572f, -160.084f, 0.005f, 0f, 0f, 0.711837f, 0.702345f)
-        },
-        {
-            new LandblockId(0x12FC << 16 | 0xFFFF),
-            new Position(0x12FC030F, 100.572f, -160.084f, 0.005f, 0f, 0f, 0.711837f, 0.702345f)
-        },
-        {
-            new LandblockId(0x12FB << 16 | 0xFFFF),
-            new Position(0x12FB030F, 100.572f, -160.084f, 0.005f, 0f, 0f, 0.711837f, 0.702345f)
-        },
-        {
-            new LandblockId(0x12FA << 16 | 0xFFFF),
-            new Position(0x12FA030F, 100.572f, -160.084f, 0.005f, 0f, 0f, 0.711837f, 0.702345f)
-        },
+        { new LandblockId(0x011C << 16 | 0xFFFF), new Position(0x011C030F, 100.572f, -160.084f, 0.005f, 0f, 0f, 0.711837f, 0.702345f) },
+        { new LandblockId(0x12FE << 16 | 0xFFFF), new Position(0x12FE030F, 100.572f, -160.084f, 0.005f, 0f, 0f, 0.711837f, 0.702345f) },
+        { new LandblockId(0x12FD << 16 | 0xFFFF), new Position(0x12FD030F, 100.572f, -160.084f, 0.005f, 0f, 0f, 0.711837f, 0.702345f) },
+        { new LandblockId(0x12FC << 16 | 0xFFFF), new Position(0x12FC030F, 100.572f, -160.084f, 0.005f, 0f, 0f, 0.711837f, 0.702345f) },
+        { new LandblockId(0x12FB << 16 | 0xFFFF), new Position(0x12FB030F, 100.572f, -160.084f, 0.005f, 0f, 0f, 0.711837f, 0.702345f) },
+        { new LandblockId(0x12FA << 16 | 0xFFFF), new Position(0x12FA030F, 100.572f, -160.084f, 0.005f, 0f, 0f, 0.711837f, 0.702345f) },
     };
+
+    public bool IsFellowshipRequired()
+    {
+        return FellowshipRequiredLandblocksIds.Contains(Id.Landblock);
+    }
+
+    private static List<uint> FellowshipRequiredLandblocksIds =
+        [
+            0x01E3, 0x13FE, 0x13FD, 0x13FC, 0x13FB, 0x13FA, // "Glenden Wood Dungeon"
+            0x01E5, 0x09FE, 0x09FD, 0x09FC, 0x09FB, 0x09FA, // "Green Mire Grave"
+            0x02A0, 0x0EFE, 0x0EFD, 0x0EFC, 0x0EFB, 0x0EFA, // "Sand Shallow"
+            0x01ED, 0x14FE, 0x14FD, 0x14FC, 0x14FB, 0x14FA, // "Manse of Panderlou"
+            0x014E, 0x0AFE, 0x0AFD, 0x0AFC, 0x0AFB, 0x0AFA, // "Smugglers Hideaway"
+            0x01CC, 0x0FFE, 0x0FFD, 0x0FFC, 0x0FFB, 0x0FFA, // "Halls of the Helm"
+            0x01AE, 0x18FE, 0x18FD, 0x18FC, 0x18FB, 0x18FA, // "Colier Mine"
+            0x0161, 0x0BFE, 0x0BFD, 0x0BFC, 0x0BFB, 0x0BFA, // "Empyrean Garrison"
+            0x0189, 0x10FE, 0x10FD, 0x10FC, 0x10FB, 0x10FA, // "Grievous Vault"
+            0x013B, 0x19FE, 0x19FD, 0x19FC, 0x19FB, 0x19FA, // "Folthid Cellar"
+            0x0188, 0x0CFE, 0x0CFD, 0x0CFC, 0x0CFB, 0x0CFA, // "Mines of Despair"
+            0x02AB, 0x0DFE, 0x0DFD, 0x0DFC, 0x0DFB, 0x0DFA, // "Beyond the Mines"
+            0x029B, 0x11FE, 0x11FD, 0x11FC, 0x11FB, 0x11FA, // "Gredaline Consulate"
+            0x0139, 0x15FE, 0x15FD, 0x15FC, 0x15FB, 0x15FA, // "Mage Academy"
+            0x02E9, 0x16FE, 0x16FD, 0x16FC, 0x16FB, 0x16FA, // "Lugian Mines"
+            0x02E7, 0x17FE, 0x17FD, 0x17FC, 0x17FB, 0x17FA, // "Lugian Mines2"
+            0x011C, 0x12FE, 0x12FD, 0x12FC, 0x12FB, 0x12FA // "Mountain Fortress"
+        ];
 
     private void IncreaseMinimumEncounterSpawnDensity(List<Encounter> encounters, List<uint> generatedEncounterIdList)
     {

--- a/apps/server/WorldObjects/Player_Location.cs
+++ b/apps/server/WorldObjects/Player_Location.cs
@@ -1028,29 +1028,26 @@ partial class Player
     {
         var landblockId = new LandblockId(player.Location.Landblock << 16 | 0xFFFF);
 
-        if (!Landblock.CapstoneTeleportLocations.Keys.Contains(landblockId))
+        if (!Landblock.CapstoneTeleportLocations.ContainsKey(landblockId))
         {
             return;
         }
 
         var landblock = LandblockManager.GetLandblock(landblockId, false);
 
-        if (landblock.CapstonePlayers.Keys.Contains(player.Name))
+        if (landblock.CapstonePlayers.ContainsKey(player.Name))
         {
             landblock.CapstonePlayers[player.Name] = 0;
             return;
         }
 
-        if (!landblock.CapstonePlayers.Keys.Contains(player.Name))
+        if (landblock.CapstonePlayers.Keys.Count < 9)
         {
-            if (landblock.CapstoneLockout == false && landblock.CapstonePlayers.Keys.Count < Landblock.CapstoneMax)
-            {
-                Landblock.CapstoneTeleport(player, landblock);
-            }
-            else
-            {
-                session.Player.Location = new Position(session.Player.Sanctuary);
-            }
+            Landblock.CapstoneTeleport(player, landblock);
+        }
+        else
+        {
+            session.Player.Location = new Position(session.Player.Sanctuary);
         }
     }
 

--- a/apps/server/WorldObjects/Portal.cs
+++ b/apps/server/WorldObjects/Portal.cs
@@ -317,6 +317,18 @@ public partial class Portal : WorldObject
             }
         }
 
+        // handle attempting to enter a capstone dungeon without being in a fellowship
+        if (FellowshipRequired && player.Fellowship == null)
+        {
+            player.Session.Network.EnqueueSend(
+                new GameMessageSystemChat(
+                    $"You must be in a fellowship to enter this portal.",
+                    ChatMessageType.System
+                )
+            );
+            return new ActivationResult(false);
+        }
+
         // handle quest initial flagging
         if (Quest != null)
         {

--- a/apps/server/WorldObjects/WorldObject_Properties.cs
+++ b/apps/server/WorldObjects/WorldObject_Properties.cs
@@ -8796,6 +8796,22 @@ partial class WorldObject
         }
     }
 
+    public bool FellowshipRequired
+    {
+        get => GetProperty(PropertyBool.FellowshipRequired) ?? false;
+        set
+        {
+            if (!value)
+            {
+                RemoveProperty(PropertyBool.FellowshipRequired);
+            }
+            else
+            {
+                SetProperty(PropertyBool.FellowshipRequired, value);
+            }
+        }
+    }
+
     public string CacheLog
     {
         get => GetProperty(PropertyString.CacheLog);

--- a/libs/entity/Enum/Properties/PropertyBool.cs
+++ b/libs/entity/Enum/Properties/PropertyBool.cs
@@ -232,6 +232,7 @@ public enum PropertyBool : ushort
     ShroudKillXpReward = 152,
     IsPlayerTierChest = 153,
     UpgradeableQuestItem = 154,
+    FellowshipRequired = 155,
 
     /* custom */
     [ServerOnly]


### PR DESCRIPTION
Rework dungeon instancing system.
- Add flag FellowshipRequired that can be set on dungeon portals to require the player to be in a fellowship to enter.
- Capstone dungeon landblocks now keep track of the first fellowship that enters them.
   - Players of the fellowship will be placed in the same instance when entering a capstone dungeon.
   - Players in a different fellowship will be placed in the first available inactive instance.
   - If there are no inactive instances available, player will receive a message and be teleported to their "sanctuary" (LS).
   - Leaving the fellowship instantly teleports the player back to their "sanctuary".
   - Dungeons unload after 5 minutes "dormant" (no players inside).
- Adjusted code for admin command '/capstone <name>' to show how long the dungeon has been dormant for and each player that are in the dungeon's fellowship.