### PR TITLE
refactor: DamageEvent

### DIFF
--- a/ACE.sln.DotSettings
+++ b/ACE.sln.DotSettings
@@ -1,3 +1,4 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=landblocks/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=lifestone/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=lugian/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/apps/server/Entity/DamageEvent.cs
+++ b/apps/server/Entity/DamageEvent.cs
@@ -20,136 +20,137 @@ public class DamageEvent
 {
     private readonly ILogger _log = Log.ForContext<DamageEvent>();
 
-    // factors:
-    // - lifestone protection
-    // - evade
-    //   - offense mod (heart seeker)
-    //      - accuracy mod (missile)
-    //   - defense mod (defender)
-    //      - stamina mod
-    // - base damage / mod
-    // - damage rating / mod
-    //   - recklessness
-    //   - sneak attack
-    //   - heritage bonus
-    // - damage resistance rating /mod
-    // - power meter mod
-    // - critical (chance % mod / critical damage mod)
-    // - attribute mod
-    // - armor / mod (base al, impen / bane, life armor / imperil)
-    // - ward / mod
-    // - elemental damage bonus
-    // - slayer mod
-    // - resistance mod (natural, prot, vuln)
-    //   - resistance cleaving
-    // - shield mod
-    // - rending mod
+    private Creature _attacker;
+    private Creature _defender;
 
-    public Creature Attacker;
-    public Creature Defender;
+    private Player _playerAttacker;
+    private Player _playerDefender;
 
-    public CombatType CombatType; // melee / missile / magic
+    private bool _pkBattle;
 
-    public WorldObject DamageSource;
-    public DamageType DamageType;
+    private WorldObject _damageSource;
 
-    public WorldObject Weapon; // the attacker's weapon. this can be different from DamageSource,
+    private AttackType _attackType; // slash / thrust / punch / kick / offhand / multistrike
+    private AttackHeight _attackHeight;
+    private CreatureSkill _attackSkill;
 
-    // ie. for a missile attack, the missile would the DamageSource,
-    // and the buffs would come from the Weapon
+    private CombatAbility _attackerCombatAbility;
+    private CombatAbility _defenderCombatAbility;
 
-    public AttackType AttackType; // slash / thrust / punch / kick / offhand / multistrike
-    public AttackHeight AttackHeight;
 
-    public bool LifestoneProtection;
-
-    public float EvasionChance;
-    public uint EffectiveAttackSkill;
-    public uint EffectiveDefenseSkill;
-    public float AccuracyMod;
-
+    private bool _invulnerable;
     public bool Blocked;
     public bool Evaded;
-    public PartialEvasion PartialEvasion;
+    private float _evasionMod;
+    private float _steadyShotActivatedMod;
 
-    public BaseDamageMod BaseDamageMod;
-    public float BaseDamage { get; set; }
+    private uint _effectiveDefenseSkill;
+    private float _accuracyMod;
 
-    public float AttributeMod;
-    public float PowerMod;
-    public float SlayerMod;
+    private float _baseDamage;
+    private BaseDamageMod _baseDamageMod;
 
-    public float DamageRatingBaseMod;
-    public float RecklessnessMod;
-    public float SneakAttackMod;
-    public float HeritageMod;
-    public float PkDamageMod;
+    private bool _overpower;
 
-    public float DamageRatingMod;
+    private float _damageBeforeMitigation;
+    private float _attributeMod;
+    private float _powerMod;
+    private float _slayerMod;
+    private float _recklessnessMod;
+    private float _twohandedCombatDamageBonus;
+    private float _dualWieldDamageBonus ;
+    private float _damageRatingMod;
+    private float _attackHeightDamageBonus;
+    private float _pkDamageMod;
+    private float _combatAbilityProvokeDamageBonus;
+    private float _combatAbilityFuryDamageBonus;
+    private float _combatAbilityMultishotDamagePenalty;
+    private float _ratingElementalDamageBonus;
 
-    public bool IsCritical;
 
-    public float CriticalChance;
-    public float CriticalDamageMod;
+    private float _criticalChance;
+    private float _criticalDamageMod;
+    private float _criticalDamageRating;
+    private float _criticalDamageResistanceRatingMod;
+    private bool _criticalDefended;
 
-    public float CriticalDamageRatingMod;
-    public float CriticalDamageResistanceRatingMod;
-
-    public float DamageBeforeMitigation;
-
-    public float ArmorMod;
-    public float ResistanceMod;
-    public float ShieldMod;
-    public float WeaponResistanceMod;
-
-    public float DamageResistanceRatingBaseMod;
-    public float DamageResistanceRatingMod;
-    public float PkDamageResistanceMod;
-
-    public float DamageMitigated;
+    private bool _generalFailure;
 
     // creature attacker
-    public MotionCommand? AttackMotion;
-    public AttackHook AttackHook;
-    public KeyValuePair<CombatBodyPart, PropertiesBodyPart> AttackPart; // the body part this monster is attacking with
+    private MotionCommand? _attackMotion;
+    private AttackHook _attackHook;
+    private KeyValuePair<CombatBodyPart, PropertiesBodyPart> _attackPart; // the body part this monster is attacking with
+    private Creature_BodyPart _creaturePart;
+    private Quadrant _quadrant;
 
-    // creature defender
-    public Quadrant Quadrant;
+    private KeyValuePair<CombatBodyPart, PropertiesBodyPart> _propertiesBodyPart;
+    private List<WorldObject> _armor;
+    private float _armorMod;
+    private float _damageResistanceRatingBaseMod;
+    private float _damageResistanceRatingMod;
+    private float _ignoreArmorMod;
+    private float _pkDamageResistanceMod;
+    private float _resistanceMod;
+    private float _weaponResistanceMod;
 
-    public bool IgnoreMagicArmor => (Weapon?.IgnoreMagicArmor ?? false) || (Attacker?.IgnoreMagicArmor ?? false); // ignores impen / banes
+    private float _specDefenseMod;
+    private float _ratingElementalWard;
+    private float _ratingLastStand;
+    private float _ratingSelfHarm;
 
-    public bool IgnoreMagicResist => (Weapon?.IgnoreMagicResist ?? false) || (Attacker?.IgnoreMagicResist ?? false); // ignores life armor / prots
+    private float _damageMitigated;
+    private float _levelScalingMod;
 
-    public bool Overpower;
+    private bool IgnoreMagicArmor =>
+        (Weapon?.IgnoreMagicArmor ?? false) || (_attacker?.IgnoreMagicArmor ?? false); // ignores impen / banes
 
-    // player defender
-    public BodyPart BodyPart;
-    public List<WorldObject> Armor;
+    private bool IgnoreMagicResist =>
+        (Weapon?.IgnoreMagicResist ?? false) || (_attacker?.IgnoreMagicResist ?? false); // ignores life armor / prots
 
-    // creature defender
-    public KeyValuePair<CombatBodyPart, PropertiesBodyPart> PropertiesBodyPart;
-    public Creature_BodyPart CreaturePart;
-
-    public float Damage;
-
-    public bool GeneralFailure;
+    public bool LifestoneProtection { get; private set; }
+    public PartialEvasion PartialEvasion { get; private set; }
+    public uint EffectiveAttackSkill { get; private set; }
+    public float SneakAttackMod { get; private set; }
+    public bool IsCritical { get; private set; }
+    public BodyPart BodyPart { get; private set; }
+    public float ShieldMod { get; private set; }
+    public float Damage { get; private set; }
+    public CombatType CombatType { get; private set; }
+    public DamageType DamageType { get; private set; }
+    public WorldObject Weapon { get; private set; }
 
     public bool HasDamage => !Evaded && !Blocked && !LifestoneProtection;
 
-    public bool CriticalDefended;
-
-    public static HashSet<uint> AllowDamageTypeUndef = new HashSet<uint>()
+    public AttackConditions AttackConditions
     {
-        22545, // Obsidian Spines
-        35191, // Thunder Chicken
-        38406, // Blessed Moar
-        38587, // Ardent Moar
-        38588, // Blessed Moar
-        38586, // Verdant Moar
-        40298, // Ardent Moar
-        40300, // Blessed Moar
-        40301, // Verdant Moar
-    };
+        get
+        {
+            var attackConditions = new AttackConditions();
+
+            if (_criticalDefended)
+            {
+                attackConditions |= AttackConditions.CriticalProtectionAugmentation;
+            }
+
+            if (_recklessnessMod > 1.0f)
+            {
+                attackConditions |= AttackConditions.Recklessness;
+            }
+
+            if (SneakAttackMod > 1.0f)
+            {
+                attackConditions |= AttackConditions.SneakAttack;
+            }
+
+            if (_overpower)
+            {
+                attackConditions |= AttackConditions.Overpower;
+            }
+
+            return attackConditions;
+        }
+    }
+
 
     public static DamageEvent CalculateDamage(
         Creature attacker,
@@ -159,13 +160,13 @@ public class DamageEvent
         AttackHook attackHook = null
     )
     {
-        var damageEvent = new DamageEvent();
-        damageEvent.AttackMotion = attackMotion;
-        damageEvent.AttackHook = attackHook;
-        if (damageSource == null)
+        var damageEvent = new DamageEvent
         {
-            damageSource = attacker;
-        }
+            _attackMotion = attackMotion,
+            _attackHook = attackHook
+        };
+
+        damageSource ??= attacker;
 
         var damage = damageEvent.DoCalculateDamage(attacker, defender, damageSource);
 
@@ -181,114 +182,349 @@ public class DamageEvent
             Console.WriteLine($"\n\n---- LEVEL SCALING - {attacker.Name} vs {defender.Name} ----");
         }
 
-        var playerAttacker = attacker as Player;
-        var playerDefender = defender as Player;
+        SetCombatSources(attacker, defender, damageSource);
+        SetCombatAbilities(attacker, defender);
 
-        var pkBattle = playerAttacker != null && playerDefender != null;
+        SetInvulnerable(defender);
+        SetEvasion(attacker, defender);
+        SetBlocked(attacker, defender);
 
-        Attacker = attacker;
-        Defender = defender;
+        if (_invulnerable || Evaded || Blocked)
+        {
+            CheckForParryRiposte(attacker, defender, damageSource);
+            CheckForRatingThorns(attacker, defender, damageSource);
+
+            return 0.0f;
+        }
+
+        _damageBeforeMitigation = GetDamageBeforeMitigation(attacker, defender, damageSource);
+
+        if (_generalFailure)
+        {
+            return 0.0f;
+        }
+
+        var mitigation = GetMitigation(attacker, defender);
+
+        Damage = _damageBeforeMitigation * mitigation;
+        _damageMitigated = _damageBeforeMitigation - Damage;
+
+        PostDamageEffects(attacker, defender, damageSource);
+        OptionalDamageMultiplierSettings();
+        DpsLogging();
+
+        return Damage;
+    }
+
+    /// <summary>
+    /// Sets PlayerAttacker, PlayerDefender, Attacker, Defender, PkBattle, AttackSkill, CombatType, DamageSource, Weapon, AttackType, AttackHeight
+    /// </summary>
+    private void SetCombatSources(Creature attacker, Creature defender, WorldObject damageSource)
+    {
+        _playerAttacker = attacker as Player;
+        _playerDefender = defender as Player;
+
+        _pkBattle = _playerAttacker != null && _playerDefender != null;
+
+        _attacker = attacker;
+        _defender = defender;
+
+        _attackSkill = attacker.GetCreatureSkill(attacker.GetCurrentWeaponSkill());
 
         CombatType = damageSource.ProjectileSource == null ? CombatType.Melee : CombatType.Missile;
 
-        DamageSource = damageSource;
+        _damageSource = damageSource;
 
-        Weapon =
-            damageSource.ProjectileSource == null
-                ? attacker.GetEquippedMeleeWeapon()
-                : (damageSource.ProjectileLauncher ?? damageSource.ProjectileAmmo);
+        Weapon = damageSource.ProjectileSource == null
+            ? attacker.GetEquippedMeleeWeapon()
+            : (damageSource.ProjectileLauncher ?? damageSource.ProjectileAmmo);
 
-        AttackType = attacker.AttackType;
-        AttackHeight = attacker.AttackHeight ?? AttackHeight.Medium;
+        _attackType = attacker.AttackType;
+        _attackHeight = attacker.AttackHeight ?? AttackHeight.Medium;
+    }
 
-        // ---- COMBAT TECHNIQUE REF ----
-        GetCombatAbilities(attacker, defender, out var attackerCombatAbility, out var defenderCombatAbility);
+    private void SetCombatAbilities(Creature attacker, Creature defender)
+    {
+        _attackerCombatAbility = CombatAbility.None;
+        _defenderCombatAbility = CombatAbility.None;
 
-        // ---- SNEAKING? ----
-        var isAttackFromSneaking = false;
-        if (playerAttacker != null)
+        var attackerCombatFocus = attacker?.GetEquippedCombatFocus();
+        if (attackerCombatFocus != null)
         {
-            isAttackFromSneaking = playerAttacker.IsAttackFromStealth;
-            playerAttacker.IsAttackFromStealth = false;
+            _attackerCombatAbility = attackerCombatFocus.GetCombatAbility();
         }
 
-        // ---- LIFESTONE PROTECTION ----
-        if (playerDefender != null && playerDefender.UnderLifestoneProtection)
+        var defenderCombatFocus = defender?.GetEquippedCombatFocus();
+        if (defenderCombatFocus != null)
+        {
+            _defenderCombatAbility = defenderCombatFocus.GetCombatAbility();
+        }
+    }
+
+    private void SetInvulnerable(Creature defender)
+    {
+        var playerDefender = defender as Player;
+
+        if (playerDefender is { UnderLifestoneProtection: true })
         {
             LifestoneProtection = true;
             playerDefender.HandleLifestoneProtection();
-            return 0.0f;
+            {
+                _invulnerable = true;
+            }
         }
 
         if (defender.Invincible)
         {
-            return 0.0f;
-        }
-
-        // ---- OVERPOWER ----
-        if (attacker.Overpower != null)
-        {
-            Overpower = Creature.GetOverpower(attacker, defender);
-        }
-
-        // ---- BLOCK ----
-        Blocked = IsBlocked(attacker, defender);
-
-        if (Blocked && playerDefender != null)
-        {
-            if (
-                defenderCombatAbility == CombatAbility.Parry
-                && playerDefender.LastParryActivated > Time.GetUnixTime() - playerDefender.ParryActivatedDuration
-                && attacker.GetDistance(playerDefender) < 3
-            )
             {
-                if (playerDefender.TwoHandedCombat || playerDefender.IsDualWieldAttack)
+                _invulnerable = true;
+            }
+        }
+
+        _invulnerable = false;
+    }
+
+    /// <summary>
+    /// Checks for Overpower, Steady Shot, Fury, and Backstab auto-hits.
+    /// If evade succeeded, determine if evade was full, partial, or none.
+    /// Equal chance for each evasion type to occur.
+    /// </summary>
+    private void SetEvasion(Creature attacker, Creature defender)
+    {
+        var playerAttacker = attacker as Player;
+
+        Evaded = false;
+        _evasionMod = 1.0f;
+        PartialEvasion = PartialEvasion.None;
+
+        var isOverpower = CheckForOverpower(attacker, defender);
+        var isSteadyShotNoEvade = CheckForCombatAbilitySteadyShotNoEvade(playerAttacker, _attackerCombatAbility);
+        var isFuryNoEvade = CheckForCombatAbilityFuryNoEvade(playerAttacker, _attackerCombatAbility);
+        var isBackstabNoEvade = CheckForCombatAbilityBackstabNoEvade(playerAttacker);
+
+        if (isOverpower || isSteadyShotNoEvade || isFuryNoEvade || isBackstabNoEvade || attacker == defender)
+        {
+            return;
+        }
+
+        const float fullEvadeChance = 1.0f / 3.0f;
+        const float partialEvadeChance = fullEvadeChance * 2;
+
+        var roll = ThreadSafeRandom.Next(0.0f, 1.0f);
+
+        switch (roll)
+        {
+            case < fullEvadeChance:
+                Evaded = true;
+                break;
+            case < partialEvadeChance when _defenderCombatAbility == CombatAbility.Provoke:
+                _evasionMod = 0.25f;
+                PartialEvasion = PartialEvasion.Some;
+                Evaded = false;
+                break;
+            case < partialEvadeChance:
+                _evasionMod = 0.5f;
+                PartialEvasion = PartialEvasion.Some;
+                Evaded = false;
+                break;
+            default:
+                _evasionMod = 1.0f;
+                PartialEvasion = PartialEvasion.None;
+                Evaded = false;
+                break;
+        }
+    }
+
+    private bool CheckForOverpower(Creature attacker, Creature defender)
+    {
+        if (attacker.Overpower == null)
+        {
+            return false;
+        }
+
+        _overpower = Creature.GetOverpower(attacker, defender);
+        return _overpower;
+    }
+
+    private bool CheckForCombatAbilityFuryNoEvade(Player playerAttacker, CombatAbility attackerCombatAbility)
+    {
+        if (playerAttacker == null)
+        {
+            return false;
+        }
+
+        if (attackerCombatAbility != CombatAbility.Fury
+            || !playerAttacker.RecklessActivated
+            || !(playerAttacker.LastRecklessActivated > Time.GetUnixTime() - playerAttacker.RecklessActivatedDuration))
+        {
+            return false;
+        }
+
+        Evaded = false;
+        PartialEvasion = PartialEvasion.None;
+        _evasionMod = 1f;
+
+        return true;
+    }
+
+    private bool CheckForCombatAbilitySteadyShotNoEvade(Player playerAttacker, CombatAbility attackerCombatAbility)
+    {
+        if (playerAttacker == null)
+        {
+            return false;
+        }
+
+        if (attackerCombatAbility != CombatAbility.SteadyShot
+            || playerAttacker.GetEquippedMissileLauncher() == null
+            || !(playerAttacker.LastSteadyShotActivated
+                 > Time.GetUnixTime() - playerAttacker.SteadyShotActivatedDuration))
+        {
+            return false;
+        }
+
+        Evaded = false;
+        PartialEvasion = PartialEvasion.None;
+        _evasionMod = 1f;
+        _steadyShotActivatedMod = 1.25f;
+
+        return true;
+    }
+
+    /// <summary>
+    /// Attack cannot be evaded if Backstab ability activated when attacking from behind
+    /// </summary>
+    private bool CheckForCombatAbilityBackstabNoEvade(Player playerAttacker)
+    {
+        if (playerAttacker == null)
+        {
+            return false;
+        }
+
+        if (playerAttacker.EquippedCombatAbility != CombatAbility.Backstab
+            || !(playerAttacker.LastBackstabActivated > Time.GetUnixTime() - playerAttacker.BackstabActivatedDuration))
+        {
+            return false;
+        }
+
+        Evaded = false;
+        PartialEvasion = PartialEvasion.None;
+
+        return true;
+    }
+
+    private void SetBlocked(Creature attacker, Creature defender)
+    {
+        var playerAttacker = attacker as Player;
+        var playerDefender = defender as Player;
+
+        var blockChance = 0.0f;
+
+        var effectiveAngle = 180.0f;
+
+        // SPEC BONUS - Shield: Increase shield effective angle to 225 degrees
+        if (playerDefender != null && playerDefender.GetCreatureSkill(Skill.Shield).AdvancementClass == SkillAdvancementClass.Specialized)
+        {
+            effectiveAngle = 225.0f;
+        }
+
+        // check for frontal radius prior to allowing a block unless PhalanxActivated
+        if (
+            playerDefender is not { EquippedCombatAbility: CombatAbility.Phalanx }
+            || playerDefender.LastPhalanxActivated < Time.GetUnixTime() - playerDefender.PhalanxActivatedDuration
+        )
+        {
+            var angle = defender.GetAngle(attacker);
+            if (Math.Abs(angle) > effectiveAngle / 2.0f)
+            {
+                Blocked = false;
+            }
+        }
+
+        if (defender.GetEquippedShield() != null && defender.GetCreatureSkill(Skill.MeleeDefense).AdvancementClass == SkillAdvancementClass.Specialized)
+        {
+            _accuracyMod = attacker.GetAccuracySkillMod(Weapon);
+            EffectiveAttackSkill = attacker.GetEffectiveAttackSkill();
+
+            // ATTACK HEIGHT BONUS: Medium (+10% attack skill, +15% if weapon specialized)
+            if (playerAttacker is { AttackHeight: AttackHeight.Medium })
+            {
+                var bonus = WeaponIsSpecialized(playerAttacker) ? 1.15f : 1.1f;
+
+                EffectiveAttackSkill = (uint)Math.Round(EffectiveAttackSkill * bonus);
+            }
+
+            var shieldArmorLevel = defender.GetEquippedShield().ArmorLevel ?? 0;
+
+            var blockChanceMod = SkillCheck.GetSkillChance((uint)shieldArmorLevel, EffectiveAttackSkill);
+
+            blockChance = 0.1f + 0.1f * (float)blockChanceMod;
+        }
+        // COMBAT ABILITY - Parry: 20% chance to block attacks while using a two-handed weapon or dual-wielding
+        else if (playerDefender != null && playerDefender.EquippedCombatAbility == CombatAbility.Parry)
+        {
+            if (playerDefender.TwoHandedCombat || playerDefender.IsDualWieldAttack)
+            {
+                blockChance = 0.2f;
+
+                if (playerDefender.LastParryActivated > Time.GetUnixTime() - playerDefender.ParryActivatedDuration)
                 {
-                    playerDefender.DamageTarget(attacker, damageSource);
+                    blockChance += 0.15f;
                 }
             }
         }
 
-        // ---- EVASION ----
-        var evasionMod = GetEvasionMod(attacker, defender);
-        //Console.WriteLine(EvasionChance + " " + partialEvasion);
-
-        var steadyShotActivatedMod = 1f;
-        if (playerAttacker != null)
+        // COMBAT ABILITY - Phalanx: Activated Block Bonus
+        if (
+            playerDefender != null
+            && playerDefender.LastPhalanxActivated > Time.GetUnixTime() - playerDefender.PhalanxActivatedDuration
+        )
         {
-            if (
-                attackerCombatAbility == CombatAbility.SteadyShot
-                && playerAttacker.GetEquippedMissileLauncher() != null
-                && playerAttacker.LastSteadyShotActivated
-                    > Time.GetUnixTime() - playerAttacker.SteadyShotActivatedDuration
-            )
-            {
-                Evaded = false;
-                PartialEvasion = PartialEvasion.None;
-                evasionMod = 1f;
-                steadyShotActivatedMod = 1.25f;
-            }
-
-            if (
-                playerAttacker.EquippedCombatAbility == CombatAbility.Fury
-                && playerAttacker.RecklessActivated
-                && playerAttacker.LastRecklessActivated > Time.GetUnixTime() - playerAttacker.RecklessActivatedDuration
-            )
-            {
-                Evaded = false;
-                PartialEvasion = PartialEvasion.None;
-                evasionMod = 1f;
-            }
+            blockChance += 0.5f;
         }
 
-        // ---- BASE DAMAGE ----
+        // JEWEL - Turquoise: Passive Block %
+        if (defender.GetEquippedItemsRatingSum(PropertyInt.GearBlock) > 0)
+        {
+            blockChance += (defender.GetEquippedItemsRatingSum(PropertyInt.GearBlock) * 0.01f);
+        }
+
+        if ((ThreadSafeRandom.Next(0f, 1f) > blockChance))
+        {
+            Blocked = false;
+        }
+
+        Blocked = true;
+    }
+
+    private float GetDamageBeforeMitigation(Creature attacker, Creature defender, WorldObject damageSource)
+    {
+        SetBaseDamage(attacker, defender, damageSource);
+        SetDamageModifiers(attacker, defender);
+
+        _criticalChance = GetCriticalChance(attacker, defender);
+        _criticalDefended = GetCriticalDefended(attacker, defender);
+
+        if (_criticalChance < ThreadSafeRandom.Next(0.0f, 1.0f) && _criticalDefended)
+        {
+            IsCritical = true;
+
+            return GetNonCriticalDamageBeforeMitigation();
+        }
+
+        return GetCriticalDamageBeforeMitigation(attacker, defender);
+    }
+
+    private void SetBaseDamage(Creature attacker, Creature defender, WorldObject damageSource)
+    {
+        var playerAttacker = attacker as Player;
+
         if (playerAttacker != null)
         {
             GetBaseDamage(playerAttacker);
         }
         else
         {
-            GetBaseDamage(attacker, AttackMotion ?? MotionCommand.Invalid, AttackHook);
+            GetBaseDamage(attacker, _attackMotion ?? MotionCommand.Invalid, _attackHook);
         }
 
         if (DamageType == DamageType.Undef)
@@ -298,647 +534,528 @@ public class DamageEvent
                 _log.Error(
                     $"DamageEvent.DoCalculateDamage({attacker?.Name} ({attacker?.Guid}), {defender?.Name} ({defender?.Guid}), {damageSource?.Name} ({damageSource?.Guid})) - DamageType == DamageType.Undef"
                 );
-                GeneralFailure = true;
+                _generalFailure = true;
             }
         }
+    }
 
-        if (GeneralFailure)
+    private void SetDamageModifiers(Creature attacker, Creature defender)
+    {
+        var playerAttacker = attacker as Player;
+        var playerDefender = defender as Player;
+
+        _powerMod = attacker.GetPowerMod(Weapon);
+        _attributeMod = attacker.GetAttributeMod(Weapon, false, defender);
+        _slayerMod = WorldObject.GetWeaponCreatureSlayerModifier(Weapon, attacker, defender);
+        _damageRatingMod = Creature.GetPositiveRatingMod(attacker.GetDamageRating());
+        _dualWieldDamageBonus = GetDualWieldDamageBonus(playerAttacker);
+        _twohandedCombatDamageBonus = GetTwohandedCombatDamageBonus(playerAttacker);
+        _combatAbilityMultishotDamagePenalty = GetCombatAbilityMultishotDamagePenalty(playerAttacker);
+        _combatAbilityProvokeDamageBonus = GetCombatAbilityProvokeDamageBonus(playerAttacker);
+        _combatAbilityFuryDamageBonus = GetCombatAbilityRecklessDamageBonus(attacker, defender, playerAttacker);
+        _recklessnessMod = Creature.GetRecklessnessMod(attacker, defender);
+        SneakAttackMod = attacker.GetSneakAttackMod(defender);
+        _attackHeightDamageBonus += GetHighAttackHeightBonus(playerAttacker);
+        _ratingElementalDamageBonus = Jewel.HandleElementalBonuses(playerAttacker, DamageType);
+        _levelScalingMod = GetLevelScalingMod(attacker, defender, playerDefender);
+
+        if (_pkBattle)
+        {
+            _pkDamageMod = Creature.GetPositiveRatingMod(attacker.GetPKDamageRating());
+            _damageRatingMod = Creature.AdditiveCombine(_damageRatingMod, _pkDamageMod);
+        }
+    }
+
+    /// <summary>
+    /// Dual Wield Damage Mod
+    /// </summary>
+    private float GetDualWieldDamageBonus(Player playerAttacker)
+    {
+        return playerAttacker is { IsDualWieldAttack: true, DualWieldAlternate: false }
+            ? playerAttacker.GetDualWieldDamageMod()
+            : 1.0f;
+    }
+
+    /// <summary>
+    /// Two-handed Combat Damage Mod
+    /// </summary>
+    private static float GetTwohandedCombatDamageBonus(Player playerAttacker)
+    {
+        if (playerAttacker?.GetEquippedWeapon() == null)
+        {
+            return 1.0f;
+        }
+
+        return playerAttacker.GetEquippedWeapon().W_WeaponType == WeaponType.TwoHanded
+            ? playerAttacker.GetTwoHandedCombatDamageMod()
+            : 1.0f;
+    }
+
+    /// <summary>
+    /// COMBAT ABILITY - Multishot: Damage reduced by 25%.
+    /// </summary>
+    private float GetCombatAbilityMultishotDamagePenalty(Player playerAttacker)
+    {
+        return playerAttacker is { EquippedCombatAbility: CombatAbility.Multishot } ? 0.75f : 1.0f;
+    }
+
+    private void OptionalDamageMultiplierSettings()
+    {
+        if (_attacker.IsMonster)
+        {
+            Damage = Damage * 1.0f;
+        }
+
+        if (!_attacker.IsMonster)
+        {
+            Damage = Damage * 1.0f;
+        }
+    }
+
+    /// <summary>
+    /// COMBAT ABILITY - Provoke: Damage increased by 20%.
+    /// </summary>
+    private static float GetCombatAbilityProvokeDamageBonus(Player playerAttacker)
+    {
+        if (playerAttacker == null)
+        {
+            return 1.0f;
+        }
+
+        if (playerAttacker.EquippedCombatAbility != CombatAbility.Provoke)
+        {
+            return 1.0f;
+        }
+
+        return playerAttacker.LastProvokeActivated > Time.GetUnixTime() - playerAttacker.ProvokeActivatedDuration
+            ? 1.2f
+            : 1.0f;
+    }
+
+    /// <summary>
+    /// COMBAT ABILITY - Fury: Damage increased by up to 25%.
+    /// </summary>
+    private float GetCombatAbilityRecklessDamageBonus(Creature attacker, Creature defender, Player playerAttacker)
+    {
+        var recklessMod = 1.0f;
+
+        if (playerAttacker == null)
+        {
+            return recklessMod;
+        }
+
+        if (playerAttacker.EquippedCombatAbility != CombatAbility.Fury || defender == playerAttacker)
+        {
+            return recklessMod;
+        }
+
+        if (CombatType != CombatType.Melee && !(attacker.GetDistance(defender) < 3))
+        {
+            return recklessMod;
+        }
+
+        // 500 stacks is max, out of 2000 for a max of 25%
+        var recklessStacks = Player.HandleRecklessStamps(playerAttacker);
+
+        // If Reckless is not activated and last Reckless duration is over, recklessMod += stacks / 2000
+        if (!playerAttacker.RecklessActivated && playerAttacker.LastRecklessActivated <
+            Time.GetUnixTime() - playerAttacker.RecklessActivatedDuration)
+        {
+            recklessMod += recklessStacks / 2000f;
+        }
+
+        // If Reckless is activated and Reckless duration is over, set Activated to false and erase quest stamps
+        if (playerAttacker.RecklessActivated && playerAttacker.LastRecklessActivated <
+            Time.GetUnixTime() - playerAttacker.RecklessActivatedDuration)
+        {
+            playerAttacker.RecklessActivated = false;
+            playerAttacker.RecklessDumped = false;
+            playerAttacker.QuestManager.Erase($"{playerAttacker.Name},Reckless");
+        }
+
+        // If Reckless is activated and duration is not over, set Activated to false, erase quest stamps, and recklessMod += stacks / 1000
+        if (playerAttacker.RecklessActivated && playerAttacker.LastRecklessActivated >
+            Time.GetUnixTime() - playerAttacker.RecklessActivatedDuration)
+        {
+            playerAttacker.RecklessActivated = false;
+            playerAttacker.RecklessDumped = true;
+            playerAttacker.QuestManager.Erase($"{playerAttacker.Name},Reckless");
+
+            recklessMod += recklessStacks / 1000f;
+        }
+
+        return recklessMod;
+    }
+
+    /// <summary>
+    /// ATTACK HEIGHT BONUS - High: (10% increased damage, 15% if weapon is specialized)
+    /// </summary>
+    private float GetHighAttackHeightBonus(Player playerAttacker)
+    {
+        if (playerAttacker is { AttackHeight: AttackHeight.High })
+        {
+            return WeaponIsSpecialized(playerAttacker) ? 1.15f : 1.10f;
+        }
+
+        return 1.0f;
+    }
+
+    private static float GetLevelScalingMod(Creature attacker, Creature defender, Player playerDefender)
+    {
+        return playerDefender != null
+            ? LevelScaling.GetMonsterDamageDealtHealthScalar(playerDefender, attacker)
+            : LevelScaling.GetMonsterDamageTakenHealthScalar(attacker, defender);
+    }
+
+    private float GetCriticalChance(Creature attacker, Creature defender)
+    {
+        var playerAttacker = attacker as Player;
+        var playerDefender = defender as Player;
+
+        if (playerDefender != null && (playerDefender.IsLoggingOut || playerDefender.PKLogout))
+        {
+            return 1.0f;
+        }
+
+        if (CheckForPlayerStealthGuaranteedCritical(playerAttacker, playerDefender) || CheckForRatingReprisal(playerAttacker))
+        {
+            return 1.0f;
+        }
+
+        var criticalChance = WorldObject.GetWeaponCriticalChance(Weapon, attacker, _attackSkill, defender);
+        criticalChance += GetPlayerBackstabCriticalChanceBonus();
+        criticalChance += GetPlayerSpecSkillCriticalChanceBonus();
+
+        return criticalChance;
+    }
+
+    private bool GetCriticalDefended(Creature attacker, Creature defender)
+    {
+        var playerAttacker = attacker as Player;
+        var playerDefender = defender as Player;
+
+        return CheckForAugmentationCriticalDefense(playerDefender, playerAttacker) ||
+               CheckForSpecPerceptionCriticalDefense(playerDefender);
+    }
+
+    private float GetCriticalDamageBeforeMitigation(Creature attacker, Creature defender)
+    {
+        var playerAttacker = attacker as Player;
+        var playerDefender = defender as Player;
+
+        _criticalDamageMod = 1.0f + WorldObject.GetWeaponCritDamageMod(Weapon, attacker, _attackSkill, defender);
+        _criticalDamageMod += GetMaceSpecCriticalDamageBonus(playerAttacker);
+        _criticalDamageMod += GetStaffSpecCriticalDamageBonus(playerAttacker);
+        _criticalDamageMod += GetRatingBludgeonCriticalDamageBonus(defender, playerAttacker);
+
+        CheckForRatingReprisalCriticalDefense(attacker, playerDefender);
+
+        _criticalDamageRating = Creature.GetPositiveRatingMod(attacker.GetCritDamageRating());
+        _damageRatingMod = Creature.AdditiveCombine(_damageRatingMod, _criticalDamageRating);
+
+        if (_pkBattle)
+        {
+            _damageRatingMod = Creature.AdditiveCombine(_damageRatingMod, _pkDamageMod);
+        }
+
+        return
+            _baseDamageMod.MaxDamage
+            * _attributeMod
+            * _powerMod
+            * _slayerMod
+            * _damageRatingMod
+            * _criticalDamageMod
+            * _dualWieldDamageBonus
+            * _twohandedCombatDamageBonus
+            * _steadyShotActivatedMod
+            * _combatAbilityMultishotDamagePenalty
+            * _combatAbilityProvokeDamageBonus
+            * _combatAbilityFuryDamageBonus
+            * SneakAttackMod
+            * _attackHeightDamageBonus
+            * _levelScalingMod;
+    }
+
+    private float GetNonCriticalDamageBeforeMitigation()
+    {
+        return
+            _baseDamage
+            * _attributeMod
+            * _powerMod
+            * _slayerMod
+            * _damageRatingMod
+            * _recklessnessMod
+            * SneakAttackMod
+            * _attackHeightDamageBonus
+            * _ratingElementalDamageBonus
+            * _dualWieldDamageBonus
+            * _twohandedCombatDamageBonus
+            * _steadyShotActivatedMod
+            * _combatAbilityMultishotDamagePenalty
+            * _combatAbilityProvokeDamageBonus
+            * _combatAbilityFuryDamageBonus
+            * _levelScalingMod;
+    }
+
+    private bool CheckForPlayerStealthGuaranteedCritical(Creature playerAttacker, Creature playerDefender)
+    {
+        if (playerAttacker == null)
+        {
+            return false;
+        }
+
+        if (!IsAttackFromStealth())
+        {
+            return false;
+        }
+
+        if (playerDefender == null)
+        {
+            SneakAttackMod = 3.0f;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// COMBAT ABILITY - Backstab: +20% crit chance from behind
+    /// </summary>
+    private float GetPlayerBackstabCriticalChanceBonus()
+    {
+        return SneakAttackMod > 1.0f ? 0.2f : 0.0f;
+    }
+
+    private float GetMitigation(Creature attacker, Creature defender)
+    {
+        var playerAttacker = attacker as Player;
+        var playerDefender = attacker as Player;
+
+        _ignoreArmorMod = GetIgnoreArmorMod(attacker, defender);
+        _ignoreArmorMod -= GetSpearSpecIgnoreArmorBonus(attacker);
+
+        _armorMod = GetArmorMod(attacker, defender);
+
+        _weaponResistanceMod = WorldObject.GetWeaponResistanceModifier(Weapon, attacker, _attackSkill, DamageType, defender);
+
+        _resistanceMod = GetResistanceMod(defender, playerDefender);
+        _resistanceMod += GetRatingPierceResistanceBonus(defender, playerAttacker);
+
+        _damageResistanceRatingMod = GetDamageResistRatingMod(defender, _pkBattle);
+        _damageResistanceRatingMod += GetRatingHardenedDefenseDamageResistanceBonus(playerDefender);
+
+        _specDefenseMod = GetSpecDefenseMod(attacker, playerDefender);
+
+        ShieldMod = _defender.GetShieldMod(attacker, DamageType, Weapon);
+
+        _ratingElementalWard = GetRatingElementalWard(playerDefender);
+        _ratingSelfHarm = GetRatingSelfHarm(playerAttacker);
+        _ratingLastStand = GetRatingLastStand(defender, playerAttacker);
+
+        return _armorMod
+               * ShieldMod
+               * _resistanceMod
+               * _damageResistanceRatingMod
+               * _evasionMod
+               * _specDefenseMod
+               * _ratingElementalWard
+               * _ratingSelfHarm
+               * _ratingLastStand;
+    }
+
+    private float GetIgnoreArmorMod(Creature attacker, Creature defender)
+    {
+        var playerAttacker = attacker as Player;
+
+        var armorRendingMod = GetArmorRendingMod(defender, playerAttacker);
+        var armorCleavingMod = attacker.GetArmorCleavingMod(Weapon);
+
+        return Math.Min(armorRendingMod, armorCleavingMod);
+    }
+
+    private float GetArmorRendingMod(Creature defender, Player playerAttacker)
+    {
+        if (Weapon != null && Weapon.HasImbuedEffect(ImbuedEffectType.ArmorRending))
+        {
+            return 1.0f - WorldObject.GetArmorRendingMod(_attackSkill, playerAttacker, defender);
+        }
+
+        return 1.0f;
+    }
+
+    /// <summary>
+    /// SPEC BONUS - Martial Weapons (Spear): +10% armor penetration (additively)
+    /// </summary>
+    private float GetSpearSpecIgnoreArmorBonus(Creature attacker)
+    {
+        var playerAttacker = attacker as Player;
+
+        if (playerAttacker?.GetEquippedWeapon() == null)
         {
             return 0.0f;
         }
 
-        // ---- DAMAGE RATING ----
-        PowerMod = attacker.GetPowerMod(Weapon);
+        return IsSkillSpecialized(playerAttacker, Skill.Spear, Skill.HeavyWeapons) ? 0.1f : 0.0f;
+    }
 
-        AttributeMod = attacker.GetAttributeMod(Weapon, false, defender);
-
-        SlayerMod = WorldObject.GetWeaponCreatureSlayerModifier(Weapon, attacker, defender);
-
-        DamageRatingBaseMod = Creature.GetPositiveRatingMod(attacker.GetDamageRating());
-
-        RecklessnessMod = Creature.GetRecklessnessMod(attacker, defender);
-
-        SneakAttackMod = attacker.GetSneakAttackMod(defender, out var backstabMod);
-        var backstabPenalty = backstabMod > 0.0f ? 0.8f : 1.0f;
-
-        // Backstab Activated - If behind, can't be evaded
-        if (playerAttacker != null)
-        {
-            if (
-                playerAttacker.EquippedCombatAbility == CombatAbility.Backstab
-                && backstabMod > 0.0f
-                && playerAttacker.LastBackstabActivated > Time.GetUnixTime() - playerAttacker.BackstabActivatedDuration
-            )
-            {
-                Evaded = false;
-                PartialEvasion = PartialEvasion.None;
-            }
-        }
-
-        HeritageMod = attacker.GetHeritageBonus(Weapon) ? 1.05f : 1.0f;
-
-        // ATTACK HEIGHT BONUS: High (10 damage rating, 15 if weapon is specialized)
-        var extraDamageMod = 1.0f;
-        if (playerAttacker != null)
-        {
-            if (playerAttacker.AttackHeight == AttackHeight.High)
-            {
-                if (WeaponIsSpecialized(playerAttacker))
-                {
-                    extraDamageMod += 0.15f;
-                }
-                else
-                {
-                    extraDamageMod += 0.10f;
-                }
-            }
-        }
-
-        // Dual Wield Damage Mod
-        var dualWieldDamageMod = 1.0f;
-        if (playerAttacker != null && playerAttacker.IsDualWieldAttack && !playerAttacker.DualWieldAlternate)
-        {
-            dualWieldDamageMod = playerAttacker.GetDualWieldDamageMod();
-        }
-
-        // Two-handed Combat Damage Mod
-        var twohandedCombatDamageMod = 1.0f;
-        if (playerAttacker != null && playerAttacker.GetEquippedWeapon() != null)
-        {
-            if (playerAttacker.GetEquippedWeapon().W_WeaponType == WeaponType.TwoHanded)
-            {
-                twohandedCombatDamageMod = playerAttacker.GetTwoHandedCombatDamageMod();
-            }
-        }
-
-        // COMBAT ABILITY DAMAGE FACTORS
-        var recklessMod = 1f;
-        var multishotPenalty = 1f;
-        var provokeMod = 1f;
-        if (playerAttacker != null)
-        {
-            if (playerAttacker.EquippedCombatAbility == CombatAbility.Multishot)
-            {
-                multishotPenalty = 0.75f;
-            }
-
-            if (playerAttacker.EquippedCombatAbility == CombatAbility.Provoke)
-            {
-                if (playerAttacker.LastProvokeActivated > Time.GetUnixTime() - playerAttacker.ProvokeActivatedDuration)
-                {
-                    provokeMod += 0.2f;
-                }
-            }
-            // Reckless -- Stamp and apply bonus only if target not self, and melee / short range
-            if (playerAttacker.EquippedCombatAbility == CombatAbility.Fury && defender != playerAttacker)
-            {
-                if (CombatType == CombatType.Melee || attacker.GetDistance(defender) < 3)
-                {
-                    // 500 stacks is max, out of 2000 for a max of 25%
-                    var recklessStacks = Player.HandleRecklessStamps(playerAttacker);
-
-                    if (
-                        !playerAttacker.RecklessActivated
-                        && playerAttacker.LastRecklessActivated
-                            < Time.GetUnixTime() - playerAttacker.RecklessActivatedDuration
-                    )
-                    {
-                        recklessMod += (float)recklessStacks / 2000f;
-                    }
-
-                    if (
-                        playerAttacker.RecklessActivated
-                        && playerAttacker.LastRecklessActivated
-                            < Time.GetUnixTime() - playerAttacker.RecklessActivatedDuration
-                    )
-                    {
-                        playerAttacker.RecklessActivated = false;
-                        playerAttacker.RecklessDumped = false;
-                        playerAttacker.QuestManager.Erase($"{playerAttacker.Name},Reckless");
-                    }
-                    if (
-                        playerAttacker.RecklessActivated
-                        && playerAttacker.LastRecklessActivated
-                            > Time.GetUnixTime() - playerAttacker.RecklessActivatedDuration
-                    )
-                    {
-                        playerAttacker.RecklessActivated = false;
-                        playerAttacker.RecklessDumped = true;
-                        recklessMod += (float)recklessStacks / 1000f;
-                        playerAttacker.QuestManager.Erase($"{playerAttacker.Name},Reckless");
-                    }
-                }
-            }
-        }
-
-        DamageRatingMod = Creature.AdditiveCombine(
-            DamageRatingBaseMod,
-            RecklessnessMod,
-            SneakAttackMod,
-            HeritageMod,
-            extraDamageMod,
-            recklessMod
-        );
-
-        if (pkBattle)
-        {
-            PkDamageMod = Creature.GetPositiveRatingMod(attacker.GetPKDamageRating());
-            DamageRatingMod = Creature.AdditiveCombine(DamageRatingMod, PkDamageMod);
-        }
-
-        // LEVEL SCALING - A damage modifier for monsters to address the difference in player health at their current level and target enemy level
-        float levelScalingMod;
-
-        if (playerDefender != null)
-        {
-            levelScalingMod = LevelScaling.GetMonsterDamageDealtHealthScalar(playerDefender, attacker);
-        }
-        else
-        {
-            levelScalingMod = LevelScaling.GetMonsterDamageTakenHealthScalar(attacker, defender);
-        }
-
-        // ---- DAMAGE BEFORE MITIGATION ----
-        DamageBeforeMitigation =
-            BaseDamage
-            * AttributeMod
-            * PowerMod
-            * SlayerMod
-            * DamageRatingMod
-            * dualWieldDamageMod
-            * twohandedCombatDamageMod
-            * steadyShotActivatedMod
-            * multishotPenalty
-            * provokeMod
-            * levelScalingMod;
-
-        // JEWEL - White Quartz: Deflects damage at attacker on Block
-        if (Blocked == true && playerDefender != null && attacker.GetDistance(playerDefender) < 10)
-        {
-            if (playerDefender.GetEquippedItemsRatingSum(PropertyInt.GearThorns) > 0)
-            {
-                var thornsAmount =
-                    DamageBeforeMitigation
-                    * (float)playerDefender.GetEquippedItemsRatingSum(PropertyInt.GearThorns)
-                    / 20;
-                attacker.UpdateVitalDelta(attacker.Health, -(int)thornsAmount);
-                attacker.DamageHistory.Add(playerDefender, DamageType.Health, (uint)thornsAmount);
-                playerDefender.ShieldReprisal = (int)thornsAmount;
-                if (attacker != null && attacker.IsDead)
-                {
-                    attacker.OnDeath(attacker.DamageHistory.LastDamager, DamageType.Health, false);
-                    attacker.Die();
-                }
-            }
-        }
-
-        // ---- CRIT ----
-        var attackSkill = attacker.GetCreatureSkill(attacker.GetCurrentWeaponSkill());
-
-        CriticalChance = WorldObject.GetWeaponCriticalChance(Weapon, attacker, attackSkill, defender);
-
-        if (playerAttacker != null)
-        {
-            // Backstab combat ability bonus
-            CriticalChance += backstabMod;
-
-            // Iron Fist combat ability bonus
-            if (attackerCombatAbility == CombatAbility.IronFist)
-            {
-                if (
-                    playerAttacker.LastIronFistActivated
-                    > Time.GetUnixTime() - playerAttacker.IronFistActivatedDuration
-                )
-                {
-                    CriticalChance += 0.25f;
-                }
-                else
-                {
-                    CriticalChance += 0.1f;
-                }
-            }
-
-            if (CombatType == CombatType.Missile)
-            {
-                // critical chance bonus from accuracy bar
-                CriticalChance += playerAttacker.GetAccuracyCritChanceMod(Weapon);
-            }
-
-            if (isAttackFromSneaking)
-            {
-                CriticalChance = 1.0f;
-                if (playerDefender == null)
-                {
-                    SneakAttackMod = 3.0f;
-                }
-            }
-            if (playerAttacker.GetEquippedWeapon() != null)
-            {
-                // SPEC BONUS - Martial Weapons (Axe): +5% crit chance (additively)
-                if (
-                    playerAttacker.GetEquippedWeapon().WeaponSkill == Skill.Axe
-                    && playerAttacker.GetCreatureSkill(Skill.HeavyWeapons).AdvancementClass
-                        == SkillAdvancementClass.Specialized
-                )
-                {
-                    CriticalChance += 0.05f;
-                }
-
-                // SPEC BONUS - Dagger: +5% crit chance (additively)
-                if (
-                    playerAttacker.GetEquippedWeapon().WeaponSkill == Skill.Dagger
-                    && playerAttacker.GetCreatureSkill(Skill.Dagger).AdvancementClass
-                        == SkillAdvancementClass.Specialized
-                )
-                {
-                    CriticalChance += 0.05f;
-                }
-            }
-        }
-
-        // https://asheron.fandom.com/wiki/Announcements_-_2002/08_-_Atonement
-        // It should be noted that any time a character is logging off, PK or not, all physical attacks against them become automatically critical.
-        // (Note that spells do not share this behavior.) We hope this will stress the need to log off in a safe place.
-
-        if (playerDefender != null && (playerDefender.IsLoggingOut || playerDefender.PKLogout))
-        {
-            CriticalChance = 1.0f;
-        }
-
-        // Jewelcrafting Reprisal -- Auto crit in return
-        if (playerAttacker != null)
-        {
-            if (playerAttacker.GetEquippedItemsRatingSum(PropertyInt.GearReprisal) > 0)
-            {
-                if (playerAttacker.QuestManager.HasQuest($"{defender.Guid}/Reprisal"))
-                {
-                    CriticalChance = 1f;
-                    playerAttacker.QuestManager.Erase($"{defender.Guid}/Reprisal");
-                }
-            }
-        }
-
-        if (CriticalChance > ThreadSafeRandom.Next(0.0f, 1.0f))
-        {
-            if (playerDefender != null && playerDefender.AugmentationCriticalDefense > 0)
-            {
-                var criticalDefenseMod = playerAttacker != null ? 0.05f : 0.25f;
-                var criticalDefenseChance = playerDefender.AugmentationCriticalDefense * criticalDefenseMod;
-
-                if (criticalDefenseChance > ThreadSafeRandom.Next(0.0f, 1.0f))
-                {
-                    CriticalDefended = true;
-                }
-            }
-
-            var perceptionDefended = false;
-            // SPEC BONUS: Perception - 50% chance to defend against a critical hit
-            if (playerDefender != null)
-            {
-                var perception = playerDefender.GetCreatureSkill(Skill.AssessCreature);
-                if (perception.AdvancementClass == SkillAdvancementClass.Specialized)
-                {
-                    var skillCheck = (float)perception.Current / (float)attackSkill.Current;
-                    var criticalDefenseChance = skillCheck > 1f ? 0.5f : skillCheck * 0.5f;
-
-                    if (criticalDefenseChance > ThreadSafeRandom.Next(0f, 1f))
-                    {
-                        perceptionDefended = true;
-                        playerDefender.Session.Network.EnqueueSend(
-                            new GameMessageSystemChat(
-                                $"Your perception skill allowed you to prevent a critical strike!",
-                                ChatMessageType.CombatEnemy
-                            )
-                        );
-                    }
-                }
-            }
-
-            if (!CriticalDefended && perceptionDefended == false)
-            {
-                IsCritical = true;
-
-                // verify: CriticalMultiplier only applied to the additional crit damage,
-                // whereas CD/CDR applied to the total damage (base damage + additional crit damage)
-                CriticalDamageMod = 1.0f + WorldObject.GetWeaponCritDamageMod(Weapon, attacker, attackSkill, defender);
-
-                // Iron Fist combat ability penalty
-                if (attackerCombatAbility == CombatAbility.IronFist)
-                {
-                    CriticalDamageMod -= 0.2f;
-                }
-
-                if (playerAttacker != null && playerAttacker.GetEquippedWeapon() != null)
-                {
-                    // SPEC BONUS - Martial Weapons (Mace): +50% crit damage (additively)
-                    if (
-                        playerAttacker.GetEquippedWeapon().WeaponSkill == Skill.Mace
-                        && playerAttacker.GetCreatureSkill(Skill.HeavyWeapons).AdvancementClass
-                            == SkillAdvancementClass.Specialized
-                    )
-                    {
-                        CriticalDamageMod += 0.5f;
-                    }
-
-                    // SPEC BONUS - Staff: +50% crit damage (additively)
-                    if (
-                        playerAttacker.GetEquippedWeapon().WeaponSkill == Skill.Staff
-                        && playerAttacker.GetCreatureSkill(Skill.Staff).AdvancementClass
-                            == SkillAdvancementClass.Specialized
-                    )
-                    {
-                        CriticalDamageMod += 0.5f;
-                    }
-                }
-
-                if (CombatType == CombatType.Missile && playerAttacker != null)
-                {
-                    CriticalDamageMod += playerAttacker.GetAccuracyCritDamageMod(Weapon);
-                }
-
-                if (playerAttacker != null)
-                { // JEWEL - White Sapphire: Ramping Bludgeon Crit Damage Bonus
-                    if (playerAttacker.GetEquippedItemsRatingSum(PropertyInt.GearBludgeon) > 0)
-                    {
-                        var jewelcraftingRampMod =
-                            (float)defender.QuestManager.GetCurrentSolves($"{playerAttacker.Name},Bludgeon") / 500;
-                        var jewelcraftingBludgeMod =
-                            (float)jewelcraftingRampMod
-                            * ((float)playerAttacker.GetEquippedItemsRatingSum(PropertyInt.GearBludgeon) / 50);
-
-                        CriticalDamageMod += jewelcraftingBludgeMod;
-                    }
-                }
-
-                // Jewelcrafting Reprisal -- Evade an Incoming Crit, auto crit in return
-                if (playerDefender != null)
-                {
-                    if (playerDefender.GetEquippedItemsRatingSum(PropertyInt.GearReprisal) > 0)
-                    {
-                        if (
-                            (playerDefender.GetEquippedItemsRatingSum(PropertyInt.GearReprisal) / 2)
-                            >= ThreadSafeRandom.Next(0, 100)
-                        )
-                        {
-                            playerDefender.QuestManager.HandleReprisalQuest();
-                            playerDefender.QuestManager.Stamp($"{attacker.Guid}/Reprisal");
-                            Evaded = true;
-                            PartialEvasion = PartialEvasion.All;
-                            playerDefender.Reprisal = true;
-                        }
-                    }
-                }
-
-                CriticalDamageRatingMod = Creature.GetPositiveRatingMod(attacker.GetCritDamageRating());
-
-                // recklessness excluded from crits
-                RecklessnessMod = 1.0f;
-                DamageRatingMod = Creature.AdditiveCombine(
-                    DamageRatingBaseMod,
-                    CriticalDamageRatingMod,
-                    SneakAttackMod,
-                    HeritageMod,
-                    extraDamageMod
-                );
-
-                if (pkBattle)
-                {
-                    DamageRatingMod = Creature.AdditiveCombine(DamageRatingMod, PkDamageMod);
-                }
-
-                DamageBeforeMitigation =
-                    BaseDamageMod.MaxDamage
-                    * AttributeMod
-                    * PowerMod
-                    * SlayerMod
-                    * DamageRatingMod
-                    * CriticalDamageMod
-                    * dualWieldDamageMod
-                    * twohandedCombatDamageMod
-                    * steadyShotActivatedMod
-                    * multishotPenalty
-                    * levelScalingMod;
-            }
-        }
-
-        // ---- ARMOR ----
-        var armorRendingMod = 1.0f;
-        if (Weapon != null && Weapon.HasImbuedEffect(ImbuedEffectType.ArmorRending))
-        {
-            armorRendingMod = 1.0f - WorldObject.GetArmorRendingMod(attackSkill, playerAttacker, defender);
-        }
-
-        var armorCleavingMod = attacker.GetArmorCleavingMod(Weapon);
-
-        var ignoreArmorMod = Math.Min(armorRendingMod, armorCleavingMod);
-
-        if (playerAttacker != null && playerAttacker.GetEquippedWeapon() != null)
-        {
-            // SPEC BONUS - Two-handed combat (Spear): +10% armor penetration (additively)
-            if (
-                playerAttacker.GetEquippedWeapon().W_WeaponType == WeaponType.TwoHanded
-                && Weapon.WeaponSkill == Skill.Spear
-                && playerAttacker.GetCreatureSkill(Skill.TwoHandedCombat).AdvancementClass
-                    == SkillAdvancementClass.Specialized
-            )
-            {
-                ignoreArmorMod -= 0.1f;
-            }
-
-            // SPEC BONUS - Martial Weapons (Spear): +10% armor penetration (additively)
-            if (
-                playerAttacker.GetEquippedWeapon().WeaponSkill == Skill.Spear
-                && playerAttacker.GetCreatureSkill(Skill.HeavyWeapons).AdvancementClass
-                    == SkillAdvancementClass.Specialized
-            )
-            {
-                ignoreArmorMod -= 0.1f;
-            }
-        }
-
-        if (playerDefender != null)
-        {
-            // select random body part @ current attack height
-            GetBodyPart(AttackHeight);
-
-            // get player armor pieces
-            Armor = attacker.GetArmorLayers(playerDefender, BodyPart);
-
-            // get armor modifiers
-            ArmorMod = attacker.GetArmorMod(playerDefender, DamageType, Armor, Weapon, ignoreArmorMod);
-        }
-        else
-        {
-            // determine height quadrant
-            Quadrant = GetQuadrant(Defender, Attacker, AttackHeight, DamageSource);
-
-            // select random body part @ current attack height
-            GetBodyPart(Defender, Quadrant);
-            if (Evaded || Blocked)
-            {
-                return 0.0f;
-            }
-
-            Armor = CreaturePart.GetArmorLayers(PropertiesBodyPart.Key);
-
-            // get target armor
-            ArmorMod = CreaturePart.GetArmorMod(DamageType, Armor, Attacker, Weapon, ignoreArmorMod);
-        }
+    private float GetArmorMod(Creature attacker, Creature defender)
+    {
+        var playerDefender = defender as Player;
 
         if (Weapon != null && Weapon.HasImbuedEffect(ImbuedEffectType.IgnoreAllArmor))
         {
-            ArmorMod = 1.0f;
+            return 1.0f;
         }
-
-        // ---- RESISTANCE ----
-        WeaponResistanceMod = WorldObject.GetWeaponResistanceModifier(
-            Weapon,
-            attacker,
-            attackSkill,
-            DamageType,
-            defender
-        );
 
         if (playerDefender != null)
         {
-            ResistanceMod = playerDefender.GetResistanceMod(DamageType, Attacker, Weapon, WeaponResistanceMod);
-        }
-        else
-        {
-            var resistanceType = Creature.GetResistanceType(DamageType);
-            ResistanceMod = (float)
-                Math.Max(0.0f, defender.GetResistanceMod(resistanceType, Attacker, Weapon, WeaponResistanceMod));
+            // select random body part @ current attack height
+            GetBodyPart(_attackHeight);
+
+            // get player armor pieces
+            _armor = attacker.GetArmorLayers(playerDefender, BodyPart);
+
+            // get armor modifiers
+            return attacker.GetArmorMod(playerDefender, DamageType, _armor, Weapon, _ignoreArmorMod);
         }
 
-        if (playerAttacker != null)
-        { // JEWEL - Black Garnet - Ramping Piercing Resistance Penetration
-            if (playerAttacker.GetEquippedItemsRatingSum(PropertyInt.GearPierce) > 0 && DamageType == DamageType.Pierce)
-            {
-                var jewelcraftingRampMod =
-                    (float)defender.QuestManager.GetCurrentSolves($"{playerAttacker.Name},Pierce") / 500;
-                ResistanceMod +=
-                    (float)jewelcraftingRampMod
-                    * ((float)playerAttacker.GetEquippedItemsRatingSum(PropertyInt.GearPierce) / 66);
-            }
-        }
+        // determine height quadrant
+        _quadrant = GetQuadrant(defender, attacker, _attackHeight, _damageSource);
 
-        // ---- DAMAGE RESIST RATING ----
-        DamageResistanceRatingMod = DamageResistanceRatingBaseMod = defender.GetDamageResistRatingMod(CombatType);
+        // select random body part @ current attack height
+        GetBodyPart(defender, _quadrant);
 
-        if (IsCritical)
-        {
-            CriticalDamageResistanceRatingMod = Creature.GetNegativeRatingMod(defender.GetCritDamageResistRating());
-            DamageResistanceRatingMod = Creature.AdditiveCombine(
-                DamageResistanceRatingBaseMod,
-                CriticalDamageResistanceRatingMod
-            );
-        }
+        _armor = _creaturePart.GetArmorLayers(_propertiesBodyPart.Key);
 
-        if (pkBattle)
-        {
-            PkDamageResistanceMod = Creature.GetNegativeRatingMod(defender.GetPKDamageResistRating());
-            DamageResistanceRatingMod = Creature.AdditiveCombine(DamageResistanceRatingMod, PkDamageResistanceMod);
-        }
-        // JEWEL - Diamond: Ramping Physical Damage Reduction
+        // get target armor
+        return _creaturePart.GetArmorMod(DamageType, _armor, attacker, Weapon, _ignoreArmorMod);
+    }
+
+    private float GetResistanceMod(Creature defender, Player playerDefender)
+    {
         if (playerDefender != null)
         {
-            if (playerDefender.GetEquippedItemsRatingSum(PropertyInt.GearHardenedDefense) > 0)
-            {
-                var jewelcraftingRampMod =
-                    (float)playerDefender.QuestManager.GetCurrentSolves($"{playerDefender.Name},Hardened Defense")
-                    / 200;
-                DamageResistanceRatingMod +=
-                    jewelcraftingRampMod
-                    * ((float)playerDefender.GetEquippedItemsRatingSum(PropertyInt.GearHardenedDefense) / 66);
-            }
+            return playerDefender.GetResistanceMod(DamageType, _attacker, Weapon, _weaponResistanceMod);
         }
 
-        // SPEC BONUS: Physical Defense
-        var specDefenseMod = 1.0f;
-        if (
-            playerDefender != null
-            && playerDefender.GetCreatureSkill(Skill.MeleeDefense).AdvancementClass == SkillAdvancementClass.Specialized
-        )
-        {
-            var playerDefenderPhysicalDefense =
-                playerDefender.GetModdedMeleeDefSkill()
-                * LevelScaling.GetPlayerDefenseSkillScalar(playerDefender, attacker);
-            var bonusAmount = (float)Math.Min(playerDefenderPhysicalDefense, 500) / 50;
+        var resistanceType = Creature.GetResistanceType(DamageType);
 
-            specDefenseMod = 0.9f - bonusAmount * 0.01f;
+        return (float)Math.Max(0.0f, defender.GetResistanceMod(resistanceType, _attacker, Weapon, _weaponResistanceMod));
+    }
+
+    /// <summary>
+    /// JEWEL - Black Garnet - Ramping Piercing Resistance Penetration
+    /// </summary>
+    private float GetRatingPierceResistanceBonus(Creature defender, Player playerAttacker)
+    {
+        if (playerAttacker == null)
+        {
+            return 0.0f;
         }
 
-        // ---- SHIELD ----
-        ShieldMod = defender.GetShieldMod(attacker, DamageType, Weapon);
-
-        var jewelProtection = 1f;
-        if (playerDefender != null)
+        if (playerAttacker.GetEquippedItemsRatingSum(PropertyInt.GearPierce) <= 0 || DamageType != DamageType.Pierce)
         {
-            // JEWEL - Onyx: Protection vs. Slash/Pierce/Bludgeon
-            if (DamageType == DamageType.Slash || DamageType == DamageType.Pierce || DamageType == DamageType.Bludgeon)
+            return 0.0f;
+        }
+
+        var jewelcraftingRampMod = (float)defender.QuestManager.GetCurrentSolves($"{playerAttacker.Name},Pierce") / 500;
+
+        return jewelcraftingRampMod * ((float)playerAttacker.GetEquippedItemsRatingSum(PropertyInt.GearPierce) / 66);
+    }
+
+    /// <summary>
+    /// JEWEL - Onyx: Protection vs. Slash/Pierce/Bludgeon
+    /// JEWEL - Zircon: Protection vs. Acid/Fire/Cold/Electric
+    /// </summary>
+    private float GetRatingElementalWard(Player playerDefender)
+    {
+        if (playerDefender == null)
+        {
+            return 1.0f;
+        }
+
+        switch (DamageType)
+        {
+            case DamageType.Slash:
+            case DamageType.Pierce:
+            case DamageType.Bludgeon:
             {
                 if (playerDefender.GetEquippedItemsRatingSum(PropertyInt.GearPhysicalWard) > 0)
                 {
-                    jewelProtection = (
-                        1 - ((float)playerDefender.GetEquippedItemsRatingSum(PropertyInt.GearPhysicalWard) / 100)
-                    );
+                    return (1 - ((float)playerDefender.GetEquippedItemsRatingSum(PropertyInt.GearPhysicalWard) / 100));
                 }
+
+                break;
             }
-            // JEWEL - Zircon: Protection vs. Acid/Fire/Cold/Electric
-            if (
-                DamageType == DamageType.Acid
-                || DamageType == DamageType.Fire
-                || DamageType == DamageType.Cold
-                || DamageType == DamageType.Electric
-            )
+            case DamageType.Acid:
+            case DamageType.Fire:
+            case DamageType.Cold:
+            case DamageType.Electric:
             {
                 if (playerDefender.GetEquippedItemsRatingSum(PropertyInt.GearElementalWard) > 0)
                 {
-                    jewelProtection = (
-                        1 - ((float)playerDefender.GetEquippedItemsRatingSum(PropertyInt.GearElementalWard) / 100)
-                    );
+                    return (1 - ((float)playerDefender.GetEquippedItemsRatingSum(PropertyInt.GearElementalWard) / 100));
                 }
+
+                break;
             }
+            default:
+                return 1.0f;
         }
 
-        var jewelSelfHarm = 1f;
-        var jewelLastStand = 1f;
-        var jewelElemental = 1f;
+        return 1.0f;
+    }
 
-        if (playerAttacker != null)
+    /// <summary>
+    /// JEWEL - Ruby: Bonus damage below 50% HP, reduced damage above
+    /// </summary>
+    private static float GetRatingLastStand(Creature defender, Player playerAttacker)
+    {
+        if (playerAttacker == null)
         {
-            // JEWEL - Hematite: Deal bonus damage but take the same amount
-            if (playerAttacker.GetEquippedItemsRatingSum(PropertyInt.GearSelfHarm) > 0)
-            {
-                jewelSelfHarm += (float)(playerAttacker.GetEquippedItemsRatingSum(PropertyInt.GearSelfHarm) / 100);
-            }
-            // JEWEL - Ruby: Bonus damage below 50% HP, reduced damage above
-            if (playerAttacker.GetEquippedItemsRatingSum(PropertyInt.GearLastStand) > 0)
-            {
-                jewelLastStand += Jewel.GetJewelLastStand(playerAttacker, defender);
-            }
-            // JEWEL - Aquamarine, Emerald, Jet, Red Garnet: Bonus elemental damage
-            jewelElemental = Jewel.HandleElementalBonuses(playerAttacker, DamageType);
+            return 1.0f;
         }
 
-        // ---- FINAL CALCULATIONS ----
-        Damage =
-            DamageBeforeMitigation
-            * ArmorMod
-            * ShieldMod
-            * ResistanceMod
-            * DamageResistanceRatingMod
-            * evasionMod
-            * backstabPenalty
-            * specDefenseMod
-            * jewelProtection
-            * jewelSelfHarm
-            * jewelLastStand
-            * jewelElemental;
+        if (playerAttacker.GetEquippedItemsRatingSum(PropertyInt.GearLastStand) > 0)
+        {
+            return 1.0f + Jewel.GetJewelLastStand(playerAttacker, defender);
+        }
 
-        DamageMitigated = DamageBeforeMitigation - Damage;
+        return 1.0f;
+    }
 
-        // --- JEWELCRAFTING POST-DAMAGE STAMPS / PROCS / BONUSES
+    /// <summary>
+    /// JEWEL - Hematite: Deal bonus damage but take the same amount
+    /// </summary>
+    private static float GetRatingSelfHarm(Player playerAttacker)
+    {
+        if (playerAttacker == null)
+        {
+            return 1.0f;
+        }
+
+        if (playerAttacker.GetEquippedItemsRatingSum(PropertyInt.GearSelfHarm) > 0)
+        {
+            return (playerAttacker.GetEquippedItemsRatingSum(PropertyInt.GearSelfHarm) / 100);
+        }
+
+        return 1.0f;
+    }
+
+    private void PostDamageEffects(Creature attacker, Creature defender, WorldObject damageSource)
+    {
+        var playerAttack = attacker as Player;
+        var playerDefender = defender as Player;
+
+        CheckForJewelPostDamageEffects(attacker, defender, damageSource, playerAttack, playerDefender);
+        CheckForCombatAbilityFuryRecklessSelfDamage(playerAttack);
+    }
+
+    /// <summary>
+    /// JEWELCRAFTING POST-DAMAGE STAMPS / PROCS / BONUSES
+    /// </summary>
+    private void CheckForJewelPostDamageEffects(Creature attacker, Creature defender, WorldObject damageSource,
+        Player playerAttacker, Player playerDefender)
+    {
         if (playerAttacker != null)
         {
             Jewel.HandlePlayerAttackerBonuses(playerAttacker, defender, Damage, DamageType);
@@ -950,55 +1067,364 @@ public class DamageEvent
             Jewel.HandleMeleeDefenderBonuses(playerDefender, attacker, Damage);
             Jewel.HandlePlayerDefenderBonuses(playerDefender, attacker, Damage);
         }
+    }
 
-        // --- COMBAT ABILITY: FURY SELF-HARM CHANCE - 50% of the damage done to the enemy on this attack, or 10% of player max health, whichever is smaller
-
-        if (playerAttacker != null && playerAttacker.EquippedCombatAbility == CombatAbility.Fury)
+    /// <summary>
+    /// COMBAT ABILITY - Fury Self-damage chance with reckless attacks.
+    /// Max Fury stacks = 500. Become "Reckless" at 250 stacks. Self-damage chance grows as player gets closer
+    /// to 500 stacks. Max chance = 10%. When Self-damage occurs, attacker takes damage equal to
+    /// 50% of the damage done to the enemy on this attack, or 10% of player max health, whichever is smaller.
+    /// </summary>
+    private void CheckForCombatAbilityFuryRecklessSelfDamage(Player playerAttacker)
+    {
+        if (playerAttacker == null || playerAttacker.EquippedCombatAbility != CombatAbility.Fury)
         {
-            var stacks = playerAttacker.QuestManager.GetCurrentSolves($"{playerAttacker.Name},Reckless");
-            if (stacks > 250)
-            {
-                var recklessChance = 0.075f * (stacks - 250) / 250;
-                if (recklessChance > ThreadSafeRandom.Next(0f, 1f))
-                {
-                    var damageDealt = (uint)(Damage / 2);
-                    var percentHealth = playerAttacker.Health.MaxValue / 10;
-                    var damage = Math.Min(damageDealt, percentHealth);
-
-                    playerAttacker.UpdateVitalDelta(playerAttacker.Health, -(int)damage);
-                    playerAttacker.DamageHistory.Add(playerAttacker, DamageType.Health, damage);
-                    playerAttacker.Session.Network.EnqueueSend(
-                        new GameMessageSystemChat(
-                            $"In your rage, you injure yourself, suffering {damage} points of damage!",
-                            ChatMessageType.CombatSelf
-                        )
-                    );
-                    playerAttacker.PlayParticleEffect(PlayScript.SplatterMidLeftFront, playerAttacker.Guid);
-                    if (playerAttacker.IsDead)
-                    {
-                        var lastDamager = new DamageHistoryInfo(playerAttacker);
-
-                        playerAttacker.OnDeath(lastDamager, DamageType.Health, false);
-                        playerAttacker.Die();
-                    }
-                }
-            }
+            return;
         }
 
-        // ---- OPTIONAL GLOBAL MULTIPLIERS FOR PLAYERS or MONSTERS ----
-        if (attacker.IsMonster)
+        const int recklessThreshold = 250;
+        var stacks = playerAttacker.QuestManager.GetCurrentSolves($"{playerAttacker.Name},Reckless");
+
+        if (stacks <= recklessThreshold)
         {
-            Damage *= 1.0f;
+            return;
         }
 
-        if (!attacker.IsMonster)
+        var recklessChance = 0.1f * (stacks - recklessThreshold) / recklessThreshold;
+
+        if (!(recklessChance > ThreadSafeRandom.Next(0f, 1f)))
         {
-            Damage *= 1.0f;
+            return;
         }
 
-        //DpsLogging(attacker, attackSkill, defender, dualWieldDamageMod, twohandedCombatDamageMod, steadyShotActivatedMod, multishotPenalty, provokeMod, levelScalingMod);
+        var damageDealt = (uint)(Damage / 2);
+        var percentHealth = playerAttacker.Health.MaxValue / 10;
+        var damage = Math.Min(damageDealt, percentHealth);
 
-        return Damage;
+        playerAttacker.UpdateVitalDelta(playerAttacker.Health, -(int)damage);
+        playerAttacker.DamageHistory.Add(playerAttacker, DamageType.Health, damage);
+
+        playerAttacker.Session.Network.EnqueueSend(
+            new GameMessageSystemChat(
+                $"In your rage, you injure yourself, suffering {damage} points of damage!",
+                ChatMessageType.CombatSelf
+            )
+        );
+
+        playerAttacker.PlayParticleEffect(PlayScript.SplatterMidLeftFront, playerAttacker.Guid);
+
+        if (!playerAttacker.IsDead)
+        {
+            return;
+        }
+
+        var lastDamager = new DamageHistoryInfo(playerAttacker);
+
+        playerAttacker.OnDeath(lastDamager, DamageType.Health, false);
+        playerAttacker.Die();
+    }
+
+    /// <summary>
+    /// SPEC BONUS: Physical Defense
+    /// </summary>
+    private static float GetSpecDefenseMod(Creature attacker, Player playerDefender)
+    {
+        if (playerDefender == null || playerDefender.GetCreatureSkill(Skill.MeleeDefense).AdvancementClass !=
+            SkillAdvancementClass.Specialized)
+        {
+            return 1.0f;
+        }
+
+        var playerDefenderPhysicalDefense = playerDefender.GetModdedMeleeDefSkill() *
+                                            LevelScaling.GetPlayerDefenseSkillScalar(playerDefender, attacker);
+        var bonusAmount = (float)Math.Min(playerDefenderPhysicalDefense, 500) / 50;
+
+        return 0.9f - bonusAmount * 0.01f;
+    }
+
+    /// <summary>
+    /// JEWEL - Diamond: Ramping Physical Damage Reduction
+    /// </summary>
+    private static float GetRatingHardenedDefenseDamageResistanceBonus(Player playerDefender)
+    {
+        if (playerDefender == null)
+        {
+            return 0.0f;
+        }
+
+        if (playerDefender.GetEquippedItemsRatingSum(PropertyInt.GearHardenedDefense) <= 0)
+        {
+            return 0.0f;
+        }
+
+        var jewelcraftingRampMod =
+            (float)playerDefender.QuestManager.GetCurrentSolves($"{playerDefender.Name},Hardened Defense") / 200;
+
+        return jewelcraftingRampMod *
+               ((float)playerDefender.GetEquippedItemsRatingSum(PropertyInt.GearHardenedDefense) / 66);
+    }
+
+    private float GetDamageResistRatingMod(Creature defender, bool pkBattle)
+    {
+        _damageResistanceRatingBaseMod = defender.GetDamageResistRatingMod(CombatType);
+
+        if (IsCritical)
+        {
+            _criticalDamageResistanceRatingMod = Creature.GetNegativeRatingMod(defender.GetCritDamageResistRating());
+            return Creature.AdditiveCombine(_damageResistanceRatingBaseMod, _criticalDamageResistanceRatingMod);
+        }
+
+        if (pkBattle)
+        {
+            _pkDamageResistanceMod = Creature.GetNegativeRatingMod(defender.GetPKDamageResistRating());
+            return Creature.AdditiveCombine(_damageResistanceRatingBaseMod, _pkDamageResistanceMod);
+        }
+
+        return _damageResistanceRatingBaseMod;
+    }
+
+    private void CheckForRatingReprisalCriticalDefense(Creature attacker, Player playerDefender)
+    {
+        // Jewelcrafting Reprisal -- Evade an Incoming Crit, auto crit in return
+        if (playerDefender == null)
+        {
+            return;
+        }
+
+        if (playerDefender.GetEquippedItemsRatingSum(PropertyInt.GearReprisal) <= 0)
+        {
+            return;
+        }
+
+        if ((playerDefender.GetEquippedItemsRatingSum(PropertyInt.GearReprisal) / 2) < ThreadSafeRandom.Next(0, 100))
+        {
+            return;
+        }
+
+        playerDefender.QuestManager.HandleReprisalQuest();
+        playerDefender.QuestManager.Stamp($"{attacker.Guid}/Reprisal");
+        Evaded = true;
+        PartialEvasion = PartialEvasion.All;
+        playerDefender.Reprisal = true;
+    }
+
+    /// <summary>
+    /// JEWEL - White Sapphire: Ramping Bludgeon Crit Damage Bonus
+    /// </summary>
+    private static float GetRatingBludgeonCriticalDamageBonus(Creature defender, Player playerAttacker)
+    {
+        if (playerAttacker == null)
+        {
+            return 0.0f;
+        }
+
+        if (playerAttacker.GetEquippedItemsRatingSum(PropertyInt.GearBludgeon) <= 0)
+        {
+            return 0.0f;
+        }
+
+        var jewelcraftingRampMod =
+            (float)defender.QuestManager.GetCurrentSolves($"{playerAttacker.Name},Bludgeon") / 500;
+
+        return jewelcraftingRampMod * ((float)playerAttacker.GetEquippedItemsRatingSum(PropertyInt.GearBludgeon) / 50);
+    }
+
+    /// <summary>
+    /// SPEC BONUS - Staff: +50% crit damage (additively)
+    /// </summary>
+    private static float GetStaffSpecCriticalDamageBonus(Player playerAttacker)
+    {
+        if (playerAttacker?.GetEquippedWeapon() == null)
+        {
+            return 0.0f;
+        }
+
+        return IsSkillSpecialized(playerAttacker, Skill.Staff, Skill.Staff) ? 0.5f : 0.0f;
+    }
+
+    /// <summary>
+    /// SPEC BONUS - Martial Weapons (Mace): +50% crit damage (additively)
+    /// </summary>
+    private static float GetMaceSpecCriticalDamageBonus(Player playerAttacker)
+    {
+        if (playerAttacker?.GetEquippedWeapon() == null)
+        {
+            return 0.0f;
+        }
+
+        return IsSkillSpecialized(playerAttacker, Skill.Mace, Skill.HeavyWeapons) ? 0.5f : 0.0f;
+    }
+
+    /// <summary>
+    /// SPEC BONUS - Perception - 50% chance to defend against a critical hit
+    /// </summary>
+    private bool CheckForSpecPerceptionCriticalDefense(Player playerDefender)
+    {
+        if (playerDefender == null)
+        {
+            return false;
+        }
+
+        var perception = playerDefender.GetCreatureSkill(Skill.AssessCreature);
+        if (perception.AdvancementClass != SkillAdvancementClass.Specialized)
+        {
+            return false;
+        }
+
+        var skillCheck = (float)perception.Current / (float)_attackSkill.Current;
+        var criticalDefenseChance = skillCheck > 1f ? 0.5f : skillCheck * 0.5f;
+
+        if (!(criticalDefenseChance > ThreadSafeRandom.Next(0f, 1f)))
+        {
+            return false;
+        }
+
+        playerDefender.Session.Network.EnqueueSend(
+            new GameMessageSystemChat(
+                $"Your perception skill allowed you to prevent a critical strike!",
+                ChatMessageType.CombatEnemy
+            )
+        );
+
+        return true;
+    }
+
+    private static bool CheckForAugmentationCriticalDefense(Player playerDefender, Player playerAttacker)
+    {
+        if (playerDefender == null || playerDefender.AugmentationCriticalDefense <= 0)
+        {
+            return false;
+        }
+
+        var criticalDefenseMod = playerAttacker != null ? 0.05f : 0.25f;
+        var criticalDefenseChance = playerDefender.AugmentationCriticalDefense * criticalDefenseMod;
+
+        return !(criticalDefenseChance < ThreadSafeRandom.Next(0.0f, 1.0f));
+    }
+
+    private bool CheckForRatingReprisal(Creature playerAttacker)
+    {
+        if (playerAttacker == null)
+        {
+            return false;
+        }
+
+        if (playerAttacker.GetEquippedItemsRatingSum(PropertyInt.GearReprisal) <= 0)
+        {
+            return false;
+        }
+
+        if (!playerAttacker.QuestManager.HasQuest($"{_defender.Guid}/Reprisal"))
+        {
+            return false;
+        }
+
+        playerAttacker.QuestManager.Erase($"{_defender.Guid}/Reprisal");
+        return true;
+    }
+
+    /// <summary>
+    /// SPEC BONUS - Axe/Dagger: +5% crit chance
+    /// </summary>
+    private float GetPlayerSpecSkillCriticalChanceBonus()
+    {
+        if (_playerAttacker?.GetEquippedWeapon() == null)
+        {
+            return 0.0f;
+        }
+
+        // SPEC BONUS - Martial Weapons (Axe): +5% crit chance (additively)
+        if (IsSkillSpecialized(_playerAttacker, Skill.Axe, Skill.HeavyWeapons))
+        {
+            return 0.05f;
+        }
+
+        // SPEC BONUS - Dagger: +5% crit chance (additively)
+        if (IsSkillSpecialized(_playerAttacker, Skill.Dagger, Skill.Dagger))
+        {
+            return 0.05f;
+        }
+
+        return 0.0f;
+    }
+
+    private static bool IsSkillSpecialized(Player playerAttacker, Skill weaponSkill, Skill creatureSkill)
+    {
+        return playerAttacker.GetEquippedWeapon().WeaponSkill == weaponSkill
+               && playerAttacker.GetCreatureSkill(creatureSkill).AdvancementClass
+               == SkillAdvancementClass.Specialized;
+    }
+
+    /// <summary>
+    /// Rating Thorns - Reflects damage on block (JEWEL - White Quartz)
+    /// </summary>
+    private void CheckForRatingThorns(Creature attacker, Creature defender, WorldObject damageSource)
+    {
+        var playerDefender = defender as Player;
+
+        if (Blocked != true || playerDefender == null || !(attacker.GetDistance(playerDefender) < 10))
+        {
+            return;
+        }
+
+        if (playerDefender.GetEquippedItemsRatingSum(PropertyInt.GearThorns) <= 0)
+        {
+            return;
+        }
+
+        SetBaseDamage(attacker, defender, damageSource);
+        SetDamageModifiers(attacker, defender);
+
+        var damage = GetNonCriticalDamageBeforeMitigation();
+
+        var thornsAmount = damage * playerDefender.GetEquippedItemsRatingSum(PropertyInt.GearThorns) / 20;
+
+        attacker.UpdateVitalDelta(attacker.Health, -(int)thornsAmount);
+        attacker.DamageHistory.Add(playerDefender, DamageType.Health, (uint)thornsAmount);
+        playerDefender.ShieldReprisal = (int)thornsAmount;
+
+        if (!attacker.IsDead)
+        {
+            return;
+        }
+
+        attacker.OnDeath(attacker.DamageHistory.LastDamager, DamageType.Health);
+        attacker.Die();
+    }
+
+    private void CheckForParryRiposte(Creature attacker, Creature defender, WorldObject damageSource)
+    {
+        var playerDefender = defender as Player;
+
+        if (!Blocked || playerDefender == null)
+        {
+            return;
+        }
+
+        if (_defenderCombatAbility != CombatAbility.Parry
+            || !(playerDefender.LastParryActivated > Time.GetUnixTime() - playerDefender.ParryActivatedDuration)
+            || !(attacker.GetDistance(playerDefender) < 3))
+        {
+            return;
+        }
+
+        if (playerDefender.TwoHandedCombat || playerDefender.IsDualWieldAttack)
+        {
+            playerDefender.DamageTarget(attacker, damageSource);
+        }
+    }
+
+    private bool IsAttackFromStealth()
+    {
+        if (_playerAttacker == null)
+        {
+            return false;
+        }
+
+        var isAttackFromStealth = _playerAttacker.IsAttackFromStealth;
+        _playerAttacker.IsAttackFromStealth = false;
+
+        return isAttackFromStealth;
     }
 
     public Quadrant GetQuadrant(
@@ -1026,18 +1452,16 @@ public class DamageEvent
         var playerDefender = defender as Player;
         var isPvP = playerAttacker != null && playerDefender != null;
 
-        AccuracyMod = attacker.GetAccuracySkillMod(Weapon);
+        _accuracyMod = attacker.GetAccuracySkillMod(Weapon);
 
         EffectiveAttackSkill = (uint)(
             attacker.GetEffectiveAttackSkill() * LevelScaling.GetPlayerAttackSkillScalar(playerAttacker, defender)
         );
 
-        EffectiveDefenseSkill = (uint)(
+        _effectiveDefenseSkill = (uint)(
             defender.GetEffectiveDefenseSkill(CombatType)
             * LevelScaling.GetPlayerDefenseSkillScalar(playerDefender, attacker)
         );
-
-        GetCombatAbilities(attacker, defender, out var attackerCombatAbility, out var defenderCombatAbility);
 
         // ATTACK HEIGHT BONUS: Medium (+10% attack skill, +15% if weapon specialized)
         if (playerAttacker != null)
@@ -1062,7 +1486,7 @@ public class DamageEvent
         // ATTACK HEIGHT BONUS: Low (+10% physical defense skill, +15% if weapon specialized)
         if (playerDefender != null)
         {
-            if (playerDefender != null && playerDefender.AttackHeight == AttackHeight.Low)
+            if (playerDefender.AttackHeight == AttackHeight.Low)
             {
                 float bonus;
 
@@ -1075,14 +1499,14 @@ public class DamageEvent
                     bonus = 1.1f;
                 }
 
-                EffectiveDefenseSkill = (uint)Math.Round(EffectiveDefenseSkill * bonus);
+                _effectiveDefenseSkill = (uint)Math.Round(_effectiveDefenseSkill * bonus);
             }
         }
 
         // COMBAT FOCUS - Steady Shot
         if (playerAttacker != null)
         {
-            if (attackerCombatAbility == CombatAbility.SteadyShot)
+            if (_attackerCombatAbility == CombatAbility.SteadyShot)
             {
                 var bonus = 1.2f;
 
@@ -1091,7 +1515,8 @@ public class DamageEvent
         }
 
         if (playerDefender != null)
-        { // JEWEL - Fire Opal: Evade chance bonus for having attacked target creature
+        {
+            // JEWEL - Fire Opal: Evade chance bonus for having attacked target creature
             if (playerDefender.GetEquippedItemsRatingSum(PropertyInt.GearFamiliarity) > 0)
             {
                 if (attacker.QuestManager.HasQuest($"{playerDefender.Name},Familiarity"))
@@ -1112,7 +1537,8 @@ public class DamageEvent
         }
 
         if (playerAttacker != null)
-        { // JEWEL - Yellow Garnet: Hit chance bonus for having been attacked frequently
+        {
+            // JEWEL - Yellow Garnet: Hit chance bonus for having been attacked frequently
             if (playerAttacker.GetEquippedItemsRatingSum(PropertyInt.GearBravado) > 0)
             {
                 if (playerAttacker.QuestManager.HasQuest($"{playerAttacker.Name},Bravado"))
@@ -1127,17 +1553,17 @@ public class DamageEvent
             }
         }
 
-        var evadeChance = 1.0f - SkillCheck.GetSkillChance(EffectiveAttackSkill, EffectiveDefenseSkill);
+        var evadeChance = 1.0f - SkillCheck.GetSkillChance(EffectiveAttackSkill, _effectiveDefenseSkill);
 
         // COMBAT FOCUS - Smokescreen (+10% chance to evade, +40% on Activated)
-        if (defenderCombatAbility == CombatAbility.Smokescreen)
+        if (_defenderCombatAbility == CombatAbility.Smokescreen)
         {
             evadeChance += 0.1f;
 
             if (
                 playerDefender != null
                 && playerDefender.LastSmokescreenActivated
-                    > Time.GetUnixTime() - playerDefender.SmokescreenActivatedDuration
+                > Time.GetUnixTime() - playerDefender.SmokescreenActivatedDuration
             )
             {
                 evadeChance += 0.3f;
@@ -1157,243 +1583,13 @@ public class DamageEvent
     }
 
     /// <summary>
-    /// If evade succeeded, determine if evade was partial or full. Return true if full.
-    /// </summary>
-    private bool GetEvadedMod(Creature attacker, Creature defender, out float evasionMod)
-    {
-        evasionMod = 1.0f;
-
-        if (attacker != defender && EvasionChance > ThreadSafeRandom.Next(0.0f, 1.0f))
-        {
-            var fullEvadeChance = 0.25f; // 25%
-            var partialEvadeChance = 0.75f; // 50%
-            var noEvadeChance = 1.0f; // 25%
-
-            var attackRoll = ThreadSafeRandom.Next(0.0f, 1.0f);
-
-            //Console.WriteLine($"BaseEvasionChance: {Math.Round(EvasionChance * 100)}% AttackRoll: {Math.Round(attackRoll * 100)}");
-            //Console.WriteLine($"FullEvadeChance: {Math.Round(fullEvade * 100)}% MostEvadeChance: {Math.Round(mostEvade * 100)}% SomeEvadeChance: {Math.Round(someEvade * 100)}");
-
-            // full evade
-
-            if (attacker != defender && fullEvadeChance > attackRoll)
-            {
-                //Console.WriteLine($"Full Evade");
-                Evaded = true;
-                return true;
-            }
-            // partial evade
-            else
-            {
-                GetCombatAbilities(attacker, defender, out var attackerCombatAbility, out var defenderCombatAbility);
-
-                if (partialEvadeChance > attackRoll) // Evaded 50% of
-                {
-                    //Console.WriteLine($"Partial Evade");
-                    if (defenderCombatAbility == CombatAbility.Provoke) // 50% less damage received from Glancing Blows
-                    {
-                        evasionMod = 0.25f;
-                        PartialEvasion = PartialEvasion.Some;
-                    }
-                    else
-                    {
-                        evasionMod = 0.5f;
-                        PartialEvasion = PartialEvasion.Some;
-                    }
-                }
-                else if (noEvadeChance > attackRoll) // No Evade
-                {
-                    //Console.WriteLine($"No Evade");
-
-                    evasionMod = 1.0f;
-                    PartialEvasion = PartialEvasion.None;
-                }
-            }
-            //Console.WriteLine($"EvasionMod: {Math.Round(evasionMod * 100)}%");
-            //if (!attacker.IsMonster)
-            //{
-            //    Console.WriteLine($"{attacker.Name} vs {defender.Name}:\n" +
-            //        $" -AttackRoll: {Math.Round(attackRoll * 100)}\n" +
-            //        $" -EvasionChance: {Math.Round(EvasionChance * 100)}%\n" +
-            //        $" -FullEvadeChance: {Math.Round(fullEvadeChance * 100)}%\n" +
-            //        $" -EvasionMod: {Math.Round(evasionMod * 100)}% (IF PARTIAL EVADE)");
-            //}
-        }
-        return false;
-    }
-
-    private bool IsBlocked(Creature attacker, Creature defender)
-    {
-        var playerAttacker = attacker as Player;
-        var playerDefender = defender as Player;
-
-        var blockChance = 0.0f;
-
-        var effectiveAngle = 180.0f;
-
-        // SPEC BONUS - Shield: Increase shield effective angle to 225 degrees
-        if (
-            playerDefender != null
-            && playerDefender.GetCreatureSkill(Skill.Shield).AdvancementClass == SkillAdvancementClass.Specialized
-        )
-        {
-            effectiveAngle = 225.0f;
-        }
-
-        // check for frontal radius prior to allowing a block unless PhalanxActivated
-        if (
-            playerDefender == null
-            || playerDefender.EquippedCombatAbility != CombatAbility.Phalanx
-            || playerDefender.LastPhalanxActivated < Time.GetUnixTime() - playerDefender.PhalanxActivatedDuration
-            || playerDefender.GetEquippedShield == null
-        )
-        {
-            var angle = defender.GetAngle(attacker);
-            if (Math.Abs(angle) > effectiveAngle / 2.0f)
-            {
-                return false;
-            }
-        }
-
-        var defenderEquippedShield = defender.GetEquippedShield();
-        if (
-            defenderEquippedShield != null
-            && defender.GetCreatureSkill(Skill.MeleeDefense).AdvancementClass == SkillAdvancementClass.Specialized
-        )
-        {
-            AccuracyMod = attacker.GetAccuracySkillMod(Weapon);
-            EffectiveAttackSkill = attacker.GetEffectiveAttackSkill();
-
-            GetCombatAbilities(attacker, defender, out var attackerCombatAbility, out var defenderCombatAbility);
-
-            // ATTACK HEIGHT BONUS: Medium (+10% attack skill, +15% if weapon specialized)
-            if (playerAttacker != null)
-            {
-                if (playerAttacker.AttackHeight == AttackHeight.Medium)
-                {
-                    float bonus;
-
-                    if (WeaponIsSpecialized(playerAttacker))
-                    {
-                        bonus = 1.15f;
-                    }
-                    else
-                    {
-                        bonus = 1.1f;
-                    }
-
-                    EffectiveAttackSkill = (uint)Math.Round(EffectiveAttackSkill * bonus);
-                }
-            }
-
-            if (defenderEquippedShield != null)
-            {
-                var shieldArmorLevel = defenderEquippedShield.ArmorLevel ?? 0;
-
-                var blockChanceMod = SkillCheck.GetSkillChance((uint)shieldArmorLevel, EffectiveAttackSkill);
-
-                blockChance = 0.1f + 0.1f * (float)blockChanceMod;
-            }
-        }
-        // COMBAT ABILITY - Parry: 20% chance to block attacks while using a two-handed weapon or dual-wielding
-        else if (playerDefender != null && playerDefender.EquippedCombatAbility == CombatAbility.Parry)
-        {
-            if (playerDefender.TwoHandedCombat || playerDefender.IsDualWieldAttack)
-            {
-                blockChance = 0.2f;
-
-                if (playerDefender.LastParryActivated > Time.GetUnixTime() - playerDefender.ParryActivatedDuration)
-                {
-                    blockChance += 0.15f;
-                }
-            }
-        }
-
-        // COMBAT ABILITY - Phalanx: Activated Block Bonus
-        if (
-            playerDefender != null
-            && playerDefender.LastPhalanxActivated > Time.GetUnixTime() - playerDefender.PhalanxActivatedDuration
-            && playerDefender.GetEquippedShield != null
-        )
-        {
-            blockChance += 0.5f;
-        }
-
-        // JEWEL - Turquoise: Passive Block %
-        if (defender.GetEquippedItemsRatingSum(PropertyInt.GearBlock) > 0)
-        {
-            blockChance += (float)(defender.GetEquippedItemsRatingSum(PropertyInt.GearBlock) / 100);
-        }
-
-        if (ThreadSafeRandom.Next(0f, 1f) < blockChance)
-        {
-            return true;
-        }
-
-        return false;
-    }
-
-    public static void GetCombatAbilities(
-        Creature attacker,
-        Creature defender,
-        out CombatAbility attackerCombatAbility,
-        out CombatAbility defenderCombatAbility
-    )
-    {
-        attackerCombatAbility = CombatAbility.None;
-        defenderCombatAbility = CombatAbility.None;
-
-        if (attacker != null)
-        {
-            var attackerCombatFocus = attacker.GetEquippedCombatFocus();
-            if (attackerCombatFocus != null)
-            {
-                attackerCombatAbility = attackerCombatFocus.GetCombatAbility();
-            }
-        }
-
-        if (defender != null)
-        {
-            var defenderCombatFocus = defender.GetEquippedCombatFocus();
-            if (defenderCombatFocus != null)
-            {
-                defenderCombatAbility = defenderCombatFocus.GetCombatAbility();
-            }
-        }
-    }
-
-    private float GetEvasionMod(Creature attacker, Creature defender)
-    {
-        var evasionMod = 1.0f;
-
-        if (!Overpower)
-        {
-            var defenderSkillAmount = defender.GetEffectiveDefenseSkill(CombatType);
-
-            // This optionally adds a curve to how effective evasion can be as a character levels
-            //var evasionDefenseMod = 1 - (200 / (200 + defenderSkillAmount));
-            //EvasionChance = GetEvadeChance(attacker, defender) * evasionDefenseMod;
-
-            EvasionChance = GetEvadeChance(attacker, defender);
-
-            var evaded = GetEvadedMod(attacker, defender, out evasionMod);
-            if (evaded)
-            {
-                return 0.0f;
-            }
-        }
-
-        return evasionMod;
-    }
-
-    /// <summary>
     /// Returns the base damage for a player attacker
     /// </summary>
-    public void GetBaseDamage(Player attacker)
+    private void GetBaseDamage(Player attacker)
     {
-        if (DamageSource.ItemType == ItemType.MissileWeapon)
+        if (_damageSource.ItemType == ItemType.MissileWeapon)
         {
-            DamageType = DamageSource.W_DamageType;
+            DamageType = _damageSource.W_DamageType;
 
             // handle prismatic arrows
             if (DamageType == DamageType.Base)
@@ -1414,21 +1610,21 @@ public class DamageEvent
         }
 
         // TODO: combat maneuvers for player?
-        BaseDamageMod = attacker.GetBaseDamageMod(DamageSource);
+        _baseDamageMod = attacker.GetBaseDamageMod(_damageSource);
 
         // some quest bows can have built-in damage bonus
         if (Weapon?.WeenieType == WeenieType.MissileLauncher)
         {
-            BaseDamageMod.DamageBonus += Weapon.Damage ?? 0;
+            _baseDamageMod.DamageBonus += Weapon.Damage ?? 0;
         }
 
-        if (DamageSource.ItemType == ItemType.MissileWeapon)
+        if (_damageSource.ItemType == ItemType.MissileWeapon)
         {
-            BaseDamageMod.ElementalBonus = WorldObject.GetMissileElementalDamageBonus(Weapon, attacker, DamageType);
-            BaseDamageMod.DamageMod = WorldObject.GetMissileElementalDamageModifier(Weapon, DamageType);
+            _baseDamageMod.ElementalBonus = WorldObject.GetMissileElementalDamageBonus(Weapon, attacker, DamageType);
+            _baseDamageMod.DamageMod = WorldObject.GetMissileElementalDamageModifier(Weapon, DamageType);
         }
 
-        BaseDamage = (float)ThreadSafeRandom.Next(BaseDamageMod.MinDamage, BaseDamageMod.MaxDamage);
+        _baseDamage = (float)ThreadSafeRandom.Next(_baseDamageMod.MinDamage, _baseDamageMod.MaxDamage);
     }
 
     /// <summary>
@@ -1436,17 +1632,17 @@ public class DamageEvent
     /// </summary>
     public void GetBaseDamage(Creature attacker, MotionCommand motionCommand, AttackHook attackHook)
     {
-        AttackPart = attacker.GetAttackPart(motionCommand, attackHook);
-        if (AttackPart.Value == null)
+        _attackPart = attacker.GetAttackPart(motionCommand, attackHook);
+        if (_attackPart.Value == null)
         {
-            GeneralFailure = true;
+            _generalFailure = true;
             return;
         }
 
-        BaseDamageMod = attacker.GetBaseDamage(AttackPart.Value);
-        BaseDamage = (float)ThreadSafeRandom.Next(BaseDamageMod.MinDamage, BaseDamageMod.MaxDamage);
+        _baseDamageMod = attacker.GetBaseDamage(_attackPart.Value);
+        _baseDamage = (float)ThreadSafeRandom.Next(_baseDamageMod.MinDamage, _baseDamageMod.MaxDamage);
 
-        DamageType = attacker.GetDamageType(AttackPart.Value, CombatType);
+        DamageType = attacker.GetDamageType(_attackPart.Value, CombatType);
     }
 
     /// <summary>
@@ -1457,9 +1653,6 @@ public class DamageEvent
         // select random body part @ current attack height
         BodyPart = BodyParts.GetBodyPart(attackHeight);
     }
-
-    public static readonly Quadrant LeftRight = Quadrant.Left | Quadrant.Right;
-    public static readonly Quadrant FrontBack = Quadrant.Front | Quadrant.Back;
 
     /// <summary>
     /// Returns a body part for a creature defender
@@ -1488,7 +1681,7 @@ public class DamageEvent
         //Console.WriteLine($"AttackHeight: {AttackHeight}, Quadrant: {quadrant & FrontBack}{quadrant & LeftRight}, AttackPart: {bodyPart}");
 
         defender.Biota.PropertiesBodyPart.TryGetValue(bodyPart, out var value);
-        PropertiesBodyPart = new KeyValuePair<CombatBodyPart, PropertiesBodyPart>(bodyPart, value);
+        _propertiesBodyPart = new KeyValuePair<CombatBodyPart, PropertiesBodyPart>(bodyPart, value);
 
         // select random body part @ current attack height
         /*BiotaPropertiesBodyPart = BodyParts.GetBodyPart(defender, attackHeight);
@@ -1499,7 +1692,7 @@ public class DamageEvent
             return;
         }*/
 
-        CreaturePart = new Creature_BodyPart(defender, PropertiesBodyPart);
+        _creaturePart = new Creature_BodyPart(defender, _propertiesBodyPart);
     }
 
     public void ShowInfo(Creature creature)
@@ -1512,19 +1705,19 @@ public class DamageEvent
         }
 
         // setup
-        var info = $"Attacker: {Attacker.Name} ({Attacker.Guid})\n";
-        info += $"Defender: {Defender.Name} ({Defender.Guid})\n";
+        var info = $"Attacker: {_attacker.Name} ({_attacker.Guid})\n";
+        info += $"Defender: {_defender.Name} ({_defender.Guid})\n";
 
         info += $"CombatType: {CombatType}\n";
 
-        info += $"DamageSource: {DamageSource.Name} ({DamageSource.Guid})\n";
+        info += $"DamageSource: {_damageSource.Name} ({_damageSource.Guid})\n";
         info += $"DamageType: {DamageType}\n";
 
         var weaponName = Weapon != null ? $"{Weapon.Name} ({Weapon.Guid})" : "None\n";
         info += $"Weapon: {weaponName}\n";
 
-        info += $"AttackType: {AttackType}\n";
-        info += $"AttackHeight: {AttackHeight}\n";
+        info += $"AttackType: {_attackType}\n";
+        info += $"AttackHeight: {_attackHeight}\n";
 
         // lifestone protection
         if (LifestoneProtection)
@@ -1533,109 +1726,98 @@ public class DamageEvent
         }
 
         // evade
-        if (AccuracyMod != 0.0f && AccuracyMod != 1.0f)
+        if (_accuracyMod != 0.0f && _accuracyMod != 1.0f)
         {
-            info += $"AccuracyMod: {AccuracyMod}\n";
+            info += $"AccuracyMod: {_accuracyMod}\n";
         }
 
         info += $"EffectiveAttackSkill: {EffectiveAttackSkill}\n";
-        info += $"EffectiveDefenseSkill: {EffectiveDefenseSkill}\n";
+        info += $"EffectiveDefenseSkill: {_effectiveDefenseSkill}\n";
 
-        if (Attacker.Overpower != null)
+        if (_attacker.Overpower != null)
         {
-            info += $"Overpower: {Overpower} ({Creature.GetOverpowerChance(Attacker, Defender)})\n";
+            info += $"Overpower: {_overpower} ({Creature.GetOverpowerChance(_attacker, _defender)})\n";
         }
 
-        info += $"EvasionChance: {EvasionChance}\n";
         info += $"Evaded: {Evaded}\n";
         info += $"Blocked: {Blocked}\n";
         info += $"PartialEvaded: {PartialEvasion}\n";
 
-        if (!(Attacker is Player))
+        if (!(_attacker is Player))
         {
-            if (AttackMotion != null)
+            if (_attackMotion != null)
             {
-                info += $"AttackMotion: {AttackMotion}\n";
+                info += $"AttackMotion: {_attackMotion}\n";
             }
 
-            if (AttackPart.Value != null)
+            if (_attackPart.Value != null)
             {
-                info += $"AttackPart: {AttackPart.Key}\n";
+                info += $"AttackPart: {_attackPart.Key}\n";
             }
         }
 
         // base damage
-        if (BaseDamageMod != null)
+        if (_baseDamageMod != null)
         {
-            info += $"BaseDamageRange: {BaseDamageMod.Range}\n";
+            info += $"BaseDamageRange: {_baseDamageMod.Range}\n";
         }
 
-        info += $"BaseDamage: {BaseDamage}\n";
+        info += $"BaseDamage: {_baseDamage}\n";
 
         // damage modifiers
-        info += $"AttributeMod: {AttributeMod}\n";
+        info += $"AttributeMod: {_attributeMod}\n";
 
-        if (PowerMod != 0.0f && PowerMod != 1.0f)
+        if (_powerMod != 0.0f && _powerMod != 1.0f)
         {
-            info += $"PowerMod: {PowerMod}\n";
+            info += $"PowerMod: {_powerMod}\n";
         }
 
-        if (SlayerMod != 0.0f && SlayerMod != 1.0f)
+        if (_slayerMod != 0.0f && _slayerMod != 1.0f)
         {
-            info += $"SlayerMod: {SlayerMod}\n";
+            info += $"SlayerMod: {_slayerMod}\n";
         }
 
-        if (BaseDamageMod != null)
+        if (_baseDamageMod != null)
         {
-            if (BaseDamageMod.DamageBonus != 0)
+            if (_baseDamageMod.DamageBonus != 0)
             {
-                info += $"DamageBonus: {BaseDamageMod.DamageBonus}\n";
+                info += $"DamageBonus: {_baseDamageMod.DamageBonus}\n";
             }
 
-            if (BaseDamageMod.DamageMod != 0.0f && BaseDamageMod.DamageMod != 1.0f)
+            if (_baseDamageMod.DamageMod != 0.0f && _baseDamageMod.DamageMod != 1.0f)
             {
-                info += $"DamageMod: {BaseDamageMod.DamageMod}\n";
+                info += $"DamageMod: {_baseDamageMod.DamageMod}\n";
             }
 
-            if (BaseDamageMod.ElementalBonus != 0)
+            if (_baseDamageMod.ElementalBonus != 0)
             {
-                info += $"ElementalDamageBonus: {BaseDamageMod.ElementalBonus}\n";
+                info += $"ElementalDamageBonus: {_baseDamageMod.ElementalBonus}\n";
             }
         }
 
         // critical hit
-        info += $"CriticalChance: {CriticalChance}\n";
+        info += $"CriticalChance: {_criticalChance}\n";
         info += $"CriticalHit: {IsCritical}\n";
 
-        if (CriticalDefended)
+        if (_criticalDefended)
         {
-            info += $"CriticalDefended: {CriticalDefended}\n";
+            info += $"CriticalDefended: {_criticalDefended}\n";
         }
 
-        if (CriticalDamageMod != 0.0f && CriticalDamageMod != 1.0f)
+        if (_criticalDamageMod != 0.0f && _criticalDamageMod != 1.0f)
         {
-            info += $"CriticalDamageMod: {CriticalDamageMod}\n";
+            info += $"CriticalDamageMod: {_criticalDamageMod}\n";
         }
 
-        if (CriticalDamageRatingMod != 0.0f && CriticalDamageRatingMod != 1.0f)
+        if (_criticalDamageRating != 0.0f && _criticalDamageRating != 1.0f)
         {
-            info += $"CriticalDamageRatingMod: {CriticalDamageRatingMod}\n";
+            info += $"CriticalDamageRatingMod: {_criticalDamageRating}\n";
         }
 
         // damage ratings
-        if (DamageRatingBaseMod != 0.0f && DamageRatingBaseMod != 1.0f)
+        if (_recklessnessMod != 0.0f && _recklessnessMod != 1.0f)
         {
-            info += $"DamageRatingBaseMod: {DamageRatingBaseMod}\n";
-        }
-
-        if (HeritageMod != 0.0f && HeritageMod != 1.0f)
-        {
-            info += $"HeritageMod: {HeritageMod}\n";
-        }
-
-        if (RecklessnessMod != 0.0f && RecklessnessMod != 1.0f)
-        {
-            info += $"RecklessnessMod: {RecklessnessMod}\n";
+            info += $"RecklessnessMod: {_recklessnessMod}\n";
         }
 
         if (SneakAttackMod != 0.0f && SneakAttackMod != 1.0f)
@@ -1643,14 +1825,14 @@ public class DamageEvent
             info += $"SneakAttackMod: {SneakAttackMod}\n";
         }
 
-        if (PkDamageMod != 0.0f && PkDamageMod != 1.0f)
+        if (_pkDamageMod != 0.0f && _pkDamageMod != 1.0f)
         {
-            info += $"PkDamageMod: {PkDamageMod}\n";
+            info += $"PkDamageMod: {_pkDamageMod}\n";
         }
 
-        if (DamageRatingMod != 0.0f && DamageRatingMod != 1.0f)
+        if (_damageRatingMod != 0.0f && _damageRatingMod != 1.0f)
         {
-            info += $"DamageRatingMod: {DamageRatingMod}\n";
+            info += $"DamageRatingMod: {_damageRatingMod}\n";
         }
 
         if (BodyPart != 0)
@@ -1658,27 +1840,28 @@ public class DamageEvent
             // player body part
             info += $"BodyPart: {BodyPart}\n";
         }
-        if (Armor != null && Armor.Count > 0)
+
+        if (_armor != null && _armor.Count > 0)
         {
-            info += $"Armors: {string.Join(", ", Armor.Select(i => i.Name))}\n";
+            info += $"Armors: {string.Join(", ", _armor.Select(i => i.Name))}\n";
         }
 
-        if (CreaturePart != null)
+        if (_creaturePart != null)
         {
             // creature body part
-            info += $"BodyPart: {PropertiesBodyPart.Key}\n";
-            info += $"BaseArmor: {CreaturePart.Biota.Value.BaseArmor}\n";
+            info += $"BodyPart: {_propertiesBodyPart.Key}\n";
+            info += $"BaseArmor: {_creaturePart.Biota.Value.BaseArmor}\n";
         }
 
         // damage mitigation
-        if (ArmorMod != 0.0f && ArmorMod != 1.0f)
+        if (_armorMod != 0.0f && _armorMod != 1.0f)
         {
-            info += $"ArmorMod: {ArmorMod}\n";
+            info += $"ArmorMod: {_armorMod}\n";
         }
 
-        if (ResistanceMod != 0.0f && ResistanceMod != 1.0f)
+        if (_resistanceMod != 0.0f && _resistanceMod != 1.0f)
         {
-            info += $"ResistanceMod: {ResistanceMod}\n";
+            info += $"ResistanceMod: {_resistanceMod}\n";
         }
 
         if (ShieldMod != 0.0f && ShieldMod != 1.0f)
@@ -1686,29 +1869,29 @@ public class DamageEvent
             info += $"ShieldMod: {ShieldMod}\n";
         }
 
-        if (WeaponResistanceMod != 0.0f && WeaponResistanceMod != 1.0f)
+        if (_weaponResistanceMod != 0.0f && _weaponResistanceMod != 1.0f)
         {
-            info += $"WeaponResistanceMod: {WeaponResistanceMod}\n";
+            info += $"WeaponResistanceMod: {_weaponResistanceMod}\n";
         }
 
-        if (DamageResistanceRatingBaseMod != 0.0f && DamageResistanceRatingBaseMod != 1.0f)
+        if (_damageResistanceRatingBaseMod != 0.0f && _damageResistanceRatingBaseMod != 1.0f)
         {
-            info += $"DamageResistanceRatingBaseMod: {DamageResistanceRatingBaseMod}\n";
+            info += $"DamageResistanceRatingBaseMod: {_damageResistanceRatingBaseMod}\n";
         }
 
-        if (CriticalDamageResistanceRatingMod != 0.0f && CriticalDamageResistanceRatingMod != 1.0f)
+        if (_criticalDamageResistanceRatingMod != 0.0f && _criticalDamageResistanceRatingMod != 1.0f)
         {
-            info += $"CriticalDamageResistanceRatingMod: {CriticalDamageResistanceRatingMod}\n";
+            info += $"CriticalDamageResistanceRatingMod: {_criticalDamageResistanceRatingMod}\n";
         }
 
-        if (PkDamageResistanceMod != 0.0f && PkDamageResistanceMod != 1.0f)
+        if (_pkDamageResistanceMod != 0.0f && _pkDamageResistanceMod != 1.0f)
         {
-            info += $"PkDamageResistanceMod: {PkDamageResistanceMod}\n";
+            info += $"PkDamageResistanceMod: {_pkDamageResistanceMod}\n";
         }
 
-        if (DamageResistanceRatingMod != 0.0f && DamageResistanceRatingMod != 1.0f)
+        if (_damageResistanceRatingMod != 0.0f && _damageResistanceRatingMod != 1.0f)
         {
-            info += $"DamageResistanceRatingMod: {DamageResistanceRatingMod}\n";
+            info += $"DamageResistanceRatingMod: {_damageResistanceRatingMod}\n";
         }
 
         if (IgnoreMagicArmor)
@@ -1722,8 +1905,8 @@ public class DamageEvent
         }
 
         // final damage
-        info += $"DamageBeforeMitigation: {DamageBeforeMitigation}\n";
-        info += $"DamageMitigated: {DamageMitigated}\n";
+        info += $"DamageBeforeMitigation: {_damageBeforeMitigation}\n";
+        info += $"DamageMitigated: {_damageMitigated}\n";
         info += $"Damage: {Damage}\n";
 
         info += "----";
@@ -1737,39 +1920,10 @@ public class DamageEvent
         {
             ShowInfo(attacker);
         }
+
         if (defender != null && (defender.DebugDamage & Creature.DebugDamageType.Defender) != 0)
         {
             ShowInfo(defender);
-        }
-    }
-
-    public AttackConditions AttackConditions
-    {
-        get
-        {
-            var attackConditions = new AttackConditions();
-
-            if (CriticalDefended)
-            {
-                attackConditions |= AttackConditions.CriticalProtectionAugmentation;
-            }
-
-            if (RecklessnessMod > 1.0f)
-            {
-                attackConditions |= AttackConditions.Recklessness;
-            }
-
-            if (SneakAttackMod > 1.0f)
-            {
-                attackConditions |= AttackConditions.SneakAttack;
-            }
-
-            if (Overpower)
-            {
-                attackConditions |= AttackConditions.Overpower;
-            }
-
-            return attackConditions;
         }
     }
 
@@ -1783,34 +1937,34 @@ public class DamageEvent
                 {
                     case Skill.Axe:
                         return playerAttacker.GetCreatureSkill(Skill.HeavyWeapons).AdvancementClass
-                            == SkillAdvancementClass.Specialized;
+                               == SkillAdvancementClass.Specialized;
                     case Skill.Mace:
                         return playerAttacker.GetCreatureSkill(Skill.HeavyWeapons).AdvancementClass
-                            == SkillAdvancementClass.Specialized;
+                               == SkillAdvancementClass.Specialized;
                     case Skill.Sword:
                         return playerAttacker.GetCreatureSkill(Skill.HeavyWeapons).AdvancementClass
-                            == SkillAdvancementClass.Specialized;
+                               == SkillAdvancementClass.Specialized;
                     case Skill.Spear:
                         return playerAttacker.GetCreatureSkill(Skill.HeavyWeapons).AdvancementClass
-                            == SkillAdvancementClass.Specialized;
+                               == SkillAdvancementClass.Specialized;
                     case Skill.Dagger:
                         return playerAttacker.GetCreatureSkill(Skill.Dagger).AdvancementClass
-                            == SkillAdvancementClass.Specialized;
+                               == SkillAdvancementClass.Specialized;
                     case Skill.Staff:
                         return playerAttacker.GetCreatureSkill(Skill.Staff).AdvancementClass
-                            == SkillAdvancementClass.Specialized;
+                               == SkillAdvancementClass.Specialized;
                     case Skill.UnarmedCombat:
                         return playerAttacker.GetCreatureSkill(Skill.UnarmedCombat).AdvancementClass
-                            == SkillAdvancementClass.Specialized;
+                               == SkillAdvancementClass.Specialized;
                     case Skill.Bow:
                         return playerAttacker.GetCreatureSkill(Skill.Bow).AdvancementClass
-                            == SkillAdvancementClass.Specialized;
+                               == SkillAdvancementClass.Specialized;
                     case Skill.Crossbow:
                         return playerAttacker.GetCreatureSkill(Skill.Bow).AdvancementClass
-                            == SkillAdvancementClass.Specialized;
+                               == SkillAdvancementClass.Specialized;
                     case Skill.ThrownWeapon:
                         return playerAttacker.GetCreatureSkill(Skill.ThrownWeapon).AdvancementClass
-                            == SkillAdvancementClass.Specialized;
+                               == SkillAdvancementClass.Specialized;
                     default:
                         return false;
                 }
@@ -1818,91 +1972,81 @@ public class DamageEvent
             else
             {
                 return playerAttacker.GetCreatureSkill(Skill.UnarmedCombat).AdvancementClass
-                    == SkillAdvancementClass.Specialized;
+                       == SkillAdvancementClass.Specialized;
             }
         }
+
         return false;
     }
 
-    private void DpsLogging(
-        Creature attacker,
-        CreatureSkill attackSkill,
-        Creature defender,
-        float dualWieldDamageMod,
-        float twohandedCombatDamageMod,
-        float steadyShotActivatedMod,
-        float multishotPenalty,
-        float provokeMod,
-        float damageScalar
-    )
+    private void DpsLogging()
     {
-        if (attacker == null || defender == null)
+        return;
+        if (_attacker == null || _defender == null)
         {
             return;
         }
 
         var currentTime = Time.GetUnixTime();
-        var timeSinceLastAttack = currentTime - attacker.LastAttackedCreatureTime;
-        if (attacker as Player == null)
+        var timeSinceLastAttack = currentTime - _attacker.LastAttackedCreatureTime;
+        if (_attacker as Player == null)
         {
-            timeSinceLastAttack = MonsterAverageAnimationLength.GetValueMod(attacker.CreatureType);
+            timeSinceLastAttack = MonsterAverageAnimationLength.GetValueMod(_attacker.CreatureType);
         }
 
-        var damageSource = Weapon == null ? attacker : Weapon;
+        var damageSource = Weapon == null ? _attacker : Weapon;
 
         Console.WriteLine($"\n---- DAMAGE LOG ({damageSource.Name}) ----");
         Console.WriteLine(
-            $"CurrentTime: {currentTime}, LastAttackTime: {attacker.LastAttackedCreatureTime} TimeBetweenAttacks: {timeSinceLastAttack}"
+            $"CurrentTime: {currentTime}, LastAttackTime: {_attacker.LastAttackedCreatureTime} TimeBetweenAttacks: {timeSinceLastAttack}"
         );
-        attacker.LastAttackedCreatureTime = currentTime;
+        _attacker.LastAttackedCreatureTime = currentTime;
 
-        var critRate = CriticalChance;
+        var critRate = _criticalChance;
         var nonCritRate = 1 - critRate;
-        var critDamageMod = 1.0f + WorldObject.GetWeaponCritDamageMod(damageSource, attacker, attackSkill, defender);
+        var critDamageMod = 1.0f + WorldObject.GetWeaponCritDamageMod(damageSource, _attacker, _attackSkill, _defender);
 
-        var avgNonCritHit = (BaseDamageMod.MaxDamage + BaseDamageMod.MinDamage) / 2;
-        var critHit = BaseDamageMod.MaxDamage * critDamageMod;
+        var avgNonCritHit = (_baseDamageMod.MaxDamage + _baseDamageMod.MinDamage) / 2;
+        var critHit = _baseDamageMod.MaxDamage * critDamageMod;
 
         var averageDamage = avgNonCritHit * nonCritRate + critHit * critRate;
         var baseDps = averageDamage / timeSinceLastAttack;
 
         var averageDamageBeforeMitigation =
             averageDamage
-            * PowerMod
-            * AttributeMod
-            * SlayerMod
-            * DamageRatingMod
-            * dualWieldDamageMod
-            * twohandedCombatDamageMod
-            * steadyShotActivatedMod
-            * multishotPenalty
-            * provokeMod;
+            * _powerMod
+            * _attributeMod
+            * _slayerMod
+            * _damageRatingMod
+            * _dualWieldDamageBonus
+            * _twohandedCombatDamageBonus
+            * _steadyShotActivatedMod;
         var averageDpsBeforeMitigation = averageDamageBeforeMitigation / timeSinceLastAttack;
 
         var averageDamageAfterMitigation =
             averageDamageBeforeMitigation
-            * ArmorMod
+            * _armorMod
             * ShieldMod
-            * ResistanceMod
-            * DamageResistanceRatingMod
-            * damageScalar;
+            * _resistanceMod
+            * _damageResistanceRatingMod
+            * _levelScalingMod;
         var averageDpsAfterMitigation = averageDamageAfterMitigation / timeSinceLastAttack;
 
         Console.WriteLine(
             $"TimeSinceLastAttack: {timeSinceLastAttack}"
-                + $"\n\n-- Base --\n"
-                + $"BaseDamageMod.MaxDamage: {BaseDamageMod.MaxDamage}, BaseDamageMod.MinDamage: {BaseDamageMod.MinDamage}, LiveBaseDamage: {BaseDamage}\n"
-                + $"AverageDamageNonCrit: {avgNonCritHit}, AverageDamageCrit: {critHit}, AverageDamageHit: {averageDamage}\n"
-                + $"DPS Base: {baseDps}\n\n"
-                + $"-- Before Mitigation --\n"
-                + $"PowerMod: {PowerMod}, AttributeMod: {AttributeMod}, SlayerMod: {SlayerMod}, DamageRatingMod: {DamageRatingMod}\n"
-                + $"AverageDamage Before Mitigation: {averageDamageBeforeMitigation}\n"
-                + $"DPS Before Mitigation: {averageDpsBeforeMitigation}\n\n"
-                + $"-- After Mitigation --\n"
-                + $"DamageScalar(health): {damageScalar}, ArmorMod: {ArmorMod}, ShieldMod: {ShieldMod}, ResistanceMod: {ResistanceMod}, DamageResistanceRatingMod: {DamageResistanceRatingMod}\n"
-                + $"AverageDamage After Mitigation: {averageDamageAfterMitigation}\n"
-                + $"DPS After Mitigation: {averageDpsAfterMitigation}\n"
-                + $"---- END DAMAGE LOG ({damageSource.Name}) ----"
+            + $"\n\n-- Base --\n"
+            + $"BaseDamageMod.MaxDamage: {_baseDamageMod.MaxDamage}, BaseDamageMod.MinDamage: {_baseDamageMod.MinDamage}, LiveBaseDamage: {_baseDamage}\n"
+            + $"AverageDamageNonCrit: {avgNonCritHit}, AverageDamageCrit: {critHit}, AverageDamageHit: {averageDamage}\n"
+            + $"DPS Base: {baseDps}\n\n"
+            + $"-- Before Mitigation --\n"
+            + $"PowerMod: {_powerMod}, AttributeMod: {_attributeMod}, SlayerMod: {_slayerMod}, DamageRatingMod: {_damageRatingMod}\n"
+            + $"AverageDamage Before Mitigation: {averageDamageBeforeMitigation}\n"
+            + $"DPS Before Mitigation: {averageDpsBeforeMitigation}\n\n"
+            + $"-- After Mitigation --\n"
+            + $"DamageScalar(health): {_levelScalingMod}, ArmorMod: {_armorMod}, ShieldMod: {ShieldMod}, ResistanceMod: {_resistanceMod}, DamageResistanceRatingMod: {_damageResistanceRatingMod}\n"
+            + $"AverageDamage After Mitigation: {averageDamageAfterMitigation}\n"
+            + $"DPS After Mitigation: {averageDpsAfterMitigation}\n"
+            + $"---- END DAMAGE LOG ({damageSource.Name}) ----"
         );
     }
 }

--- a/apps/server/Entity/DamageEvent.cs
+++ b/apps/server/Entity/DamageEvent.cs
@@ -917,7 +917,8 @@ public class DamageEvent
     }
 
     /// <summary>
-    /// JEWEL - Black Garnet - Ramping Piercing Resistance Penetration
+    /// RATING - Pierce: Ramping Piercing Resistance Penetration
+    /// (JEWEL - Black Garnet)
     /// </summary>
     private float GetRatingPierceResistanceBonus(Creature defender, Player playerAttacker)
     {
@@ -937,8 +938,8 @@ public class DamageEvent
     }
 
     /// <summary>
-    /// JEWEL - Onyx: Protection vs. Slash/Pierce/Bludgeon
-    /// JEWEL - Zircon: Protection vs. Acid/Fire/Cold/Electric
+    /// RATING - Physical Ward: Protection vs. Slash/Pierce/Bludgeon (JEWEL - Onyx:)
+    /// RATING - Elemental Ward: Protection vs. Acid/Fire/Cold/Electric (JEWEL - Zircon)
     /// </summary>
     private float GetRatingElementalWard(Player playerDefender)
     {
@@ -980,7 +981,8 @@ public class DamageEvent
     }
 
     /// <summary>
-    /// JEWEL - Ruby: Bonus damage below 50% HP, reduced damage above
+    /// RATING - LastStand: Bonus damage below 50% HP, reduced damage above
+    /// (JEWEL - Ruby)
     /// </summary>
     private static float GetRatingLastStand(Creature defender, Player playerAttacker)
     {
@@ -998,7 +1000,8 @@ public class DamageEvent
     }
 
     /// <summary>
-    /// JEWEL - Hematite: Deal bonus damage but take the same amount
+    /// RATING - Self Harm: Deal bonus damage but take the same amount
+    /// (JEWEL - Hematite)
     /// </summary>
     private static float GetRatingSelfHarm(Player playerAttacker)
     {
@@ -1125,7 +1128,8 @@ public class DamageEvent
     }
 
     /// <summary>
-    /// JEWEL - Diamond: Ramping Physical Damage Reduction
+    /// RATING - Hardened Defense: Ramping Physical Damage Reduction
+    /// (JEWEL - Diamond)
     /// </summary>
     private static float GetRatingHardenedDefenseDamageResistanceBonus(Player playerDefender)
     {
@@ -1165,9 +1169,14 @@ public class DamageEvent
         return _damageResistanceRatingBaseMod;
     }
 
+    /// <summary>
+    /// RATING - Reprisal: Evade an Incoming Crit, auto crit in return
+    /// (JEWEL - ??)
+    /// </summary>
+    /// <param name="attacker"></param>
+    /// <param name="playerDefender"></param>
     private void CheckForRatingReprisalCriticalDefense(Creature attacker, Player playerDefender)
     {
-        // Jewelcrafting Reprisal -- Evade an Incoming Crit, auto crit in return
         if (playerDefender == null)
         {
             return;
@@ -1191,7 +1200,8 @@ public class DamageEvent
     }
 
     /// <summary>
-    /// JEWEL - White Sapphire: Ramping Bludgeon Crit Damage Bonus
+    /// RATING - Bludgeon: Ramping Bludgeon Crit Damage Bonus
+    /// (JEWEL - White Sapphire)
     /// </summary>
     private static float GetRatingBludgeonCriticalDamageBonus(Creature defender, Player playerAttacker)
     {
@@ -1342,7 +1352,8 @@ public class DamageEvent
     }
 
     /// <summary>
-    /// Rating Thorns - Reflects damage on block (JEWEL - White Quartz)
+    /// RATING - Thorns: Reflects damage on block
+    /// (JEWEL - White Quartz)
     /// </summary>
     private void CheckForRatingThorns(Creature attacker, Creature defender, WorldObject damageSource)
     {
@@ -1441,18 +1452,14 @@ public class DamageEvent
 
         _accuracyMod = attacker.GetAccuracySkillMod(Weapon);
 
-        EffectiveAttackSkill = (uint)(
-            attacker.GetEffectiveAttackSkill() * LevelScaling.GetPlayerAttackSkillScalar(playerAttacker, defender)
-        );
+        EffectiveAttackSkill = (uint)(attacker.GetEffectiveAttackSkill() * LevelScaling.GetPlayerAttackSkillScalar(playerAttacker, defender));
 
         EffectiveAttackSkill = Convert.ToUInt32(EffectiveAttackSkill * CheckForAttackHeightMediumAttackSkillBonus(playerAttacker));
         EffectiveAttackSkill = Convert.ToUInt32(EffectiveAttackSkill * CheckForCombatAbilitySteadyShotAttackSkillBonus(playerAttacker));
         EffectiveAttackSkill = Convert.ToUInt32(EffectiveAttackSkill * CheckForRatingFamiliarityAttackSkillPenalty(attacker, playerDefender));
         EffectiveAttackSkill = Convert.ToUInt32(EffectiveAttackSkill * CheckForRatingBravadoAttackSkillBonus(playerAttacker));
 
-        _effectiveDefenseSkill = (uint)(
-            defender.GetEffectiveDefenseSkill(CombatType)
-            * LevelScaling.GetPlayerDefenseSkillScalar(playerDefender, attacker)
+        _effectiveDefenseSkill = (uint)(defender.GetEffectiveDefenseSkill(CombatType) * LevelScaling.GetPlayerDefenseSkillScalar(playerDefender, attacker)
         );
 
         _effectiveDefenseSkill = Convert.ToUInt32(_effectiveDefenseSkill * CheckForAttackHeightLowDefenseSkillBonus(playerDefender, playerAttacker));
@@ -1491,7 +1498,7 @@ public class DamageEvent
 
     /// <summary>
     /// RATING - Bravado: Hit chance bonus for having been attacked frequently.
-    /// JEWEL - Yellow Garnet
+    /// (JEWEL - Yellow Garnet)
     /// </summary>
     private float CheckForRatingBravadoAttackSkillBonus(Player playerAttacker)
     {
@@ -1519,7 +1526,7 @@ public class DamageEvent
 
     /// <summary>
     /// RATING - Familiarity: Evade chance bonus for having attacked target creature.
-    /// JEWEL - Fire Opal
+    /// (JEWEL - Fire Opal)
     /// </summary>
     private float CheckForRatingFamiliarityAttackSkillPenalty(Creature attacker, Player playerDefender)
     {
@@ -1772,7 +1779,7 @@ public class DamageEvent
 
     /// <summary>
     /// RATING - GearBlock: Passively increases block chance by the rating amount (additively).
-    /// JEWEL - Turquoise: Passive Block %
+    /// (JEWEL - Turquoise)
     /// </summary>
     private float GetRatingBlockChanceBonus(Creature defender)
     {

--- a/apps/server/WorldObjects/Creature_Combat.cs
+++ b/apps/server/WorldObjects/Creature_Combat.cs
@@ -16,6 +16,7 @@ namespace ACE.Server.WorldObjects;
 
 partial class Creature
 {
+    [Flags]
     public enum DebugDamageType
     {
         None = 0x0,

--- a/apps/server/WorldObjects/Creature_Combat.cs
+++ b/apps/server/WorldObjects/Creature_Combat.cs
@@ -1017,10 +1017,8 @@ partial class Creature
         //return recklessnessMod;
     }
 
-    public float GetSneakAttackMod(WorldObject target, out float backstabMod)
+    public float GetSneakAttackMod(WorldObject target)
     {
-        backstabMod = 0.0f;
-
         // ensure creature target
         var creatureTarget = target as Creature;
         if (creatureTarget == null)
@@ -1063,12 +1061,6 @@ partial class Creature
                 {
                     return 1.0f;
                 }
-            }
-
-            var combatAbilityTrinket = GetEquippedTrinket();
-            if (combatAbilityTrinket != null && combatAbilityTrinket.CombatAbilityId == (int)CombatAbility.Backstab)
-            {
-                backstabMod = 0.2f;
             }
 
             return 1.2f; // 20% bonus

--- a/apps/server/WorldObjects/Player_Combat.cs
+++ b/apps/server/WorldObjects/Player_Combat.cs
@@ -1135,7 +1135,7 @@ partial class Player
         {
             var critMessage = crit == true ? "Critical Hit! " : "";
 
-            var sneakAttackMod = creature.GetSneakAttackMod(this, out var backstabMod);
+            var sneakAttackMod = creature.GetSneakAttackMod(this);
             var sneakMsg = sneakAttackMod > 1.0f ? "Sneak Attack! " : "";
 
             var percentHp = damageTaken / Health.MaxValue;

--- a/apps/server/WorldObjects/SpellProjectile.cs
+++ b/apps/server/WorldObjects/SpellProjectile.cs
@@ -1429,14 +1429,14 @@ public class SpellProjectile : WorldObject
             {
                 // TODO: use target direction vs. projectile position, instead of player position
                 // could sneak attack be applied to void DoTs?
-                sneakAttackMod = sourcePlayer.GetSneakAttackMod(target, out var backstabMod);
+                sneakAttackMod = sourcePlayer.GetSneakAttackMod(target);
                 //Console.WriteLine("Magic sneak attack:  + sneakAttackMod);
                 heritageMod = sourcePlayer.GetHeritageBonus(sourcePlayer.GetEquippedWand()) ? 1.05f : 1.0f;
             }
             // Calc sneak bonus for monsters
             if (targetPlayer != null && sourceCreature != null)
             {
-                sneakAttackMod = sourceCreature.GetSneakAttackMod(targetPlayer, out var backstabMod);
+                sneakAttackMod = sourceCreature.GetSneakAttackMod(targetPlayer);
             }
 
             var damageRating = sourceCreature?.GetDamageRating() ?? 0;

--- a/apps/server/WorldObjects/WorldObject_Weapon.cs
+++ b/apps/server/WorldObjects/WorldObject_Weapon.cs
@@ -443,13 +443,6 @@ partial class WorldObject
 
         critRate += wielder.GetCritRating() * 0.01f;
 
-        // COMBAT ABILITY - Iron Fist: +10% crit chance
-        DamageEvent.GetCombatAbilities(wielder, target, out var attackerCombatAbility, out var _);
-        if (attackerCombatAbility == CombatAbility.IronFist)
-        {
-            critRate += 0.1f;
-        }
-
         // mitigation
         var critResistRatingMod = Creature.GetNegativeRatingMod(target.GetCritResistRating());
         critRate *= critResistRatingMod;
@@ -478,13 +471,6 @@ partial class WorldObject
             var cripplingBlowMod = DefaultCritDamageMultiplier + GetCripplingBlowMod(skill, wielder, target);
 
             critDamageMod = Math.Max(critDamageMod, cripplingBlowMod);
-        }
-
-        // COMBAT ABILITY - Iron Fist: -20% crit damage
-        DamageEvent.GetCombatAbilities(wielder, target, out var attackerCombatAbility, out var _);
-        if (attackerCombatAbility == CombatAbility.IronFist)
-        {
-            critDamageMod -= 0.2f;
         }
 
         return critDamageMod;


### PR DESCRIPTION
Major refactor of the DamageEvent class.
- Convert unnecessary public variables to private.
- Encapsulate public variables and prevent write access.
- Reorganize member variables.
- Refactor DoCalculateDamage() method from ~800 to ~35 lines by dividing it into smaller fucntions, making it more readable.
- Attempt to move all CombatAbility/SpecialRating/SkillSpec bonuses into their own functions.
- Various other tweaks and adjustments.
