### PR TITLE
feat: add playtest config settings

### DIFF
--- a/apps/server/Factories/PlayerFactory.cs
+++ b/apps/server/Factories/PlayerFactory.cs
@@ -11,6 +11,7 @@ using ACE.Entity.Models;
 using ACE.Server.Managers;
 using ACE.Server.WorldObjects;
 using Serilog;
+using Position = ACE.Entity.Position;
 
 namespace ACE.Server.Factories;
 
@@ -544,6 +545,8 @@ public static class PlayerFactory
                 break;
         }
 
+        PlaytestSettings(player);
+
         instantiation = new Position(player.Location);
 
         player.Instantiation = new Position(instantiation);
@@ -853,5 +856,41 @@ public static class PlayerFactory
 
         // This option was seen in PCAPs on new characters, and possibly was added to Defaults post PDB we have
         player.SetCharacterOption(CharacterOption.ListenToPKDeathMessages, true);
+    }
+
+    private static void PlaytestSettings(Player player)
+    {
+        var playtestLevel = PropertyManager.GetLong("playtest_starting_level").Item;
+        if (playtestLevel <= 0)
+        {
+            return;
+        }
+
+        player.TryRemoveFromInventory(player.Inventory.FirstOrDefault(k => k.Value.Name.Contains("Starter")).Key);
+        player.TryRemoveFromInventory(player.Inventory.FirstOrDefault(k => k.Value.Name.Contains("Starter")).Key);
+
+        player.TryRemoveFromInventory(player.Inventory.FirstOrDefault(k => k.Value.WeenieClassId.Equals(4746)).Key); // Flask of Water
+        player.TryRemoveFromInventory(player.Inventory.FirstOrDefault(k => k.Value.WeenieClassId.Equals(151)).Key); // Empty Flask
+
+        player.TryRemoveFromInventory(player.Inventory.FirstOrDefault(k => k.Value.WeenieClassId.Equals(1050902)).Key); // A Guide to Magic and Spellcasting
+        player.TryRemoveFromInventory(player.Inventory.FirstOrDefault(k => k.Value.WeenieClassId.Equals(1050900)).Key); // Combat Guide
+
+        var tradeNotes = WorldObjectFactory.CreateNewWorldObject(2627); // Trade Note (100,000)
+        tradeNotes.StackSize = 100;
+        player.TryAddToInventory(tradeNotes);
+
+        player.TryAddToInventory(WorldObjectFactory.CreateNewWorldObject(1000030)); // Hotel Swank Portal Gem
+        player.TryAddToInventory(WorldObjectFactory.CreateNewWorldObject(1051111)); // Shard of Shrouding
+
+        player.Location = new Position(
+            0x018A0273,
+            120.000000f,
+            -79.900000f,
+            0.005000f,
+            0.000000f,
+            0.000000f,
+            -0.707107f,
+            -0.707107f
+        );
     }
 }

--- a/apps/server/Managers/PropertyManager.cs
+++ b/apps/server/Managers/PropertyManager.cs
@@ -679,95 +679,20 @@ public static class DefaultPropertyManager
     // ==================================================================================
 
     public static readonly ReadOnlyDictionary<string, Property<bool>> DefaultBooleanProperties = DictOf(
-        (
-            "account_login_boots_in_use",
-            new Property<bool>(true, "if FALSE, oldest connection to account is not booted when new connection occurs")
-        ),
-        (
-            "advanced_combat_pets",
-            new Property<bool>(false, "(non-retail function) If enabled, Combat Pets can cast spells")
-        ),
-        (
-            "advocate_fane_auto_bestow",
-            new Property<bool>(
-                false,
-                "If enabled, Advocate Fane will automatically bestow new advocates to advocate_fane_auto_bestow_level"
-            )
-        ),
-        (
-            "aetheria_heal_color",
-            new Property<bool>(
-                false,
-                "If enabled, changes the aetheria healing over time messages from the default retail red color to green"
-            )
-        ),
-        (
-            "allow_combat_mode_crafting",
-            new Property<bool>(
-                false,
-                "If enabled, allows players to do crafting (recipes) from all stances. Forces players to NonCombat first, then continues to recipe action."
-            )
-        ),
-        (
-            "allow_door_hold",
-            new Property<bool>(
-                true,
-                "enables retail behavior where standing on a door while it is closing keeps the door as ethereal until it is free from collisions, effectively holding the door open for other players"
-            )
-        ),
-        (
-            "allow_fast_chug",
-            new Property<bool>(
-                true,
-                "enables retail behavior where a player can consume food and drink faster than normal by breaking animation"
-            )
-        ),
-        (
-            "allow_jump_loot",
-            new Property<bool>(
-                true,
-                "enables retail behavior where a player can quickly loot items while jumping, bypassing the 'crouch down' animation"
-            )
-        ),
-        (
-            "allow_negative_dispel_resist",
-            new Property<bool>(true, "enables retail behavior where #-# negative dispels can be resisted")
-        ),
-        (
-            "allow_negative_rating_curve",
-            new Property<bool>(
-                true,
-                "enables retail behavior where negative DRR from void dots didn't switch to the reverse rating formula, resulting in a possibly unintended curve that quickly ramps up as -rating goes down, eventually approaching infinity / divide by 0 for -100 rating. less than -100 rating would produce negative numbers."
-            )
-        ),
-        (
-            "allow_pkl_bump",
-            new Property<bool>(
-                true,
-                "enables retail behavior where /pkl checks for entry collisions, bumping the player position over if standing on another PKLite. This effectively enables /pkl door skipping from retail"
-            )
-        ),
-        (
-            "allow_summoning_killtask_multicredit",
-            new Property<bool>(
-                true,
-                "enables retail behavior where a summoner can get multiple killtask credits from a monster"
-            )
-        ),
-        (
-            "assess_creature_mod",
-            new Property<bool>(
-                false,
-                "(non-retail function) If enabled, re-enables former skill formula, when assess creature skill is not trained or spec'ed"
-            )
-        ),
-        (
-            "attribute_augmentation_safety_cap",
-            new Property<bool>(
-                true,
-                "if TRUE players are not able to use attribute augmentations if the innate value of the target attribute is >= 96. All normal restrictions to these augmentations still apply."
-            )
-        ),
+        ("account_login_boots_in_use", new Property<bool>(true, "if FALSE, oldest connection to account is not booted when new connection occurs")),
+        ("advanced_combat_pets", new Property<bool>(false, "(non-retail function) If enabled, Combat Pets can cast spells")),
+        ("advocate_fane_auto_bestow", new Property<bool>(false, "If enabled, Advocate Fane will automatically bestow new advocates to advocate_fane_auto_bestow_level")),
+        ("aetheria_heal_color", new Property<bool>(false, "If enabled, changes the aetheria healing over time messages from the default retail red color to green")),
+        ("allow_combat_mode_crafting", new Property<bool>(false, "If enabled, allows players to do crafting (recipes) from all stances. Forces players to NonCombat first, then continues to recipe action.")),
+        ("allow_door_hold", new Property<bool>(true, "enables retail behavior where standing on a door while it is closing keeps the door as ethereal until it is free from collisions, effectively holding the door open for other players")),
+        ("allow_fast_chug", new Property<bool>(true, "enables retail behavior where a player can consume food and drink faster than normal by breaking animation")),
+        ("allow_jump_loot", new Property<bool>(true, "enables retail behavior where a player can quickly loot items while jumping, bypassing the 'crouch down' animation")),
+        ("allow_negative_dispel_resist", new Property<bool>(true, "enables retail behavior where #-# negative dispels can be resisted")),
+        ("allow_negative_rating_curve", new Property<bool>(true, "enables retail behavior where negative DRR from void dots didn't switch to the reverse rating formula, resulting in a possibly unintended curve that quickly ramps up as -rating goes down, eventually approaching infinity / divide by 0 for -100 rating. less than -100 rating would produce negative numbers.")),
+        ("allow_pkl_bump", new Property<bool>(true, "enables retail behavior where /pkl checks for entry collisions, bumping the player position over if standing on another PKLite. This effectively enables /pkl door skipping from retail")),
+        ("allow_summoning_killtask_multicredit", new Property<bool>(true, "enables retail behavior where a summoner can get multiple killtask credits from a monster")),
+        ("assess_creature_mod", new Property<bool>(false, "(non-retail function) If enabled, re-enables former skill formula, when assess creature skill is not trained or spec'ed")),
+        ("attribute_augmentation_safety_cap", new Property<bool>(true, "if TRUE players are not able to use attribute augmentations if the innate value of the target attribute is >= 96. All normal restrictions to these augmentations still apply.")),
         ("chat_disable_general", new Property<bool>(false, "disable general global chat channel")),
         ("chat_disable_lfg", new Property<bool>(false, "disable lfg global chat channel")),
         ("chat_disable_olthoi", new Property<bool>(false, "disable olthoi global chat channel")),
@@ -794,682 +719,150 @@ public static class DefaultPropertyManager
         ("chat_log_society", new Property<bool>(false, "log society chat")),
         ("chat_log_trade", new Property<bool>(false, "log trade chat")),
         ("chat_log_townchans", new Property<bool>(false, "log advocate town chat")),
-        (
-            "chat_requires_account_15days",
-            new Property<bool>(false, "global chat privileges requires accounts to be 15 days or older")
-        ),
+        ("chat_requires_account_15days", new Property<bool>(false, "global chat privileges requires accounts to be 15 days or older")),
         ("chess_enabled", new Property<bool>(true, "if FALSE then chess will be disabled")),
-        (
-            "client_movement_formula",
-            new Property<bool>(
-                false,
-                "If enabled, server uses DoMotion/StopMotion self-client movement methods instead of apply_raw_movement"
-            )
-        ),
-        (
-            "container_opener_name",
-            new Property<bool>(
-                false,
-                "If enabled, when a player tries to open a container that is already in use by someone else, replaces 'someone else' in the message with the actual name of the player"
-            )
-        ),
+        ("client_movement_formula", new Property<bool>(false, "If enabled, server uses DoMotion/StopMotion self-client movement methods instead of apply_raw_movement")),
+        ("container_opener_name", new Property<bool>(false, "If enabled, when a player tries to open a container that is already in use by someone else, replaces 'someone else' in the message with the actual name of the player")),
         ("corpse_decay_tick_logging", new Property<bool>(false, "If ENABLED then player corpse ticks will be logged")),
-        (
-            "corpse_destroy_pyreals",
-            new Property<bool>(true, "If FALSE then pyreals will not be completely destroyed on player death")
-        ),
-        (
-            "craft_exact_msg",
-            new Property<bool>(
-                false,
-                "If TRUE, and player has crafting chance of success dialog enabled, shows them an additional message in their chat window with exact %"
-            )
-        ),
-        (
-            "creature_name_check",
-            new Property<bool>(
-                true,
-                "if enabled, creature names in world database restricts player names during character creation"
-            )
-        ),
-        (
-            "creatures_drop_createlist_wield",
-            new Property<bool>(
-                false,
-                "If FALSE then Wielded items in CreateList will not drop. Retail defaulted to TRUE but there are currently data errors"
-            )
-        ),
-        (
-            "equipmentsetid_enabled",
-            new Property<bool>(true, "enable this to allow adding EquipmentSetIDs to loot armor")
-        ),
-        (
-            "equipmentsetid_name_decoration",
-            new Property<bool>(false, "enable this to add the EquipmentSet name to loot armor name")
-        ),
+        ("corpse_destroy_pyreals", new Property<bool>(true, "If FALSE then pyreals will not be completely destroyed on player death")),
+        ("craft_exact_msg", new Property<bool>(false, "If TRUE, and player has crafting chance of success dialog enabled, shows them an additional message in their chat window with exact %")),
+        ("creature_name_check", new Property<bool>(true, "if enabled, creature names in world database restricts player names during character creation")),
+        ("creatures_drop_createlist_wield", new Property<bool>(false, "If FALSE then Wielded items in CreateList will not drop. Retail defaulted to TRUE but there are currently data errors")),
+        ("equipmentsetid_enabled", new Property<bool>(true, "enable this to allow adding EquipmentSetIDs to loot armor")),
+        ("equipmentsetid_name_decoration", new Property<bool>(false, "enable this to add the EquipmentSet name to loot armor name")),
         ("fastbuff", new Property<bool>(true, "If TRUE, enables the fast buffing trick from retail.")),
-        (
-            "fellow_busy_no_recruit",
-            new Property<bool>(true, "if FALSE, fellows can be recruited while they are busy, different from retail")
-        ),
-        (
-            "fellow_kt_killer",
-            new Property<bool>(
-                true,
-                "if FALSE, fellowship kill tasks will share with the fellowship, even if the killer doesn't have the quest"
-            )
-        ),
-        (
-            "fellow_kt_landblock",
-            new Property<bool>(
-                false,
-                "if TRUE, fellowship kill tasks will share with landblock range (192 distance radius, or entire dungeon)"
-            )
-        ),
-        (
-            "fellow_quest_bonus",
-            new Property<bool>(
-                false,
-                "if TRUE, applies EvenShare formula to fellowship quest reward XP (300% max bonus, defaults to false in retail)"
-            )
-        ),
-        (
-            "fix_chest_missing_inventory_window",
-            new Property<bool>(
-                false,
-                "Very non-standard fix. This fixes an acclient bug where unlocking a chest, and then quickly opening it before the client has received the Locked=false update from server can result in the chest opening, but with the chest inventory window not displaying. Bug has a higher chance of appearing with more network latency."
-            )
-        ),
-        (
-            "gateway_ties_summonable",
-            new Property<bool>(
-                true,
-                "if disabled, players cannot summon ties from gateways. defaults to enabled, as in retail"
-            )
-        ),
-        (
-            "gearknight_core_plating",
-            new Property<bool>(
-                true,
-                "if disabled, Gear Knight players are not required to use core plating devices for armor and clothing. defaults to enabled, as in retail"
-            )
-        ),
-        (
-            "house_15day_account",
-            new Property<bool>(true, "if disabled, houses can be purchased with accounts created less than 15 days old")
-        ),
-        (
-            "house_30day_cooldown",
-            new Property<bool>(
-                true,
-                "if disabled, houses can be purchased without waiting 30 days between each purchase"
-            )
-        ),
+        ("fellow_busy_no_recruit", new Property<bool>(true, "if FALSE, fellows can be recruited while they are busy, different from retail")),
+        ("fellow_kt_killer", new Property<bool>(true, "if FALSE, fellowship kill tasks will share with the fellowship, even if the killer doesn't have the quest")),
+        ("fellow_kt_landblock", new Property<bool>(false, "if TRUE, fellowship kill tasks will share with landblock range (192 distance radius, or entire dungeon)")),
+        ("fellow_quest_bonus", new Property<bool>(false, "if TRUE, applies EvenShare formula to fellowship quest reward XP (300% max bonus, defaults to false in retail)")),
+        ("fix_chest_missing_inventory_window", new Property<bool>(false, "Very non-standard fix. This fixes an acclient bug where unlocking a chest, and then quickly opening it before the client has received the Locked=false update from server can result in the chest opening, but with the chest inventory window not displaying. Bug has a higher chance of appearing with more network latency.")),
+        ("gateway_ties_summonable", new Property<bool>(true, "if disabled, players cannot summon ties from gateways. defaults to enabled, as in retail")),
+        ("gearknight_core_plating", new Property<bool>(true, "if disabled, Gear Knight players are not required to use core plating devices for armor and clothing. defaults to enabled, as in retail")),
+        ("house_15day_account", new Property<bool>(true, "if disabled, houses can be purchased with accounts created less than 15 days old")),
+        ("house_30day_cooldown", new Property<bool>(true, "if disabled, houses can be purchased without waiting 30 days between each purchase")),
         ("house_hook_limit", new Property<bool>(true, "if disabled, house hook limits are ignored")),
         ("house_hookgroup_limit", new Property<bool>(true, "if disabled, house hook group limits are ignored")),
-        (
-            "house_per_char",
-            new Property<bool>(false, "if TRUE, allows 1 house per char instead of 1 house per account")
-        ),
-        (
-            "house_purchase_requirements",
-            new Property<bool>(true, "if disabled, requirements to purchase/rent house are not checked")
-        ),
+        ("house_per_char", new Property<bool>(false, "if TRUE, allows 1 house per char instead of 1 house per account")),
+        ("house_purchase_requirements", new Property<bool>(true, "if disabled, requirements to purchase/rent house are not checked")),
         ("house_rent_enabled", new Property<bool>(true, "If FALSE then rent is not required")),
-        (
-            "iou_trades",
-            new Property<bool>(
-                false,
-                "(non-retail function) If enabled, IOUs can be traded for objects that are missing in DB but added/restored later on"
-            )
-        ),
-        (
-            "item_dispel",
-            new Property<bool>(
-                false,
-                "if enabled, allows players to dispel items. defaults to end of retail, where item dispels could only target creatures"
-            )
-        ),
+        ("iou_trades", new Property<bool>(false, "(non-retail function) If enabled, IOUs can be traded for objects that are missing in DB but added/restored later on")),
+        ("item_dispel", new Property<bool>(false, "if enabled, allows players to dispel items. defaults to end of retail, where item dispels could only target creatures")),
         ("legacy_loot_system", new Property<bool>(false, "use the previous iteration of the ace lootgen system")),
-        (
-            "lifestone_broadcast_death",
-            new Property<bool>(
-                true,
-                "if true, player deaths are additionally broadcast to other players standing near the destination lifestone"
-            )
-        ),
-        (
-            "loot_quality_mod",
-            new Property<bool>(
-                true,
-                "if FALSE then the loot quality modifier of a Death Treasure profile does not affect loot generation"
-            )
-        ),
-        (
-            "npc_hairstyle_fullrange",
-            new Property<bool>(
-                false,
-                "if TRUE, allows generated creatures to use full range of hairstyles. Retail only allowed first nine (0-8) out of 51"
-            )
-        ),
-        (
-            "offline_xp_passup_limit",
-            new Property<bool>(true, "if FALSE, allows unlimited xp to passup to offline characters in allegiances")
-        ),
-        (
-            "olthoi_play_disabled",
-            new Property<bool>(false, "if false, allows players to create and play as olthoi characters")
-        ),
-        (
-            "override_encounter_spawn_rates",
-            new Property<bool>(
-                false,
-                "if enabled, landblock encounter spawns are overidden by double properties below."
-            )
-        ),
-        (
-            "permit_corpse_all",
-            new Property<bool>(
-                false,
-                "If TRUE, /permit grants permittees access to all corpses of the permitter. Defaults to FALSE as per retail, where /permit only grants access to 1 locked corpse"
-            )
-        ),
-        (
-            "persist_movement",
-            new Property<bool>(
-                false,
-                "If TRUE, persists autonomous movements such as turns and sidesteps through non-autonomous server actions. Retail didn't appear to do this, but some players may prefer this."
-            )
-        ),
-        (
-            "pet_stow_replace",
-            new Property<bool>(
-                false,
-                "pet stowing for different pet devices becomes a stow and replace. defaults to retail value of false"
-            )
-        ),
-        (
-            "player_config_command",
-            new Property<bool>(false, "If enabled, players can use /config to change their settings via text commands")
-        ),
-        (
-            "player_receive_immediate_save",
-            new Property<bool>(
-                false,
-                "if enabled, when the player receives items from an NPC, they will be saved immediately"
-            )
-        ),
+        ("lifestone_broadcast_death", new Property<bool>(true, "if true, player deaths are additionally broadcast to other players standing near the destination lifestone")),
+        ("loot_quality_mod", new Property<bool>(true, "if FALSE then the loot quality modifier of a Death Treasure profile does not affect loot generation")),
+        ("npc_hairstyle_fullrange", new Property<bool>(false, "if TRUE, allows generated creatures to use full range of hairstyles. Retail only allowed first nine (0-8) out of 51")),
+        ("offline_xp_passup_limit", new Property<bool>(true, "if FALSE, allows unlimited xp to passup to offline characters in allegiances")),
+        ("olthoi_play_disabled", new Property<bool>(false, "if false, allows players to create and play as olthoi characters")),
+        ("override_encounter_spawn_rates", new Property<bool>(false, "if enabled, landblock encounter spawns are overidden by double properties below.")),
+        ("permit_corpse_all", new Property<bool>(false, "If TRUE, /permit grants permittees access to all corpses of the permitter. Defaults to FALSE as per retail, where /permit only grants access to 1 locked corpse")),
+        ("persist_movement", new Property<bool>(false, "If TRUE, persists autonomous movements such as turns and sidesteps through non-autonomous server actions. Retail didn't appear to do this, but some players may prefer this.")),
+        ("pet_stow_replace", new Property<bool>(false, "pet stowing for different pet devices becomes a stow and replace. defaults to retail value of false")),
+        ("player_config_command", new Property<bool>(false, "If enabled, players can use /config to change their settings via text commands")),
+        ("player_receive_immediate_save", new Property<bool>(false, "if enabled, when the player receives items from an NPC, they will be saved immediately")),
         ("pk_server", new Property<bool>(false, "set this to TRUE for darktide servers")),
-        (
-            "pk_server_safe_training_academy",
-            new Property<bool>(
-                false,
-                "set this to TRUE to disable pk fighting in training academy and time to exit starter town safely"
-            )
-        ),
+        ("pk_server_safe_training_academy", new Property<bool>(false, "set this to TRUE to disable pk fighting in training academy and time to exit starter town safely")),
         ("pkl_server", new Property<bool>(false, "set this to TRUE for pink servers")),
         ("quest_info_enabled", new Property<bool>(false, "toggles the /myquests player command")),
-        (
-            "rares_real_time",
-            new Property<bool>(
-                true,
-                "allow for second chance roll based on an rng seeded timestamp for a rare on rare eligible kills that do not generate a rare, rares_max_seconds_between defines maximum seconds before second chance kicks in"
-            )
-        ),
-        (
-            "rares_real_time_v2",
-            new Property<bool>(
-                false,
-                "chances for a rare to be generated on rare eligible kills are modified by the last time one was found per each player, rares_max_days_between defines maximum days before guaranteed rare generation"
-            )
-        ),
-        (
-            "runrate_add_hooks",
-            new Property<bool>(
-                false,
-                "if TRUE, adds some runrate hooks that were missing from retail (exhaustion done, raise skill/attribute"
-            )
-        ),
+        ("rares_real_time", new Property<bool>(true, "allow for second chance roll based on an rng seeded timestamp for a rare on rare eligible kills that do not generate a rare, rares_max_seconds_between defines maximum seconds before second chance kicks in")),
+        ("rares_real_time_v2", new Property<bool>(false, "chances for a rare to be generated on rare eligible kills are modified by the last time one was found per each player, rares_max_days_between defines maximum days before guaranteed rare generation")),
+        ("runrate_add_hooks", new Property<bool>(false, "if TRUE, adds some runrate hooks that were missing from retail (exhaustion done, raise skill/attribute")),
         ("reportbug_enabled", new Property<bool>(false, "toggles the /reportbug player command")),
-        (
-            "require_spell_comps",
-            new Property<bool>(
-                true,
-                "if FALSE, spell components are no longer required to be in inventory to cast spells. defaults to enabled, as in retail"
-            )
-        ),
+        ("require_spell_comps", new Property<bool>(true, "if FALSE, spell components are no longer required to be in inventory to cast spells. defaults to enabled, as in retail")),
         ("safe_spell_comps", new Property<bool>(false, "if TRUE, disables spell component burning for everyone")),
-        (
-            "salvage_handle_overages",
-            new Property<bool>(
-                false,
-                "in retail, if 2 salvage bags were combined beyond 100 structure, the overages would be lost"
-            )
-        ),
-        (
-            "show_ammo_buff",
-            new Property<bool>(
-                true,
-                "shows active enchantments such as blood drinker on equipped missile ammo during appraisal"
-            )
-        ),
-        (
-            "show_aura_buff",
-            new Property<bool>(false, "shows active aura enchantments on wielded items during appraisal")
-        ),
-        (
-            "show_dat_warning",
-            new Property<bool>(
-                false,
-                "if TRUE, will alert player (dat_warning_msg) when client attempts to download from server and boot them from game, disabled by default"
-            )
-        ),
-        (
-            "show_dot_messages",
-            new Property<bool>(
-                false,
-                "enabled, shows combat messages for DoT damage ticks. defaults to disabled, as in retail"
-            )
-        ),
-        (
-            "show_first_login_gift",
-            new Property<bool>(
-                false,
-                "if TRUE, will show on first login that the player earned bonus item (Blackmoor's Favor and/or Asheron's Benediction), disabled by default because msg is kind of odd on an emulator"
-            )
-        ),
-        (
-            "show_mana_conv_bonus_0",
-            new Property<bool>(
-                true,
-                "if disabled, only shows mana conversion bonus if not zero, during appraisal of casting items"
-            )
-        ),
+        ("salvage_handle_overages", new Property<bool>(false, "in retail, if 2 salvage bags were combined beyond 100 structure, the overages would be lost")),
+        ("show_ammo_buff", new Property<bool>(true, "shows active enchantments such as blood drinker on equipped missile ammo during appraisal")),
+        ("show_aura_buff", new Property<bool>(false, "shows active aura enchantments on wielded items during appraisal")),
+        ("show_dat_warning", new Property<bool>(false, "if TRUE, will alert player (dat_warning_msg) when client attempts to download from server and boot them from game, disabled by default")),
+        ("show_dot_messages", new Property<bool>(false, "enabled, shows combat messages for DoT damage ticks. defaults to disabled, as in retail")),
+        ("show_first_login_gift", new Property<bool>(false, "if TRUE, will show on first login that the player earned bonus item (Blackmoor's Favor and/or Asheron's Benediction), disabled by default because msg is kind of odd on an emulator")),
+        ("show_mana_conv_bonus_0", new Property<bool>(true, "if disabled, only shows mana conversion bonus if not zero, during appraisal of casting items")),
         ("smite_uses_takedamage", new Property<bool>(false, "if enabled, smite applies damage via TakeDamage")),
-        (
-            "spellcast_recoil_queue",
-            new Property<bool>(false, "if true, players can queue the next spell to cast during recoil animation")
-        ),
-        (
-            "spell_projectile_ethereal",
-            new Property<bool>(
-                true,
-                "broadcasts all spell projectiles as ethereal to clients only, and manually send stop velocity on collision. can fix various issues with client missing target id."
-            )
-        ),
-        (
-            "suicide_instant_death",
-            new Property<bool>(
-                false,
-                "if enabled, @die command kills player instantly. defaults to disabled, as in retail"
-            )
-        ),
-        (
-            "taboo_table",
-            new Property<bool>(true, "if enabled, taboo table restricts player names during character creation")
-        ),
-        (
-            "tailoring_intermediate_uieffects",
-            new Property<bool>(
-                false,
-                "If true, tailoring intermediate icons retain the magical/elemental highlight of the original item"
-            )
-        ),
-        (
-            "trajectory_alt_solver",
-            new Property<bool>(false, "use the alternate trajectory solver for missiles and spell projectiles")
-        ),
-        (
-            "universal_masteries",
-            new Property<bool>(
-                true,
-                "if TRUE, matches end of retail masteries - players wielding almost any weapon get +5 DR, except if the weapon \"seems tough to master\". "
-                    + "if FALSE, players start with mastery of 1 melee and 1 ranged weapon type based on heritage, and can later re-select these 2 masteries"
-            )
-        ),
-        (
-            "use_generator_rotation_offset",
-            new Property<bool>(
-                true,
-                "enables or disables using the generator's current rotation when offseting relative positions"
-            )
-        ),
-        (
-            "use_portal_max_level_requirement",
-            new Property<bool>(true, "disable this to ignore the max level restriction on portals")
-        ),
-        (
-            "use_turbine_chat",
-            new Property<bool>(
-                true,
-                "enables or disables global chat channels (General, LFG, Roleplay, Trade, Olthoi, Society, Allegience)"
-            )
-        ),
-        (
-            "use_wield_requirements",
-            new Property<bool>(true, "disable this to bypass wield requirements. mostly for dev debugging")
-        ),
+        ("spellcast_recoil_queue", new Property<bool>(false, "if true, players can queue the next spell to cast during recoil animation")),
+        ("spell_projectile_ethereal", new Property<bool>(true, "broadcasts all spell projectiles as ethereal to clients only, and manually send stop velocity on collision. can fix various issues with client missing target id.")),
+        ("suicide_instant_death", new Property<bool>(false, "if enabled, @die command kills player instantly. defaults to disabled, as in retail")),
+        ("taboo_table", new Property<bool>(true, "if enabled, taboo table restricts player names during character creation")),
+        ("tailoring_intermediate_uieffects", new Property<bool>(false, "If true, tailoring intermediate icons retain the magical/elemental highlight of the original item")),
+        ("trajectory_alt_solver", new Property<bool>(false, "use the alternate trajectory solver for missiles and spell projectiles")),
+        ("universal_masteries", new Property<bool>(true, "if TRUE, matches end of retail masteries - players wielding almost any weapon get +5 DR, except if the weapon \"seems tough to master\". " +
+                                                         "" + "if FALSE, players start with mastery of 1 melee and 1 ranged weapon type based on heritage, and can later re-select these 2 masteries")),
+        ("use_generator_rotation_offset", new Property<bool>(true, "enables or disables using the generator's current rotation when offseting relative positions")),
+        ("use_portal_max_level_requirement", new Property<bool>(true, "disable this to ignore the max level restriction on portals")),
+        ("use_turbine_chat", new Property<bool>(true, "enables or disables global chat channels (General, LFG, Roleplay, Trade, Olthoi, Society, Allegience)")),
+        ("use_wield_requirements", new Property<bool>(true, "disable this to bypass wield requirements. mostly for dev debugging")),
         ("version_info_enabled", new Property<bool>(false, "toggles the /aceversion player command")),
-        (
-            "vendor_shop_uses_generator",
-            new Property<bool>(
-                false,
-                "enables or disables vendors using generator system in addition to createlist to create artificial scarcity"
-            )
-        ),
+        ("vendor_shop_uses_generator", new Property<bool>(false, "enables or disables vendors using generator system in addition to createlist to create artificial scarcity")),
         ("world_closed", new Property<bool>(false, "enable this to startup world as a closed to players world")),
-        (
-            "allow_xp_at_max_level",
-            new Property<bool>(false, "enable this to allow players to continue earning xp after reaching max level")
-        ),
-        (
-            "block_vpn_connections",
-            new Property<bool>(false, "enable this to block user sessions from IPs identified as VPN proxies")
-        ),
-        (
-            "increase_minimum_encounter_spawn_density",
-            new Property<bool>(
-                true,
-                "enable this to increase the density of random encounters that spawn in low density landblocks"
-            )
-        ),
-        (
-            "command_who_enabled",
-            new Property<bool>(true, "disable this to prevent players from listing online players in their allegiance")
-        ),
+        ("allow_xp_at_max_level", new Property<bool>(false, "enable this to allow players to continue earning xp after reaching max level")),
+        ("block_vpn_connections", new Property<bool>(false, "enable this to block user sessions from IPs identified as VPN proxies")),
+        ("increase_minimum_encounter_spawn_density", new Property<bool>(true, "enable this to increase the density of random encounters that spawn in low density landblocks")),
+        ("command_who_enabled", new Property<bool>(true, "disable this to prevent players from listing online players in their allegiance")),
         ("debug_threat_system", new Property<bool>(false, "enable this to see threat system console logging")),
         ("debug_crafting_system", new Property<bool>(false, "enable this to see crafting system console logging")),
-        (
-            "debug_loot_quality_system",
-            new Property<bool>(false, "enable this to see loot quality system console logging")
-        ),
-        (
-            "debug_level_scaling_system",
-            new Property<bool>(false, "enable this to see level scaling system console logging")
-        ),
-        ("banking_system_logging", new Property<bool>(true, "enable this to see banking system console logging"))
-    );
+        ("debug_loot_quality_system", new Property<bool>(false, "enable this to see loot quality system console logging")),
+        ("debug_level_scaling_system", new Property<bool>(false, "enable this to see level scaling system console logging")),
+        ("banking_system_logging", new Property<bool>(true, "enable this to see banking system console logging")));
 
     public static readonly ReadOnlyDictionary<string, Property<long>> DefaultLongProperties = DictOf(
-        (
-            "char_delete_time",
-            new Property<long>(3600, "the amount of time in seconds a deleted character can be restored")
-        ),
-        (
-            "chat_requires_account_time_seconds",
-            new Property<long>(
-                0,
-                "the amount of time in seconds an account is required to have existed for for global chat privileges"
-            )
-        ),
-        (
-            "chat_requires_player_age",
-            new Property<long>(
-                0,
-                "the amount of time in seconds a player is required to have played for global chat privileges"
-            )
-        ),
-        (
-            "chat_requires_player_level",
-            new Property<long>(0, "the level a player is required to have for global chat privileges")
-        ),
-        (
-            "corpse_spam_limit",
-            new Property<long>(15, "the number of corpses a player is allowed to leave on a landblock at one time")
-        ),
-        (
-            "default_subscription_level",
-            new Property<long>(
-                1,
-                "retail defaults to 1, 1 = standard subscription (same as 2 and 3), 4 grants ToD pre-order bonus item Asheron's Benediction"
-            )
-        ),
-        (
-            "fellowship_even_share_level",
-            new Property<long>(50, "level when fellowship XP sharing is no longer restricted")
-        ),
+        ("char_delete_time", new Property<long>(3600, "the amount of time in seconds a deleted character can be restored")),
+        ("chat_requires_account_time_seconds", new Property<long>(0,"the amount of time in seconds an account is required to have existed for for global chat privileges")),
+        ("chat_requires_player_age", new Property<long>(0, "the amount of time in seconds a player is required to have played for global chat privileges")),
+        ("chat_requires_player_level", new Property<long>(0, "the level a player is required to have for global chat privileges")),
+        ("corpse_spam_limit", new Property<long>(15, "the number of corpses a player is allowed to leave on a landblock at one time")),
+        ("default_subscription_level", new Property<long>(1, "retail defaults to 1, 1 = standard subscription (same as 2 and 3), 4 grants ToD pre-order bonus item Asheron's Benediction")),
+        ("fellowship_even_share_level", new Property<long>(50, "level when fellowship XP sharing is no longer restricted")),
         ("mansion_min_rank", new Property<long>(6, "overrides the default allegiance rank required to own a mansion")),
         ("max_chars_per_account", new Property<long>(11, "retail defaults to 11, client supports up to 20")),
-        (
-            "pk_timer",
-            new Property<long>(
-                20,
-                "the number of seconds where a player cannot perform certain actions (ie. teleporting) after becoming involved in a PK battle"
-            )
-        ),
+        ("pk_timer", new Property<long>(20, "the number of seconds where a player cannot perform certain actions (ie. teleporting) after becoming involved in a PK battle")),
         ("player_save_interval", new Property<long>(300, "the number of seconds between automatic player saves")),
-        (
-            "rares_max_days_between",
-            new Property<long>(
-                45,
-                "for rares_real_time_v2: the maximum number of days a player can go before a rare is generated on rare eligible creature kills"
-            )
-        ),
-        (
-            "rares_max_seconds_between",
-            new Property<long>(
-                5256000,
-                "for rares_real_time: the maximum number of seconds a player can go before a second chance at a rare is allowed on rare eligible creature kills that did not generate a rare"
-            )
-        ),
-        (
-            "summoning_killtask_multicredit_cap",
-            new Property<long>(
-                2,
-                "if allow_summoning_killtask_multicredit is enabled, the maximum # of killtask credits a player can receive from 1 kill"
-            )
-        ),
-        (
-            "teleport_visibility_fix",
-            new Property<long>(
-                0,
-                "Fixes some possible issues with invisible players and mobs. 0 = default / disabled, 1 = players only, 2 = creatures, 3 = all world objects"
-            )
-        ),
+        ("rares_max_days_between", new Property<long>(45, "for rares_real_time_v2: the maximum number of days a player can go before a rare is generated on rare eligible creature kills")),
+        ("rares_max_seconds_between", new Property<long>(5256000, "for rares_real_time: the maximum number of seconds a player can go before a second chance at a rare is allowed on rare eligible creature kills that did not generate a rare")),
+        ("summoning_killtask_multicredit_cap", new Property<long>(2, "if allow_summoning_killtask_multicredit is enabled, the maximum # of killtask credits a player can receive from 1 kill")),
+        ("teleport_visibility_fix", new Property<long>(0, "Fixes some possible issues with invisible players and mobs. 0 = default / disabled, 1 = players only, 2 = creatures, 3 = all world objects")),
         ("max_level", new Property<long>(275, "Set the max character level.")),
         ("soft_level_cap", new Property<long>(50, "Set the 'soft' level cap (current highest possible level of monsters)")),
+        ("playtest_starting_level", new Property<long>(0, "Set the starting level for newly created characters. If above 1, also spawns new characters in Hotel Swank.")),
         ("monster_visual_awareness_range", new Property<long>(30, "Set outdoors monster visual range.")),
-        (
-            "landblock_minimum_spawn_density",
-            new Property<long>(
-                8,
-                "Set minimum spawn density for outdoor landblocks. Requires the 'increase_minimum_encounter_spawn_density' to be enabled."
-            )
-        )
+        ("landblock_minimum_spawn_density", new Property<long>(8, "Set minimum spawn density for outdoor landblocks. Requires the 'increase_minimum_encounter_spawn_density' to be enabled."))
     );
 
     public static readonly ReadOnlyDictionary<string, Property<double>> DefaultDoubleProperties = DictOf(
-        (
-            "cantrip_drop_rate",
-            new Property<double>(
-                1.0,
-                "Scales the chance for cantrips to drop in each tier. Defaults to 1.0, as per end of retail"
-            )
-        ),
-        (
-            "minor_cantrip_drop_rate",
-            new Property<double>(
-                1.0,
-                "Scales the chance for minor cantrips to drop, relative to other cantrip levels in the tier. Defaults to 1.0, as per end of retail"
-            )
-        ),
-        (
-            "major_cantrip_drop_rate",
-            new Property<double>(
-                1.0,
-                "Scales the chance for major cantrips to drop, relative to other cantrip levels in the tier. Defaults to 1.0, as per end of retail"
-            )
-        ),
-        (
-            "epic_cantrip_drop_rate",
-            new Property<double>(
-                1.0,
-                "Scales the chance for epic cantrips to drop, relative to other cantrip levels in the tier. Defaults to 1.0, as per end of retail"
-            )
-        ),
-        (
-            "legendary_cantrip_drop_rate",
-            new Property<double>(
-                1.0,
-                "Scales the chance for legendary cantrips to drop, relative to other cantrip levels in the tier. Defaults to 1.0, as per end of retail"
-            )
-        ),
-        (
-            "advocate_fane_auto_bestow_level",
-            new Property<double>(
-                1,
-                "the level that advocates are automatically bestowed by Advocate Fane if advocate_fane_auto_bestow is true"
-            )
-        ),
+        ("cantrip_drop_rate", new Property<double>(1.0, "Scales the chance for cantrips to drop in each tier. Defaults to 1.0, as per end of retail")),
+        ("minor_cantrip_drop_rate", new Property<double>(1.0, "Scales the chance for minor cantrips to drop, relative to other cantrip levels in the tier. Defaults to 1.0, as per end of retail")),
+        ("major_cantrip_drop_rate", new Property<double>(1.0, "Scales the chance for major cantrips to drop, relative to other cantrip levels in the tier. Defaults to 1.0, as per end of retail")),
+        ("epic_cantrip_drop_rate", new Property<double>(1.0, "Scales the chance for epic cantrips to drop, relative to other cantrip levels in the tier. Defaults to 1.0, as per end of retail")),
+        ("legendary_cantrip_drop_rate", new Property<double>(1.0, "Scales the chance for legendary cantrips to drop, relative to other cantrip levels in the tier. Defaults to 1.0, as per end of retail")),
+        ("advocate_fane_auto_bestow_level", new Property<double>(1, "the level that advocates are automatically bestowed by Advocate Fane if advocate_fane_auto_bestow is true")),
         ("aetheria_drop_rate", new Property<double>(1.0, "Modifier for Aetheria drop rate, 1 being normal")),
-        (
-            "chess_ai_start_time",
-            new Property<double>(-1.0, "the number of seconds for the chess ai to start. defaults to -1 (disabled)")
-        ),
-        (
-            "encounter_delay",
-            new Property<double>(
-                1800,
-                "the number of seconds a generator profile for regions is delayed from returning to free slots"
-            )
-        ),
-        (
-            "encounter_regen_interval",
-            new Property<double>(
-                600,
-                "the number of seconds a generator for regions at which spawns its next set of objects"
-            )
-        ),
-        (
-            "equipmentsetid_drop_rate",
-            new Property<double>(1.0, "Modifier for EquipmentSetID drop rate, 1 being normal")
-        ),
-        (
-            "fast_missile_modifier",
-            new Property<double>(1.2, "The speed multiplier applied to fast missiles. Defaults to retail value of 1.2")
-        ),
-        (
-            "ignore_magic_armor_pvp_scalar",
-            new Property<double>(
-                1.0,
-                "Scales the effectiveness of IgnoreMagicArmor (ie. hollow weapons) in pvp battles. 1.0 = full effectiveness / ignore all enchantments on armor (default), 0.5 = half effectiveness / use half enchantments from armor, 0.0 = no effectiveness / use full enchantments from armor"
-            )
-        ),
-        (
-            "ignore_magic_resist_pvp_scalar",
-            new Property<double>(
-                1.0,
-                "Scales the effectiveness of IgnoreMagicResist (ie. hollow weapons) in pvp battles. 1.0 = full effectiveness / ignore all resistances from life enchantments (default), 0.5 = half effectiveness / use half resistances from life enchantments, 0.0 = no effectiveness / use full resistances from life enchantments"
-            )
-        ),
+        ("chess_ai_start_time", new Property<double>(-1.0, "the number of seconds for the chess ai to start. defaults to -1 (disabled)")),
+        ("encounter_delay", new Property<double>(1800, "the number of seconds a generator profile for regions is delayed from returning to free slots")),
+        ("encounter_regen_interval", new Property<double>(600, "the number of seconds a generator for regions at which spawns its next set of objects")),
+        ("equipmentsetid_drop_rate", new Property<double>(1.0, "Modifier for EquipmentSetID drop rate, 1 being normal")),
+        ("fast_missile_modifier", new Property<double>(1.2, "The speed multiplier applied to fast missiles. Defaults to retail value of 1.2")),
+        ("ignore_magic_armor_pvp_scalar", new Property<double>(1.0, "Scales the effectiveness of IgnoreMagicArmor (ie. hollow weapons) in pvp battles. 1.0 = full effectiveness / ignore all enchantments on armor (default), 0.5 = half effectiveness / use half enchantments from armor, 0.0 = no effectiveness / use full enchantments from armor")),
+        ("ignore_magic_resist_pvp_scalar", new Property<double>(1.0, "Scales the effectiveness of IgnoreMagicResist (ie. hollow weapons) in pvp battles. 1.0 = full effectiveness / ignore all resistances from life enchantments (default), 0.5 = half effectiveness / use half resistances from life enchantments, 0.0 = no effectiveness / use full resistances from life enchantments")),
         ("luminance_modifier", new Property<double>(1.0, "Scales the amount of luminance received by players")),
-        (
-            "melee_max_angle",
-            new Property<double>(
-                0.0,
-                "for melee players, the maximum angle before a TurnTo is required. retail appeared to have required a TurnTo even for the smallest of angle offsets."
-            )
-        ),
-        (
-            "mob_awareness_range",
-            new Property<double>(1.0, "Scales the distance the monsters become alerted and aggro the players")
-        ),
-        (
-            "pk_new_character_grace_period",
-            new Property<double>(
-                300,
-                "the number of seconds, in addition to pk_respite_timer, that a player killer is set to non-player killer status after first exiting training academy"
-            )
-        ),
-        (
-            "pk_respite_timer",
-            new Property<double>(
-                300,
-                "the number of seconds that a player killer is set to non-player killer status after dying to another player killer"
-            )
-        ),
-        (
-            "quest_mindelta_rate",
-            new Property<double>(1.0, "scales all quest min delta time between solves, 1 being normal")
-        ),
-        (
-            "rare_drop_rate_percent",
-            new Property<double>(
-                0.04,
-                "Adjust the chance of a rare to spawn as a percentage. Default is 0.04, or 1 in 2,500. Max is 100, or every eligible drop."
-            )
-        ),
-        (
-            "spellcast_max_angle",
-            new Property<double>(
-                20.0,
-                "for advanced player spell casting, the maximum angle to target release a spell projectile. retail seemed to default to value of around 20, although some players seem to prefer a higher 45 degree angle"
-            )
-        ),
+        ("melee_max_angle", new Property<double>(0.0, "for melee players, the maximum angle before a TurnTo is required. retail appeared to have required a TurnTo even for the smallest of angle offsets.")),
+        ("mob_awareness_range", new Property<double>(1.0, "Scales the distance the monsters become alerted and aggro the players")),
+        ("pk_new_character_grace_period", new Property<double>(300, "the number of seconds, in addition to pk_respite_timer, that a player killer is set to non-player killer status after first exiting training academy")),
+        ("pk_respite_timer", new Property<double>(300, "the number of seconds that a player killer is set to non-player killer status after dying to another player killer")),
+        ("quest_mindelta_rate", new Property<double>(1.0, "scales all quest min delta time between solves, 1 being normal")),
+        ("rare_drop_rate_percent", new Property<double>(0.04, "Adjust the chance of a rare to spawn as a percentage. Default is 0.04, or 1 in 2,500. Max is 100, or every eligible drop.")),
+        ("spellcast_max_angle", new Property<double>(20.0, "for advanced player spell casting, the maximum angle to target release a spell projectile. retail seemed to default to value of around 20, although some players seem to prefer a higher 45 degree angle")),
         ("trophy_drop_rate", new Property<double>(1.0, "Modifier for trophies dropped on creature death")),
-        (
-            "unlocker_window",
-            new Property<double>(
-                10.0,
-                "The number of seconds a player unlocking a chest has exclusive access to first opening the chest."
-            )
-        ),
-        (
-            "vendor_unique_rot_time",
-            new Property<double>(300, "the number of seconds before unique items sold to vendors disappear")
-        ),
+        ("unlocker_window", new Property<double>(10.0, "The number of seconds a player unlocking a chest has exclusive access to first opening the chest.")),
+        ("vendor_unique_rot_time", new Property<double>(300, "the number of seconds before unique items sold to vendors disappear")),
         ("vitae_penalty", new Property<double>(0.05, "the amount of vitae penalty a player gets per death")),
         ("vitae_penalty_max", new Property<double>(0.40, "the maximum vitae penalty a player can have")),
-        (
-            "void_pvp_modifier",
-            new Property<double>(
-                0.5,
-                "Scales the amount of damage players take from Void Magic. Defaults to 0.5, as per retail. For earlier content where DRR isn't as readily available, this can be adjusted for balance."
-            )
-        ),
-        ("xp_modifier", new Property<double>(1.0, "scales the amount of xp received by players"))
-    );
+        ("void_pvp_modifier", new Property<double>(0.5, "Scales the amount of damage players take from Void Magic. Defaults to 0.5, as per retail. For earlier content where DRR isn't as readily available, this can be adjusted for balance.")),
+        ("xp_modifier", new Property<double>(1.0, "scales the amount of xp received by players")));
 
     public static readonly ReadOnlyDictionary<string, Property<string>> DefaultStringProperties = DictOf(
-        (
-            "content_folder",
-            new Property<string>(
-                "Content",
-                "for content creators to live edit weenies. defaults to Content folder found in same directory as ACE.Server.dll"
-            )
-        ),
-        (
-            "dat_older_warning_msg",
-            new Property<string>(
-                "Your DAT files are incomplete.\nThis server does not support dynamic DAT updating at this time.\nPlease visit https://emulator.ac/how-to-play to download the complete DAT files.",
-                "Warning message displayed (if show_dat_warning is true) to player if client attempts DAT download from server"
-            )
-        ),
-        (
-            "dat_newer_warning_msg",
-            new Property<string>(
-                "Your DAT files are newer than expected.\nPlease visit https://emulator.ac/how-to-play to download the correct DAT files.",
-                "Warning message displayed (if show_dat_warning is true) to player if client connects to this server"
-            )
-        ),
-        (
-            "popup_header",
-            new Property<string>("Welcome to Asheron's Call!", "Welcome message displayed when you log in")
-        ),
-        (
-            "popup_welcome",
-            new Property<string>(
-                "To begin your training, speak to the Society Greeter. Walk up to the Society Greeter using the 'W' key, then double-click on her to initiate a conversation.",
-                "Welcome message popup in training halls"
-            )
-        ),
-        (
-            "popup_welcome_olthoi",
-            new Property<string>(
-                "Welcome to the Olthoi hive! Be sure to talk to the Olthoi Queen to receive the Olthoi protections granted by the energies of the hive.",
-                "Welcome message displayed on the first login for an Olthoi Player"
-            )
-        ),
+        ("content_folder", new Property<string>("Content", "for content creators to live edit weenies. defaults to Content folder found in same directory as ACE.Server.dll")),
+        ("dat_older_warning_msg", new Property<string>("Your DAT files are incomplete.\nThis server does not support dynamic DAT updating at this time.\nPlease visit https://emulator.ac/how-to-play to download the complete DAT files.", "Warning message displayed (if show_dat_warning is true) to player if client attempts DAT download from server")),
+        ("dat_newer_warning_msg", new Property<string>("Your DAT files are newer than expected.\nPlease visit https://emulator.ac/how-to-play to download the correct DAT files.", "Warning message displayed (if show_dat_warning is true) to player if client connects to this server")),
+        ("popup_header", new Property<string>("Welcome to Asheron's Call!", "Welcome message displayed when you log in")),
+        ("popup_welcome", new Property<string>("To begin your training, speak to the Society Greeter. Walk up to the Society Greeter using the 'W' key, then double-click on her to initiate a conversation.", "Welcome message popup in training halls")),
+        ("popup_welcome_olthoi", new Property<string>("Welcome to the Olthoi hive! Be sure to talk to the Olthoi Queen to receive the Olthoi protections granted by the energies of the hive.", "Welcome message displayed on the first login for an Olthoi Player")),
         ("popup_motd", new Property<string>("", "Popup message of the day")),
         ("server_motd", new Property<string>("", "Server message of the day"))
     );

--- a/apps/server/Network/Handlers/CharacterHandler.cs
+++ b/apps/server/Network/Handlers/CharacterHandler.cs
@@ -13,6 +13,7 @@ using ACE.Server.Managers;
 using ACE.Server.Network.Enum;
 using ACE.Server.Network.GameMessages;
 using ACE.Server.Network.GameMessages.Messages;
+using ACE.Server.WorldObjects;
 using Serilog;
 
 namespace ACE.Server.Network.Handlers;
@@ -208,6 +209,8 @@ public static class CharacterHandler
             weenieType,
             out var player
         );
+
+        PlaytestSettings(player);
 
         if (result != PlayerFactory.CreateResult.Success || player == null)
         {
@@ -527,5 +530,22 @@ public static class CharacterHandler
                 }
             }
         );
+    }
+
+    private static void PlaytestSettings(Player player)
+    {
+        var playtestLevel = PropertyManager.GetLong("playtest_starting_level").Item;
+        if (playtestLevel <= 0)
+        {
+            return;
+        }
+
+        var xpToPlaytestLevel = player.GetXPBetweenLevels(1, (int)playtestLevel);
+
+        player.TotalExperience = (long)xpToPlaytestLevel;
+        player.AvailableExperience = (long)xpToPlaytestLevel;
+        player.Level = (int)playtestLevel;
+        player.TotalSkillCredits = player.GetSkillCreditsAtLevel((int)playtestLevel);
+        player.AvailableSkillCredits = player.GetSkillCreditsAtLevel((int)playtestLevel);
     }
 }

--- a/apps/server/WorldObjects/Player_Xp.cs
+++ b/apps/server/WorldObjects/Player_Xp.cs
@@ -711,9 +711,39 @@ partial class Player
         return levelB_totalXP - levelA_totalXP;
     }
 
+
     public ulong GetXPToNextLevel(int level)
     {
         return GetXPBetweenLevels(level, level + 1);
+    }
+
+    public int GetSkillCreditsAtLevel(int level)
+    {
+        switch (level)
+        {
+            case >= 100:
+                return 32;
+            case >= 90:
+                return 30;
+            case >= 80:
+                return 28;
+            case >= 70:
+                return 26;
+            case >= 60:
+                return 24;
+            case >= 50:
+                return 22;
+            case >= 40:
+                return 20;
+            case >= 30:
+                return 17;
+            case >= 20:
+                return 14;
+            case >= 10:
+                return 9;
+            default:
+                return 0;
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Add playtest config setting for easy playtesting.

- '/modifylong playtest_starting_level <level>' command can be used by admins to set a starting level for newly created characters. (set to 0 to disable)
- New characters start at the specified level with the appropriate xp and skill credits.
- Unnecessary starter items are removed from inventory (starter gear, manuals, flasks, etc).
- Testing items are added to inventory (x100 M notes, Shard of Shrouding, Hotel Swank portal gem).
- Players spawn in Hotel Swank.