### PR TITLE
feat: add special property descriptions on items

### DIFF
--- a/apps/server/Factories/LootGenerationFactory_Caster.cs
+++ b/apps/server/Factories/LootGenerationFactory_Caster.cs
@@ -537,7 +537,7 @@ public static partial class LootGenerationFactory
     /// </summary>
     private static void RollBonusCritChance(TreasureDeath treasureDeath, WorldObject wo, out float percentile)
     {
-        float[] minMod = { 0.0f, 0.01f, 0.015f, 0.02f, 0.025f, 0.03f, 0.0375f, 0.05f };
+        float[] minMod = { 0.0f, 0.01f, 0.015f, 0.02f, 0.025f, 0.03f, 0.04f, 0.05f };
 
         var tier = Math.Clamp(treasureDeath.Tier - 1, 0, minMod.Length);
         var critChanceMod = 0.05f * GetDiminishingRoll(treasureDeath);
@@ -555,7 +555,7 @@ public static partial class LootGenerationFactory
     /// </summary>
     private static void RollBonusCritDamage(TreasureDeath treasureDeath, WorldObject wo, out float percentile)
     {
-        float[] minMod = { 0.0f, 0.1f, 0.15f, 0.2f, 0.25f, 0.3f, 0.375f, 0.5f };
+        float[] minMod = { 0.0f, 0.1f, 0.15f, 0.2f, 0.25f, 0.3f, 0.4f, 0.5f };
 
         var tier = Math.Clamp(treasureDeath.Tier - 1, 0, minMod.Length);
         var critDamageMod = 0.5f * GetDiminishingRoll(treasureDeath);

--- a/apps/server/Factories/LootTables.cs
+++ b/apps/server/Factories/LootTables.cs
@@ -524,6 +524,24 @@ public static class LootTables
     public const float ArmorSkillModRollRange = 0.1f;
     public static readonly float[] ArmorSkillModBonusPerTier = [0.0f, 0.01f, 0.02f, 0.03f, 0.04f, 0.05f, 0.075f, 0.1f];
 
+    // Bonus resistance cleaving per tier
+    public static readonly float[] BonusResistanceCleavingPerTier = [0.0f, 0.01f, 0.02f, 0.03f, 0.04f, 0.05f, 0.075f, 0.1f];
+
+    // Bonus ignore armor per tier for spear/crossbow
+    public static readonly float[] BonusIgnoreArmorPerTier = [0.0f, 0.01f, 0.02f, 0.03f, 0.04f, 0.05f, 0.075f, 0.1f];
+
+    // Bonus ignore ward per tier for Orb
+    public static readonly float[] BonusIgnoreWardPerTier = [0.0f, 0.01f, 0.02f, 0.03f, 0.04f, 0.05f, 0.075f, 0.1f];
+
+    // Bonus stamina cost reduction per tier for Sword/UA
+    public static readonly float[] StaminaCostReductionPerTier = [0.0f, 0.01f, 0.02f, 0.03f, 0.04f, 0.05f, 0.075f, 0.1f];
+
+    // Bonus crit chance for Axe/Dagger/Bow/Scepter
+    public static readonly float[] BonusCritChancePerTier = [0.0f, 0.01f, 0.015f, 0.02f, 0.025f, 0.03f, 0.4f, 0.05f];
+
+    // Bonus crit multi per tier for Mace/Staff/Atlatl/Wand
+    public static readonly float[] BonusCritMultiplierPerTier = [0.0f, 0.1f, 0.15f, 0.2f, 0.25f, 0.3f, 0.4f, 0.5f];
+
     // Jewelry Ward Level per Tier
     public static readonly int[] JewelryBaseWardLeverPerTier = [0, 10, 20, 30, 40, 50, 75, 100, 126];
 

--- a/apps/server/WorldObjects/Creature_Properties.cs
+++ b/apps/server/WorldObjects/Creature_Properties.cs
@@ -765,7 +765,7 @@ partial class Creature
         return moddedShieldSkill;
     }
 
-    public double? GetArmorAssessMod()
+    public double? GetArmorPerceptionMod()
     {
         double? mod;
 
@@ -784,7 +784,7 @@ partial class Creature
     public uint GetModdedPerceptionSkill()
     {
         var assessSkill = GetCreatureSkill(Skill.AssessCreature);
-        var armorAssessSkillMod = GetArmorAssessMod() + 1;
+        var armorAssessSkillMod = GetArmorPerceptionMod() + 1;
         var tempAssessSkill = assessSkill.Current * armorAssessSkillMod;
         var moddedAssessSkill = (uint)tempAssessSkill;
 

--- a/apps/server/WorldObjects/WorldObject_Weapon.cs
+++ b/apps/server/WorldObjects/WorldObject_Weapon.cs
@@ -643,7 +643,7 @@ partial class WorldObject
         Creature wielder,
         CreatureSkill skill,
         DamageType damageType,
-        Creature target
+        Creature target = null
     )
     {
         var resistMod = DefaultModifier;
@@ -785,12 +785,13 @@ partial class WorldObject
     private static float MinCriticalStrikeMod = 0.05f;
     private static float MaxCriticalStrikeMod = 0.1f;
 
-    public static float GetCriticalStrikeMod(CreatureSkill skill, Creature wielder, Creature target, bool isPvP = false)
+    public static float GetCriticalStrikeMod(CreatureSkill skill, Creature wielder, Creature target = null, bool isPvP = false)
     {
         var baseMod = MinCriticalStrikeMod;
 
         var skillType = GetImbuedSkillType(skill);
-        var baseSkill = GetBaseSkillImbued(skill) * LevelScaling.GetPlayerAttackSkillScalar(wielder, target);
+        var levelScalar = target != null ? LevelScaling.GetPlayerAttackSkillScalar(wielder, target) : 1.0f;
+        var baseSkill = GetBaseSkillImbued(skill) * levelScalar;
 
         switch (skillType)
         {
@@ -816,10 +817,11 @@ partial class WorldObject
     private static float MinCripplingBlowMod = 0.5f;
     private static float MaxCripplingBlowMod = 1.0f;
 
-    public static float GetCripplingBlowMod(CreatureSkill skill, Creature wielder, Creature target)
+    public static float GetCripplingBlowMod(CreatureSkill skill, Creature wielder, Creature target = null)
     {
         var skillType = GetImbuedSkillType(skill);
-        var baseSkill = GetBaseSkillImbued(skill) * LevelScaling.GetPlayerAttackSkillScalar(wielder, target);
+        var levelScalar = target != null ? LevelScaling.GetPlayerAttackSkillScalar(wielder, target) : 1.0f;
+        var baseSkill = GetBaseSkillImbued(skill) * levelScalar;
 
         var baseMod = MinCripplingBlowMod;
 
@@ -847,10 +849,11 @@ partial class WorldObject
     private static float MinRendingMod = 0.15f;
     private static float MaxRendingMod = 0.30f;
 
-    public static float GetRendingMod(CreatureSkill skill, Creature wielder, Creature target)
+    public static float GetRendingMod(CreatureSkill skill, Creature wielder, Creature target = null)
     {
         var skillType = GetImbuedSkillType(skill);
-        var baseSkill = GetBaseSkillImbued(skill) * LevelScaling.GetPlayerAttackSkillScalar(wielder, target);
+        var levelScalar = target != null ? LevelScaling.GetPlayerAttackSkillScalar(wielder, target) : 1.0f;
+        var baseSkill = GetBaseSkillImbued(skill) * levelScalar;
 
         var rendingMod = MinRendingMod;
 
@@ -878,10 +881,11 @@ partial class WorldObject
     public static float MinArmorRendingMod = 0.2f;
     public static float MaxArmorRendingMod = 0.4f;
 
-    public static float GetArmorRendingMod(CreatureSkill skill, Creature wielder, Creature target)
+    public static float GetArmorRendingMod(CreatureSkill skill, Creature wielder, Creature target = null)
     {
         var skillType = GetImbuedSkillType(skill);
-        var baseSkill = GetBaseSkillImbued(skill) * LevelScaling.GetPlayerAttackSkillScalar(wielder, target);
+        var levelScalar = target != null ? LevelScaling.GetPlayerAttackSkillScalar(wielder, target) : 1.0f;
+        var baseSkill = GetBaseSkillImbued(skill) * levelScalar;
 
         var armorRendingMod = MinArmorRendingMod;
 


### PR DESCRIPTION
- Display all special (non-retail) ratings in the "Additional Properties" list, when appraising an item.
- Add a new "Property Descriptions" field near the bottom of the appraise window that displays details about every special property on the item.
   - (imbues, jewel effects, etc)
- Refactor the AppraiseInfo class.