### PR TITLE
feat: temporarily disable HandleShroudRewards

### DIFF
--- a/apps/server/WorldObjects/Creature_Death.cs
+++ b/apps/server/WorldObjects/Creature_Death.cs
@@ -1122,6 +1122,8 @@ partial class Creature
 
     public void HandleShroudRewards()
     {
+        return; // TODO: Needs adjustments. Currently gives rewards to lone shrouded players.
+
         var scaledDamagers = DamageHistory.TotalDamage.Values.Where(d =>
             (d.Level > Level + 10) && d.TotalDamage >= DamageHistory.TotalHealth / 10
         );


### PR DESCRIPTION
Currently gives rewards to lone shrouded players. Unsure if we'll be using this functionality anyways but would like to leave it available to re-enable.