### PR TITLE
Additional properties appraise info

### DIFF
--- a/apps/server/Network/Structure/AppraiseInfo.cs
+++ b/apps/server/Network/Structure/AppraiseInfo.cs
@@ -857,26 +857,334 @@ public class AppraiseInfo
             var acidMod = (float)wo.ArmorModVsAcid;
             var electricMod = (float)wo.ArmorModVsElectric;
 
-            extraPropertiesText +=
-                $"Slashing: {GetProtectionLevelText(slashingMod)} ({string.Format("{0:0.00}", slashingMod)}) \n";
-            extraPropertiesText +=
-                $"Piercing: {GetProtectionLevelText(piercingMod)} ({string.Format("{0:0.00}", piercingMod)}) \n";
-            extraPropertiesText +=
-                $"Bludgeoning: {GetProtectionLevelText(bludgeoningMod)} ({string.Format("{0:0.00}", bludgeoningMod)}) \n";
+            extraPropertiesText += $"Slashing: {GetProtectionLevelText(slashingMod)} ({string.Format("{0:0.00}", slashingMod)}) \n";
+            extraPropertiesText += $"Piercing: {GetProtectionLevelText(piercingMod)} ({string.Format("{0:0.00}", piercingMod)}) \n";
+            extraPropertiesText += $"Bludgeoning: {GetProtectionLevelText(bludgeoningMod)} ({string.Format("{0:0.00}", bludgeoningMod)}) \n";
             extraPropertiesText += $"Fire: {GetProtectionLevelText(fireMod)} ({string.Format("{0:0.00}", fireMod)}) \n";
             extraPropertiesText += $"Cold: {GetProtectionLevelText(coldMod)} ({string.Format("{0:0.00}", coldMod)}) \n";
             extraPropertiesText += $"Acid: {GetProtectionLevelText(acidMod)} ({string.Format("{0:0.00}", acidMod)}) \n";
-            extraPropertiesText +=
-                $"Electric: {GetProtectionLevelText(electricMod)} ({string.Format("{0:0.00}", electricMod)}) \n\n";
+            extraPropertiesText += $"Electric: {GetProtectionLevelText(electricMod)} ({string.Format("{0:0.00}", electricMod)}) \n\n";
 
             hasExtraPropertiesText = true;
         }
 
         // -------- WEAPON PROPERTIES --------
+        // (Additional Properties)
+        var hasAdditionalProperties = false;
+        var additionalPropertiesList = new List<string>();
+
         // Ward Rending
         if (PropertiesInt.TryGetValue(PropertyInt.ImbuedEffect, out var imbuedEffect) && imbuedEffect == 0x8000)
         {
-            extraPropertiesText += $"Additional Properties: Ward Rending\n";
+            additionalPropertiesList.Add("Ward Rending");
+
+            hasAdditionalProperties = true;
+        }
+        // Gear Strength
+        if (PropertiesInt.TryGetValue(PropertyInt.GearStrength, out var gearStrength) && gearStrength != 0)
+        {
+            additionalPropertiesList.Add($"Mighty Thews ({gearStrength})");
+
+            hasAdditionalProperties = true;
+        }
+        // Gear Endurance
+        if (PropertiesInt.TryGetValue(PropertyInt.GearEndurance, out var gearEndurance) && gearEndurance != 0)
+        {
+            additionalPropertiesList.Add($"Perseverance ({gearEndurance})");
+
+            hasAdditionalProperties = true;
+        }
+        // Gear Coordination
+        if (PropertiesInt.TryGetValue(PropertyInt.GearCoordination, out var gearCoordination) && gearCoordination != 0)
+        {
+            additionalPropertiesList.Add($"Dexterous Hand ({gearCoordination})");
+
+            hasAdditionalProperties = true;
+        }
+        // Gear Quickness
+        if (PropertiesInt.TryGetValue(PropertyInt.GearQuickness, out var gearQuickness) && gearQuickness != 0)
+        {
+            additionalPropertiesList.Add($"Swift-footed ({gearQuickness})");
+
+            hasAdditionalProperties = true;
+        }
+        // Gear Focus
+        if (PropertiesInt.TryGetValue(PropertyInt.GearFocus, out var gearFocus) && gearFocus != 0)
+        {
+            additionalPropertiesList.Add($"Focused Mind ({gearFocus})");
+
+            hasAdditionalProperties = true;
+        }
+        // Gear Self
+        if (PropertiesInt.TryGetValue(PropertyInt.GearSelf, out var gearSelf) && gearSelf != 0)
+        {
+            additionalPropertiesList.Add($"Erudite Mind ({gearSelf})");
+
+            hasAdditionalProperties = true;
+        }
+        // Gear Lifesteal
+        if (PropertiesInt.TryGetValue(PropertyInt.GearLifesteal, out var gearLifesteal) && gearLifesteal != 0)
+        {
+            additionalPropertiesList.Add($"Sanguine Thirst ({gearLifesteal})");
+
+            hasAdditionalProperties = true;
+        }
+        // Gear SelfHarm
+        if (PropertiesInt.TryGetValue(PropertyInt.GearSelfHarm, out var gearSelfHarm) && gearSelfHarm != 0)
+        {
+            additionalPropertiesList.Add($"Blood Frenzy ({gearSelfHarm})");
+
+            hasAdditionalProperties = true;
+        }
+        // Gear ThreatGain
+        if (PropertiesInt.TryGetValue(PropertyInt.GearThreatGain, out var gearThreatGain) && gearThreatGain != 0)
+        {
+            additionalPropertiesList.Add($"Provocation ({gearThreatGain})");
+
+            hasAdditionalProperties = true;
+        }
+        // Gear ThreatReduction
+        if (PropertiesInt.TryGetValue(PropertyInt.GearThreatReduction, out var gearThreatReduction) && gearThreatReduction != 0)
+        {
+            additionalPropertiesList.Add($"Clouded Vision ({gearThreatReduction})");
+
+            hasAdditionalProperties = true;
+        }
+        // Gear Elemental Ward
+        if (PropertiesInt.TryGetValue(PropertyInt.GearElementalWard, out var gearElementalWard) && gearElementalWard != 0)
+        {
+            additionalPropertiesList.Add($"Pristmatic Ward ({gearElementalWard})");
+
+            hasAdditionalProperties = true;
+        }
+        // Gear Physical Ward
+        if (PropertiesInt.TryGetValue(PropertyInt.GearPhysicalWard, out var gearPhysicalWard) && gearPhysicalWard != 0)
+        {
+            additionalPropertiesList.Add($"Black Bulwark ({gearPhysicalWard})");
+
+            hasAdditionalProperties = true;
+        }
+        // Gear Magic Find
+        if (PropertiesInt.TryGetValue(PropertyInt.GearMagicFind, out var gearMagicFind) && gearMagicFind != 0)
+        {
+            additionalPropertiesList.Add($"Seeker ({gearMagicFind})");
+
+            hasAdditionalProperties = true;
+        }
+        // Gear Block
+        if (PropertiesInt.TryGetValue(PropertyInt.GearBlock, out var gearBlock) && gearBlock != 0)
+        {
+            additionalPropertiesList.Add($"Stalwart Defense ({gearBlock})");
+
+            hasAdditionalProperties = true;
+        }
+        // Gear Item Mana Usage
+        if (PropertiesInt.TryGetValue(PropertyInt.GearItemManaUsage, out var gearItemManaUsage) && gearItemManaUsage != 0)
+        {
+            additionalPropertiesList.Add($"Thrifty Scholar ({gearItemManaUsage})");
+
+            hasAdditionalProperties = true;
+        }
+        // Gear Thorns
+        if (PropertiesInt.TryGetValue(PropertyInt.GearThorns, out var gearThorns) && gearThorns != 0)
+        {
+            additionalPropertiesList.Add($"Swift Retribution ({gearThorns})");
+
+            hasAdditionalProperties = true;
+        }
+        // Gear Vitals Transfer
+        if (PropertiesInt.TryGetValue(PropertyInt.GearVitalsTransfer, out var gearVitalsTransfer) && gearVitalsTransfer != 0)
+        {
+            additionalPropertiesList.Add($"Tilted Scales ({gearVitalsTransfer})");
+
+            hasAdditionalProperties = true;
+        }
+        // Gear Last Stand
+        if (PropertiesInt.TryGetValue(PropertyInt.GearLastStand, out var gearLastStand) && gearLastStand != 0)
+        {
+            additionalPropertiesList.Add($"Red Fury ({gearLastStand})");
+
+            hasAdditionalProperties = true;
+        }
+        // Gear Selflessness
+        if (PropertiesInt.TryGetValue(PropertyInt.GearSelflessness, out var gearSelflessness) && gearSelflessness != 0)
+        {
+            additionalPropertiesList.Add($"Selfless Spirit ({gearSelflessness})");
+
+            hasAdditionalProperties = true;
+        }
+        // Gear Familiarity
+        if (PropertiesInt.TryGetValue(PropertyInt.GearFamiliarity, out var gearFamiliarity) && gearFamiliarity != 0)
+        {
+            additionalPropertiesList.Add($"Familiar Foe ({gearFamiliarity})");
+
+            hasAdditionalProperties = true;
+        }
+        // Gear Bravado
+        if (PropertiesInt.TryGetValue(PropertyInt.GearBravado, out var gearBravado) && gearBravado != 0)
+        {
+            additionalPropertiesList.Add($"Bravado ({gearBravado})");
+
+            hasAdditionalProperties = true;
+        }
+        // Gear Health To Stamina
+        if (PropertiesInt.TryGetValue(PropertyInt.GearHealthToStamina, out var gearHealthToStamina) && gearHealthToStamina != 0)
+        {
+            additionalPropertiesList.Add($"Masochist ({gearHealthToStamina})");
+
+            hasAdditionalProperties = true;
+        }
+        // Gear Health To Mana
+        if (PropertiesInt.TryGetValue(PropertyInt.GearHealthToMana, out var gearHealthToMana) && gearHealthToMana != 0)
+        {
+            additionalPropertiesList.Add($"Austere Anchorite ({gearHealthToMana})");
+
+            hasAdditionalProperties = true;
+        }
+        // Gear Experience Gain
+        if (PropertiesInt.TryGetValue(PropertyInt.GearExperienceGain, out var gearExperienceGain) && gearExperienceGain != 0)
+        {
+            additionalPropertiesList.Add($"Illuminated Mind ({gearExperienceGain})");
+
+            hasAdditionalProperties = true;
+        }
+        // Gear Manasteal
+        if (PropertiesInt.TryGetValue(PropertyInt.GearManasteal, out var gearManasteal) && gearManasteal != 0)
+        {
+            additionalPropertiesList.Add($"Ophidian ({gearManasteal})");
+
+            hasAdditionalProperties = true;
+        }
+        // Gear Bludgeon
+        if (PropertiesInt.TryGetValue(PropertyInt.GearBludgeon, out var gearBludgeon) && gearBludgeon != 0)
+        {
+            additionalPropertiesList.Add($"Skull-cracker ({gearBludgeon})");
+
+            hasAdditionalProperties = true;
+        }
+        // Gear Pierce
+        if (PropertiesInt.TryGetValue(PropertyInt.GearPierce, out var gearPierce) && gearPierce != 0)
+        {
+            additionalPropertiesList.Add($"Precision Strikes ({gearPierce})");
+
+            hasAdditionalProperties = true;
+        }
+        // Gear Slash
+        if (PropertiesInt.TryGetValue(PropertyInt.GearSlash, out var gearSlash) && gearSlash != 0)
+        {
+            additionalPropertiesList.Add($"Falcon's Gyre ({gearSlash})");
+
+            hasAdditionalProperties = true;
+        }
+        // Gear Fire
+        if (PropertiesInt.TryGetValue(PropertyInt.GearFire, out var gearFire) && gearFire != 0)
+        {
+            additionalPropertiesList.Add($"Blazing Brand ({gearFire})");
+
+            hasAdditionalProperties = true;
+
+            PropertiesString[PropertyString.LongDesc] +=
+                $"\n\n~Blazing Brand ({gearFire}): Grants a {gearFire}% bonus to Fire damage " +
+                $"and a {gearFire}% chance on hit to set the ground beneath your target ablaze, damaging nearby enemies.";
+        }
+        // Gear Frost
+        if (PropertiesInt.TryGetValue(PropertyInt.GearFrost, out var gearFrost) && gearFrost != 0)
+        {
+            additionalPropertiesList.Add($"Bone-chiller ({gearFrost})");
+
+            hasAdditionalProperties = true;
+        }
+        // Gear Acid
+        if (PropertiesInt.TryGetValue(PropertyInt.GearAcid, out var gearAcid) && gearAcid != 0)
+        {
+            additionalPropertiesList.Add($"Devourin Mist ({gearAcid})");
+
+            hasAdditionalProperties = true;
+        }
+        // Gear Lightning
+        if (PropertiesInt.TryGetValue(PropertyInt.GearLightning, out var gearLightning) && gearLightning != 0)
+        {
+            additionalPropertiesList.Add($"Astyrrian's Rage ({gearLightning})");
+
+            hasAdditionalProperties = true;
+        }
+        // Gear Heal Bubble
+        if (PropertiesInt.TryGetValue(PropertyInt.GearHealBubble, out var gearHealBubble) && gearHealBubble != 0)
+        {
+            additionalPropertiesList.Add($"Purified Soul ({gearHealBubble})");
+
+            hasAdditionalProperties = true;
+        }
+        // Gear Comp Burn
+        if (PropertiesInt.TryGetValue(PropertyInt.GearCompBurn, out var gearCompBurn) && gearCompBurn != 0)
+        {
+            additionalPropertiesList.Add($"Meticulous Magus ({gearCompBurn})");
+
+            hasAdditionalProperties = true;
+        }
+        // Gear Pyreal Find
+        if (PropertiesInt.TryGetValue(PropertyInt.GearPyrealFind, out var gearPyrealFind) && gearPyrealFind != 0)
+        {
+            additionalPropertiesList.Add($"Prosperity ({gearPyrealFind})");
+
+            hasAdditionalProperties = true;
+        }
+        // Gear Nullification
+        if (PropertiesInt.TryGetValue(PropertyInt.GearNullification, out var gearNullification) && gearNullification != 0)
+        {
+            additionalPropertiesList.Add($"Nullification ({gearNullification})");
+
+            hasAdditionalProperties = true;
+        }
+        // Gear Ward Penetration
+        if (PropertiesInt.TryGetValue(PropertyInt.GearWardPen, out var gearWardPen) && gearWardPen != 0)
+        {
+            additionalPropertiesList.Add($"Ruthless Discernment ({gearWardPen})");
+
+            hasAdditionalProperties = true;
+        }
+        // Gear Stamina Reduction
+        if (PropertiesInt.TryGetValue(PropertyInt.GearStamReduction, out var gearStamReduction) && gearStamReduction != 0)
+        {
+            additionalPropertiesList.Add($"Third Wind ({gearStamReduction})");
+
+            hasAdditionalProperties = true;
+        }
+        // Gear Hardened Defense
+        if (PropertiesInt.TryGetValue(PropertyInt.GearHardenedDefense, out var gearHardenedDefense) && gearHardenedDefense != 0)
+        {
+            additionalPropertiesList.Add($"Hardened Fortification ({gearHardenedDefense})");
+
+            hasAdditionalProperties = true;
+        }
+        // Gear Reprisal
+        if (PropertiesInt.TryGetValue(PropertyInt.GearReprisal, out var gearReprisal) && gearReprisal != 0)
+        {
+            additionalPropertiesList.Add($"Vicious Reprisal ({gearReprisal})");
+
+            hasAdditionalProperties = true;
+        }
+        // Gear Elementalist
+        if (PropertiesInt.TryGetValue(PropertyInt.GearElementalist, out var gearElementalist) && gearElementalist != 0)
+        {
+            additionalPropertiesList.Add($"Elementalist ({gearElementalist})");
+
+            hasAdditionalProperties = true;
+        }
+        // Set Additional Properties
+        if (hasAdditionalProperties)
+        {
+            var additionaPropertiesString = "";
+
+            foreach (var property in additionalPropertiesList)
+            {
+                additionaPropertiesString += property + ", ";
+            }
+
+            additionaPropertiesString = additionaPropertiesString.TrimEnd();
+            additionaPropertiesString = additionaPropertiesString.TrimEnd(',');
+
+            extraPropertiesText += $"Additional Properties: {additionaPropertiesString}.\n\n";
 
             hasExtraPropertiesText = true;
         }

--- a/apps/server/WorldObjects/Jewel_Bonuses.cs
+++ b/apps/server/WorldObjects/Jewel_Bonuses.cs
@@ -816,10 +816,10 @@ partial class Jewel
             return description;
         }
 
-        var half = Math.Round((float)amount / 2, 1);
-        var oneHalf = Math.Round((float)amount * 1.5, 1);
         var oneTenth = Math.Round((float)amount / 10, 2);
-        var threeQ = Math.Round((float)amount * 0.66, 1);
+        var half = Math.Round((float)amount / 2, 1);
+        var doubled = Math.Round((float)amount * 2.0f, 1);
+        var tripled = Math.Round((float)amount * 3.0f, 1);
 
         if (!int.TryParse(parts[5], out var originalWorkmanship))
         {
@@ -883,11 +883,11 @@ partial class Jewel
                 break;
             case ACE.Entity.Enum.MaterialType.Amber:
                 description =
-                    $"Socket this jewel in a bracelet of workmanship {workmanship} or greater to grant a {amount}% chance to regain stamina after being hit. Chance and amount regained scale based on damage recieved.\n\nOnce socketed, the bracelet can only be worn on the left wrist.\n\n";
+                    $"Socket this jewel in a bracelet of workmanship {workmanship} or greater to grant a {amount}% chance to regain stamina after being hit. Amount regained is based on damage received.\n\nOnce socketed, the bracelet can only be worn on the left wrist.\n\n";
                 break;
             case ACE.Entity.Enum.MaterialType.LapisLazuli:
                 description =
-                    $"Socket this jewel in a bracelet of workmanship {workmanship} or greater to grant a {amount}% chance to regain mana after being hit. Chance and amount regained scale based on damage recieved.\n\nOnce socketed, the bracelet can only be worn on the left wrist.\n\n";
+                    $"Socket this jewel in a bracelet of workmanship {workmanship} or greater to grant a {amount}% chance to regain mana after being hit. Amount regained sis based on damage received.\n\nOnce socketed, the bracelet can only be worn on the left wrist.\n\n";
                 break;
             case ACE.Entity.Enum.MaterialType.Moonstone:
                 description =
@@ -895,21 +895,21 @@ partial class Jewel
                 break;
             case ACE.Entity.Enum.MaterialType.Malachite:
                 description =
-                    $"Socket this jewel in a bracelet of workmanship {workmanship} or greater to grant a {amount * 3}% reduction to your chance to burn spell components.\n\nOnce socketed, the bracelet can only be worn on the left wrist.\n\n";
+                    $"Socket this jewel in a bracelet of workmanship {workmanship} or greater to grant a {tripled}% reduction to your chance to burn spell components.\n\nOnce socketed, the bracelet can only be worn on the left wrist.\n\n";
                 break;
             case ACE.Entity.Enum.MaterialType.Citrine:
                 description =
-                    $"Socket this jewel in a bracelet of workmanship {workmanship} or greater to grant a {amount}% Stamina cost reduction.\n\nOnce socketed, the bracelet can only be worn on the left wrist.\n\n";
+                    $"Socket this jewel in a bracelet of workmanship {workmanship} or greater to grant a {amount}% stamina cost reduction.\n\nOnce socketed, the bracelet can only be worn on the left wrist.\n\n";
                 break;
 
             // bracelet right
             case ACE.Entity.Enum.MaterialType.Amethyst:
                 description =
-                    $"Socket this jewel in a bracelet of workmanship {workmanship} or greater to grant magic absorb, the amount ramping from 0 to {oneHalf}% based on how often you have recently have been hit with magic.\n\nOnce socketed, the bracelet can only be worn on the right wrist.\n\n";
+                    $"Socket this jewel in a bracelet of workmanship {workmanship} or greater to grant magic absorb, the amount ramping from 0 to {doubled}% based on how often you have recently have been hit with magic.\n\nOnce socketed, the bracelet can only be worn on the right wrist.\n\n";
                 break;
             case ACE.Entity.Enum.MaterialType.Diamond:
                 description =
-                    $"Socket this jewel in a bracelet of workmanship {workmanship} or greater to grant resistance to physical damage, the amount ramping from 0 to {oneHalf}% based on how often you have recently have been hit.\n\nOnce socketed, the bracelet can only be worn on the right wrist.\n\n";
+                    $"Socket this jewel in a bracelet of workmanship {workmanship} or greater to grant resistance to physical damage, the amount ramping from 0 to {doubled}% based on how often you have recently have been hit.\n\nOnce socketed, the bracelet can only be worn on the right wrist.\n\n";
                 break;
             case ACE.Entity.Enum.MaterialType.Onyx:
                 description =
@@ -933,29 +933,29 @@ partial class Jewel
             // weapon + shield
             case ACE.Entity.Enum.MaterialType.BlackOpal:
                 description =
-                    $"Socket this jewel in a weapon or shield of workmanship {workmanship} or greater to to grant {half}% chance to evade an incoming critical hit. Your next attack against that enemy will be a guaranteed critical strike.\n\n";
+                    $"Socket this jewel in a weapon or shield of workmanship {workmanship} or greater to grant {half}% chance to evade an incoming critical hit. Your next attack against that enemy will be a guaranteed critical strike.\n\n";
                 break;
             case ACE.Entity.Enum.MaterialType.FireOpal:
                 description =
-                    $"Socket this jewel in a weapon or shield of workmanship {workmanship} or greater to to grant an increased evade and resist chance versus the target you are attacking, the amount ramping from 0% to {amount}% based on how often you have hit the target.\n\n";
+                    $"Socket this jewel in a weapon or shield of workmanship {workmanship} or greater to grant an increased evade and resist chance versus the target you are attacking, the amount ramping from 0% to {amount}% based on how often you have hit the target.\n\n";
                 break;
             case ACE.Entity.Enum.MaterialType.YellowGarnet:
                 description =
-                    $"Socket this jewel in a weapon or shield of workmanship {workmanship} or greater to to grant an increased physical hit chance, the amount ramping from a 0% to {amount}% based on how often you have been recently physically attacked.\n\n";
+                    $"Socket this jewel in a weapon or shield of workmanship {workmanship} or greater to grant an increased physical hit chance, the amount ramping from a 0% to {amount}% based on how often you have been recently physically attacked.\n\n";
                 break;
             case ACE.Entity.Enum.MaterialType.Ruby:
                 description =
-                    $"Socket this jewel in a weapon or shield of workmanship {workmanship} or greater to to grant increased damage as your health falls below 50%, up to a maximum bonus of {amount}% at 25% HP.\nAbove 50% Health, you receive a damage reduction penalty scaling up to {amount}% at full HP.\n\n";
+                    $"Socket this jewel in a weapon or shield of workmanship {workmanship} or greater to grant increased damage as your health falls below 50%, up to a maximum bonus of {amount}% at 25% HP.\nAbove 50% Health, you receive a damage reduction penalty scaling up to {amount}% at full HP.\n\n";
                 break;
 
             // weapon only
             case ACE.Entity.Enum.MaterialType.Bloodstone:
                 description =
-                    $"Socket this jewel in a weapon of workmanship {workmanship} or greater to grant {half}% chance on hit to gain health. Chance and amount scale based on amount of damage done.\n\n";
+                    $"Socket this jewel in a weapon of workmanship {workmanship} or greater to grant {amount}% chance on hit to gain health. Amount gained is based on amount of damage done.\n\n";
                 break;
             case ACE.Entity.Enum.MaterialType.Opal:
                 description =
-                    $"Socket this jewel in a weapon of workmanship {workmanship} or greater to grant {half}% chance on hit to gain mana. Chance and amount scale based on amount of damage done.\n\n";
+                    $"Socket this jewel in a weapon of workmanship {workmanship} or greater to grant {amount}% chance on hit to gain mana. Amount gained is based on amount of damage done.\n\n";
                 break;
             case ACE.Entity.Enum.MaterialType.Hematite:
                 description =
@@ -963,35 +963,35 @@ partial class Jewel
                 break;
             case ACE.Entity.Enum.MaterialType.RoseQuartz:
                 description =
-                    $"Socket this jewel in a weapon of workmanship {workmanship} or greater to grant a {oneHalf}% bonus to your Vitals Transfer spells, but an equivalent reduction in the effectiveness of your Restoration spells.\n\n";
+                    $"Socket this jewel in a weapon of workmanship {workmanship} or greater to grant a {amount}% bonus to your Vitals Transfer spells, but an equivalent reduction in the effectiveness of your other Restoration spells.\n\n";
                 break;
             case ACE.Entity.Enum.MaterialType.LavenderJade:
                 description =
-                    $"Socket this jewel in a wand of workmanship {workmanship} or greater to grant a {oneHalf}% bonus to your restoration spells when cast on others, but an equivalent reduction in their effectiveness when cast on yourself.\n\n";
+                    $"Socket this jewel in a wand of workmanship {workmanship} or greater to grant a {doubled}% bonus to your restoration spells when cast on others, but an equivalent reduction in their effectiveness when cast on yourself.\n\n";
                 break;
             case ACE.Entity.Enum.MaterialType.GreenGarnet:
                 description =
-                    $"Socket this jewel in a wand of workmanship {workmanship} or greater to grant a bonus to War Magic spells, the amount ramping from 0% to {oneHalf}% based on how often you have hit your target.\n\n";
+                    $"Socket this jewel in a wand of workmanship {workmanship} or greater to grant a bonus to War Magic spells, the amount ramping from 0% to {doubled}% based on how often you have recently hit your target.\n\n";
                 break;
             case ACE.Entity.Enum.MaterialType.Tourmaline:
                 description =
-                    $"Socket this jewel in a wand of workmanship {workmanship} or greater to grant Ward penetration, the amount ramping from 0% to {oneHalf}% based on how often you have hit your target.\n\n";
+                    $"Socket this jewel in a wand of workmanship {workmanship} or greater to grant Ward penetration, the amount ramping from 0% to {doubled}% based on how often you have recently hit your target.\n\n";
                 break;
             case ACE.Entity.Enum.MaterialType.WhiteJade:
                 description =
-                    $"Socket this jewel in a weapon of workmanship {workmanship} or greater to grant {threeQ}% bonus to your restoration spells, and a {oneTenth}% to create a sphere of healing energy on top of your target on casting a restoration spell.\n\n";
+                    $"Socket this jewel in a weapon of workmanship {workmanship} or greater to grant {amount}% bonus to your restoration spells, and a {half}% to create a sphere of healing energy on top of your target on casting a restoration spell.\n\n";
                 break;
             case ACE.Entity.Enum.MaterialType.Aquamarine:
                 description =
-                    $"Socket this jewel in a weapon of workmanship {workmanship} or greater to grant a {threeQ}% bonus to Frost damage, and a {oneTenth}% chance on hit to surround your target with chilling mist, damaging nearby enemies.\n\n";
+                    $"Socket this jewel in a weapon of workmanship {workmanship} or greater to grant a {amount}% bonus to Frost damage, and a {half}% chance on hit to surround your target with chilling mist, damaging nearby enemies.\n\n";
                 break;
             case ACE.Entity.Enum.MaterialType.BlackGarnet:
                 description =
-                    $"Socket this jewel in a weapon of workmanship {workmanship} or greater to grant it piercing resistance penetration, the amount ramping from 0% to {oneHalf}% based on how often you have hit your target.\n\n";
+                    $"Socket this jewel in a weapon of workmanship {workmanship} or greater to grant it piercing resistance penetration, the amount ramping from +0% to +{doubled}% based on how often you have hit your target.\n\n";
                 break;
             case ACE.Entity.Enum.MaterialType.Emerald:
                 description =
-                    $"Socket this jewel in a weapon of workmanship {workmanship} or greater to grant a {threeQ}% bonus to Acid damage, and a {oneTenth}% chance on hit to surround your target with acidic mist, damaging nearby enemies.\n\n";
+                    $"Socket this jewel in a weapon of workmanship {workmanship} or greater to grant a {amount}% bonus to Acid damage, and a {half}% chance on hit to surround your target with acidic mist, damaging nearby enemies.\n\n";
                 break;
             case ACE.Entity.Enum.MaterialType.ImperialTopaz:
                 description =
@@ -999,15 +999,15 @@ partial class Jewel
                 break;
             case ACE.Entity.Enum.MaterialType.Jet:
                 description =
-                    $"Socket this jewel in a weapon of workmanship {workmanship} or greater to grant a {threeQ}% bonus to Lightning damage, and a {oneTenth}% chance on hit to electrify the ground beneath your target, damaging nearby enemies.\n\n";
+                    $"Socket this jewel in a weapon of workmanship {workmanship} or greater to grant a {amount}% bonus to Lightning damage, and a {half}% chance on hit to electrify the ground beneath your target, damaging nearby enemies.\n\n";
                 break;
             case ACE.Entity.Enum.MaterialType.RedGarnet:
                 description =
-                    $"Socket this jewel in a weapon of workmanship {workmanship} or greater to grant a {threeQ}% bonus to Fire damage, and a {oneTenth}% chance on hit to set the ground beneath your target ablaze, damaging nearby enemies.\n\n";
+                    $"Socket this jewel in a weapon of workmanship {workmanship} or greater to grant a {amount}% bonus to Fire damage, and a {half}% chance on hit to set the ground beneath your target ablaze, damaging nearby enemies.\n\n";
                 break;
             case ACE.Entity.Enum.MaterialType.WhiteSapphire:
                 description =
-                    $"Socket this jewel in a weapon of workmanship {workmanship} or greater to grant bonus critical bludgeoning damage, the amount ramping from 0% to {amount * 2}% based on how many times you have struck your target.\n\n";
+                    $"Socket this jewel in a weapon of workmanship {workmanship} or greater to grant bonus critical bludgeoning damage, the amount ramping from +0% to +{doubled}% based on how many times you have struck your target.\n\n";
                 break;
         }
         return description;
@@ -1028,10 +1028,10 @@ partial class Jewel
             return description;
         }
 
-        var half = Math.Round((float)amount / 2, 1);
-        var oneHalf = Math.Round((float)amount * 1.5, 1);
         var oneTenth = Math.Round((float)amount / 10, 2);
-        var threeQ = Math.Round((float)amount * 0.66, 1);
+        var half = Math.Round((float)amount / 2, 1);
+        var doubled = Math.Round((float)amount * 2, 1);
+        var tripled = Math.Round((float)amount * 3, 1);
 
         switch (convertedMaterialType)
         {
@@ -1061,7 +1061,7 @@ partial class Jewel
                 description = $"\n\t Socket:  {parts[1]} (-{amount * 5}% Item Mana Consumption)\n";
                 break;
             case ACE.Entity.Enum.MaterialType.Malachite:
-                description = $"\n\t Socket:  {parts[1]} (+{amount * 3}% Component Burn Reduction)\n";
+                description = $"\n\t Socket:  {parts[1]} (+{tripled}% Component Burn Reduction)\n";
                 break;
             case ACE.Entity.Enum.MaterialType.GreenJade:
                 description = $"\n\t Socket:  {parts[1]} (+{half}% Prosperity)\n";
@@ -1069,10 +1069,10 @@ partial class Jewel
 
             // bracelet right
             case ACE.Entity.Enum.MaterialType.Amethyst:
-                description = $"\n\t Socket:  {parts[1]} (+{oneHalf}% Ramping Magic Absorb)\n";
+                description = $"\n\t Socket:  {parts[1]} (+{doubled}% Ramping Magic Absorb)\n";
                 break;
             case ACE.Entity.Enum.MaterialType.Diamond:
-                description = $"\n\t Socket:  {parts[1]} (+{oneHalf}% Ramping Physical Damage Resistance)\n";
+                description = $"\n\t Socket:  {parts[1]} (+{doubled}% Ramping Physical Damage Resistance)\n";
                 break;
             // shield
             case ACE.Entity.Enum.MaterialType.WhiteQuartz:
@@ -1091,40 +1091,40 @@ partial class Jewel
                 description = $"\n\t Socket:  {parts[1]} (+{half}% Mana Leech)\n";
                 break;
             case ACE.Entity.Enum.MaterialType.RoseQuartz:
-                description = $"\n\t Socket:  {parts[1]} (+{oneHalf}% Vitals Transfer)\n";
+                description = $"\n\t Socket:  {parts[1]} (+{doubled}% Vitals Transfer)\n";
                 break;
             case ACE.Entity.Enum.MaterialType.LavenderJade:
-                description = $"\n\t Socket:  {parts[1]} (+{oneHalf}% Selflessness)\n";
+                description = $"\n\t Socket:  {parts[1]} (+{doubled}% Selflessness)\n";
                 break;
             case ACE.Entity.Enum.MaterialType.GreenGarnet:
-                description = $"\n\t Socket:  {parts[1]} (+{oneHalf}% Ramping War Damage)\n";
+                description = $"\n\t Socket:  {parts[1]} (+{doubled}% Ramping War Damage)\n";
                 break;
             case ACE.Entity.Enum.MaterialType.Tourmaline:
-                description = $"\n\t Socket:  {parts[1]} (+{oneHalf}% Ramping Ward Pen)\n";
+                description = $"\n\t Socket:  {parts[1]} (+{doubled}% Ramping Ward Pen)\n";
                 break;
             case ACE.Entity.Enum.MaterialType.WhiteJade:
-                description = $"\n\t Socket:  {parts[1]} (+{threeQ}% Restoration)\n";
+                description = $"\n\t Socket:  {parts[1]} (+{amount}% Restoration)\n";
                 break;
             case ACE.Entity.Enum.MaterialType.Aquamarine:
-                description = $"\n\t Socket:  {parts[1]} (+{threeQ}% Frost Damage)\n";
+                description = $"\n\t Socket:  {parts[1]} (+{amount}% Frost Damage)\n";
                 break;
             case ACE.Entity.Enum.MaterialType.BlackGarnet:
                 description = $"\n\t Socket:  {parts[1]} (+{amount}% Ramping Pierce Pen)\n";
                 break;
             case ACE.Entity.Enum.MaterialType.Emerald:
-                description = $"\n\t Socket:  {parts[1]} (+{threeQ}% Acid Damage)\n";
+                description = $"\n\t Socket:  {parts[1]} (+{amount}% Acid Damage)\n";
                 break;
             case ACE.Entity.Enum.MaterialType.ImperialTopaz:
                 description = $"\n\t Socket:  {parts[1]} (+{half}% Cleave Chance)\n";
                 break;
             case ACE.Entity.Enum.MaterialType.Jet:
-                description = $"\n\t Socket:  {parts[1]} (+{threeQ}% Lightning Damage)\n";
+                description = $"\n\t Socket:  {parts[1]} (+{amount}% Lightning Damage)\n";
                 break;
             case ACE.Entity.Enum.MaterialType.RedGarnet:
-                description = $"\n\t Socket:  {parts[1]} (+{threeQ}% Fire Damage)\n";
+                description = $"\n\t Socket:  {parts[1]} (+{amount}% Fire Damage)\n";
                 break;
             case ACE.Entity.Enum.MaterialType.WhiteSapphire:
-                description = $"\n\t Socket:  {parts[1]} (+{amount * 2}% Ramping Bludgeon Crit Damage)\n";
+                description = $"\n\t Socket:  {parts[1]} (+{doubled}% Ramping Bludgeon Crit Damage)\n";
                 break;
             default:
                 description = $"\n\t Socket:  {parts[1]} (+{amount}%  {parts[3]})\n";


### PR DESCRIPTION
- Disable client AppraisalLongDescDecoration functionality.
- Add custom functionality that mimics decoration text, but also allows custom text to used in the Long Desc of items.
- Add an 'Additional Properties' field to the Use text field, that displays a list of each special ratings (jewel effects) an item has.
- Add a 'Property Descriptions' field to the LongDesc text field, that displays descriptions of each special rating an item has.
- Fix some typos and formatting in the Jewel_Bonuses class.