### PR TITLE
feat: option for items to require having mana to activate properties

### DIFF
--- a/apps/server/Entity/Spell.cs
+++ b/apps/server/Entity/Spell.cs
@@ -198,12 +198,12 @@ public partial class Spell : IEquatable<Spell>
     private static float CheckForRatingCompBurn(Player player)
     {
         // JEWEL - Malachite: Reduced comp burn chance
-        if (player.GetEquippedItemsRatingSum(PropertyInt.GearCompBurn) <= 0)
+        if (player.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearCompBurn) <= 0)
         {
             return 1.0f;
         }
 
-        var ratingMod = player.GetEquippedItemsRatingSum(PropertyInt.GearCompBurn) / 30;
+        var ratingMod = player.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearCompBurn) / 30;
 
         return 1.0f - ratingMod;
     }

--- a/apps/server/Network/Structure/AppraiseInfo.cs
+++ b/apps/server/Network/Structure/AppraiseInfo.cs
@@ -1455,6 +1455,8 @@ public class AppraiseInfo
 
         _extraPropertiesText += $"Additional Properties: {additionaPropertiesString}.\n\n";
 
+        _extraPropertiesText += "(This item's properties will not activate if it is out of mana)\n\n";
+
         _hasExtraPropertiesText = true;
     }
 

--- a/apps/server/WorldObjects/Creature_Equipment.cs
+++ b/apps/server/WorldObjects/Creature_Equipment.cs
@@ -624,6 +624,31 @@ partial class Creature
         return 0;
     }
 
+    public int GetEquippedAndActivatedItemRatingSum(PropertyInt rating)
+    {
+        var ratingAmount = 0;
+
+        foreach (var item in EquippedObjects.Values)
+        {
+            if (item.SpecialPropertiesRequireMana && item.ItemCurMana == 0)
+            {
+                continue;
+            }
+
+            var properties = GetProperties(item);
+
+            foreach (var property in properties)
+            {
+                if (property.Key == rating && property.Value != null)
+                {
+                    ratingAmount += property.Value.Value;
+                }
+            }
+        }
+
+        return ratingAmount;
+    }
+
     public int GetEquippedItemsWardSum(PropertyInt wardLevel)
     {
         if (equippedItemsRatingCache == null)

--- a/apps/server/WorldObjects/Creature_Melee.cs
+++ b/apps/server/WorldObjects/Creature_Melee.cs
@@ -155,7 +155,7 @@ partial class Creature
         var player = this as Player;
         var jewelCleave = false;
         // JEWEL - Imperial Topaz - Bonus cleave chance
-        if (GetEquippedItemsRatingSum(PropertyInt.GearSlash) >= ThreadSafeRandom.Next(0, 100))
+        if (GetEquippedAndActivatedItemRatingSum(PropertyInt.GearSlash) >= ThreadSafeRandom.Next(0, 100))
         {
             jewelCleave = true;
         }

--- a/apps/server/WorldObjects/Creature_Rating.cs
+++ b/apps/server/WorldObjects/Creature_Rating.cs
@@ -224,7 +224,7 @@ partial class Creature
         var enchantments = EnchantmentManager.GetRating(PropertyInt.DamageRating);
 
         // equipment ratings
-        var equipment = GetEquippedItemsRatingSum(PropertyInt.GearDamage);
+        var equipment = GetEquippedAndActivatedItemRatingSum(PropertyInt.GearDamage);
 
         // weakness as negative damage rating?
         // TODO: this should be factored in as a separate weakness rating...
@@ -252,7 +252,7 @@ partial class Creature
         var enchantments = EnchantmentManager.GetRating(PropertyInt.DamageResistRating);
 
         // equipment ratings
-        var equipment = GetEquippedItemsRatingSum(PropertyInt.GearDamageResist);
+        var equipment = GetEquippedAndActivatedItemRatingSum(PropertyInt.GearDamageResist);
 
         // nether DoTs as negative DRR?
         // TODO: this should be factored in as a separate nether damage rating...
@@ -329,7 +329,7 @@ partial class Creature
         var enchantments = EnchantmentManager.GetRating(PropertyInt.CritRating);
 
         // equipment ratings
-        var equipment = GetEquippedItemsRatingSum(PropertyInt.GearCrit);
+        var equipment = GetEquippedAndActivatedItemRatingSum(PropertyInt.GearCrit);
 
         // augmentations
         var augBonus = 0;
@@ -351,7 +351,7 @@ partial class Creature
         var enchantments = EnchantmentManager.GetRating(PropertyInt.CritDamageRating);
 
         // equipment ratings
-        var equipment = GetEquippedItemsRatingSum(PropertyInt.GearCritDamage);
+        var equipment = GetEquippedAndActivatedItemRatingSum(PropertyInt.GearCritDamage);
 
         // augmentations
         var augBonus = 0;
@@ -377,7 +377,7 @@ partial class Creature
         var enchantments = EnchantmentManager.GetRating(PropertyInt.CritResistRating);
 
         // equipment ratings
-        var equipment = GetEquippedItemsRatingSum(PropertyInt.GearCritResist);
+        var equipment = GetEquippedAndActivatedItemRatingSum(PropertyInt.GearCritResist);
 
         // no augs / lum augs?
         return critResistRating + enchantments + equipment;
@@ -392,7 +392,7 @@ partial class Creature
         var enchantments = EnchantmentManager.GetRating(PropertyInt.CritDamageResistRating);
 
         // equipment ratings
-        var equipment = GetEquippedItemsRatingSum(PropertyInt.GearCritDamageResist);
+        var equipment = GetEquippedAndActivatedItemRatingSum(PropertyInt.GearCritDamageResist);
 
         var lumAugBonus = 0;
         if (this is Player player)
@@ -412,7 +412,7 @@ partial class Creature
         var enchantments = EnchantmentManager.GetRating(PropertyInt.HealingBoostRating);
 
         // equipment ratings
-        var equipment = GetEquippedItemsRatingSum(PropertyInt.GearHealingBoost);
+        var equipment = GetEquippedAndActivatedItemRatingSum(PropertyInt.GearHealingBoost);
 
         var lumAugBonus = 0;
         if (this is Player player)
@@ -488,7 +488,7 @@ partial class Creature
 
     public int GetGearMaxHealth()
     {
-        return GetEquippedItemsRatingSum(PropertyInt.GearMaxHealth);
+        return GetEquippedAndActivatedItemRatingSum(PropertyInt.GearMaxHealth);
     }
 
     public int GetPKDamageRating()
@@ -499,7 +499,7 @@ partial class Creature
         var enchantments = EnchantmentManager.GetRating(PropertyInt.PKDamageRating);
 
         // equipment ratings
-        var equipment = GetEquippedItemsRatingSum(PropertyInt.GearPKDamageRating);
+        var equipment = GetEquippedAndActivatedItemRatingSum(PropertyInt.GearPKDamageRating);
 
         return pkDamageRating + equipment + enchantments;
     }
@@ -512,19 +512,19 @@ partial class Creature
         var enchantments = EnchantmentManager.GetRating(PropertyInt.PKDamageResistRating);
 
         // equipment ratings
-        var equipment = GetEquippedItemsRatingSum(PropertyInt.GearPKDamageResistRating);
+        var equipment = GetEquippedAndActivatedItemRatingSum(PropertyInt.GearPKDamageResistRating);
 
         return pkDamageResistRating + equipment + enchantments;
     }
 
     public int GetGearPKDamageRating()
     {
-        return GetEquippedItemsRatingSum(PropertyInt.GearPKDamageRating);
+        return GetEquippedAndActivatedItemRatingSum(PropertyInt.GearPKDamageRating);
     }
 
     public int GetGearPKDamageResistRating()
     {
-        return GetEquippedItemsRatingSum(PropertyInt.GearPKDamageResistRating);
+        return GetEquippedAndActivatedItemRatingSum(PropertyInt.GearPKDamageResistRating);
     }
 
     public int GetItemManaReductionRating()

--- a/apps/server/WorldObjects/Hotspot.cs
+++ b/apps/server/WorldObjects/Hotspot.cs
@@ -406,7 +406,7 @@ public class Hotspot : WorldObject
 
             if (
                 damageType == DamageType.Fire
-                && ((double)playerAttacker.GetEquippedItemsRatingSum(PropertyInt.GearFire) / 200)
+                && ((double)playerAttacker.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearFire) / 200)
                 > ThreadSafeRandom.Next(0f, 1f)
             )
             {
@@ -415,7 +415,7 @@ public class Hotspot : WorldObject
 
             if (
                 damageType == DamageType.Cold
-                && ((double)playerAttacker.GetEquippedItemsRatingSum(PropertyInt.GearFrost) / 200)
+                && ((double)playerAttacker.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearFrost) / 200)
                 > ThreadSafeRandom.Next(0f, 1f)
             )
             {
@@ -424,7 +424,7 @@ public class Hotspot : WorldObject
 
             if (
                 damageType == DamageType.Acid
-                && ((double)playerAttacker.GetEquippedItemsRatingSum(PropertyInt.GearAcid) / 200)
+                && ((double)playerAttacker.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearAcid) / 200)
                 > ThreadSafeRandom.Next(0f, 1f)
             )
             {
@@ -433,7 +433,7 @@ public class Hotspot : WorldObject
 
             if (
                 damageType == DamageType.Electric
-                && ((double)playerAttacker.GetEquippedItemsRatingSum(PropertyInt.GearLightning) / 200)
+                && ((double)playerAttacker.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearLightning) / 200)
                 > ThreadSafeRandom.Next(0f, 1f)
             )
             {
@@ -443,7 +443,7 @@ public class Hotspot : WorldObject
             if (damageType == DamageType.Health || damageType == DamageType.Stamina || damageType == DamageType.Mana)
             {
                 if (
-                    (double)playerAttacker.GetEquippedItemsRatingSum(PropertyInt.GearHealBubble) / 200
+                    (double)playerAttacker.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearHealBubble) / 200
                     > ThreadSafeRandom.Next(0f, 1f)
                 )
                 {

--- a/apps/server/WorldObjects/Jewel_Bonuses.cs
+++ b/apps/server/WorldObjects/Jewel_Bonuses.cs
@@ -131,9 +131,9 @@ partial class Jewel
     /// </summary>
     private static float CheckForRatingLightningDamageBonus(Player playerAttacker, DamageType damageType, float jewelElemental)
     {
-        if (playerAttacker.GetEquippedItemsRatingSum(PropertyInt.GearLightning) > 0 && damageType == DamageType.Electric)
+        if (playerAttacker.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearLightning) > 0 && damageType == DamageType.Electric)
         {
-            jewelElemental += (float)playerAttacker.GetEquippedItemsRatingSum(PropertyInt.GearLightning) / 100;
+            jewelElemental += (float)playerAttacker.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearLightning) / 100;
         }
 
         return jewelElemental;
@@ -145,9 +145,9 @@ partial class Jewel
     /// </summary>
     private static float CheckForRatingColdDamageBonus(Player playerAttacker, DamageType damageType, float jewelElemental)
     {
-        if (playerAttacker.GetEquippedItemsRatingSum(PropertyInt.GearFrost) > 0 && damageType == DamageType.Cold)
+        if (playerAttacker.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearFrost) > 0 && damageType == DamageType.Cold)
         {
-            jewelElemental += (float)playerAttacker.GetEquippedItemsRatingSum(PropertyInt.GearFrost) / 100;
+            jewelElemental += (float)playerAttacker.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearFrost) / 100;
         }
 
         return jewelElemental;
@@ -159,9 +159,9 @@ partial class Jewel
     /// </summary>
     private static float CheckForRatingFireDamageBonus(Player playerAttacker, DamageType damageType, float jewelElemental)
     {
-        if (playerAttacker.GetEquippedItemsRatingSum(PropertyInt.GearFire) > 0 && damageType == DamageType.Fire)
+        if (playerAttacker.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearFire) > 0 && damageType == DamageType.Fire)
         {
-            jewelElemental += (float)playerAttacker.GetEquippedItemsRatingSum(PropertyInt.GearFire) / 100;
+            jewelElemental += (float)playerAttacker.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearFire) / 100;
         }
 
         return jewelElemental;
@@ -173,9 +173,9 @@ partial class Jewel
     /// </summary>
     private static float CheckForRatingAcidDamageBonus(Player playerAttacker, DamageType damageType, float jewelElemental)
     {
-        if (playerAttacker.GetEquippedItemsRatingSum(PropertyInt.GearAcid) > 0 && damageType == DamageType.Acid)
+        if (playerAttacker.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearAcid) > 0 && damageType == DamageType.Acid)
         {
-            jewelElemental += (float)playerAttacker.GetEquippedItemsRatingSum(PropertyInt.GearAcid) / 100;
+            jewelElemental += (float)playerAttacker.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearAcid) / 100;
         }
 
         return jewelElemental;
@@ -187,7 +187,7 @@ partial class Jewel
     /// </summary>
     private static void CheckForRatingNullificationStamps(Player targetPlayer)
     {
-        if (targetPlayer.GetEquippedItemsRatingSum(PropertyInt.GearNullification) <= 0)
+        if (targetPlayer.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearNullification) <= 0)
         {
             return;
         }
@@ -306,7 +306,7 @@ partial class Jewel
     /// </summary>
     private static void CheckForRatingElementalistCasterStamps(Player sourcePlayer, int baseStamps)
     {
-        if (sourcePlayer.GetEquippedItemsRatingSum(PropertyInt.GearElementalist) <= 0)
+        if (sourcePlayer.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearElementalist) <= 0)
         {
             return;
         }
@@ -331,7 +331,7 @@ partial class Jewel
     /// </summary>
     private static void CheckForRatingWardPenCasterStamps(Player sourcePlayer, Creature targetCreature, int baseStamps)
     {
-        if (sourcePlayer.GetEquippedItemsRatingSum(PropertyInt.GearWardPen) <= 0)
+        if (sourcePlayer.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearWardPen) <= 0)
         {
             return;
         }
@@ -356,7 +356,7 @@ partial class Jewel
     /// </summary>
     private static void CheckForRatingFamiliarityCasterStamps(Player sourcePlayer, Creature targetCreature, int baseStamps)
     {
-        if (sourcePlayer.GetEquippedItemsRatingSum(PropertyInt.GearFamiliarity) <= 0)
+        if (sourcePlayer.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearFamiliarity) <= 0)
         {
             return;
         }
@@ -382,7 +382,7 @@ partial class Jewel
     /// </summary>
     private static void CheckForRatingPierceCasterStamps(Player sourcePlayer, Creature targetCreature, DamageType damageType, int baseStamps)
     {
-        if (sourcePlayer.GetEquippedItemsRatingSum(PropertyInt.GearPierce) <= 0)
+        if (sourcePlayer.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearPierce) <= 0)
         {
             return;
         }
@@ -412,7 +412,7 @@ partial class Jewel
     /// </summary>
     private static void CheckForRatingBludgeonCasterStamps(Player sourcePlayer, Creature targetCreature, DamageType damageType, int baseStamps)
     {
-        if (sourcePlayer.GetEquippedItemsRatingSum(PropertyInt.GearBludgeon) <= 0)
+        if (sourcePlayer.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearBludgeon) <= 0)
         {
             return;
         }
@@ -442,7 +442,7 @@ partial class Jewel
     /// </summary>
     private static void CheckForRatingBravadoMeleeStamps(Player playerDefender)
     {
-        if (playerDefender.GetEquippedItemsRatingSum(PropertyInt.GearBravado) <= 0)
+        if (playerDefender.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearBravado) <= 0)
         {
             return;
         }
@@ -467,7 +467,7 @@ partial class Jewel
     /// </summary>
     private static void CheckForRatingHardenedDefenseMeleeStamps(Player playerDefender)
     {
-        if (playerDefender.GetEquippedItemsRatingSum(PropertyInt.GearHardenedDefense) <= 0)
+        if (playerDefender.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearHardenedDefense) <= 0)
         {
             return;
         }
@@ -492,7 +492,7 @@ partial class Jewel
     /// </summary>
     private static void CheckForRatingStamReductionMeleeStamps(Player playerAttacker, double scaledStamps)
     {
-        if (playerAttacker.GetEquippedItemsRatingSum(PropertyInt.GearStamReduction) <= 0)
+        if (playerAttacker.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearStamReduction) <= 0)
         {
             return;
         }
@@ -518,7 +518,7 @@ partial class Jewel
     /// </summary>
     private static string CheckForRatingFamiliarityMeleeStamps(Player playerAttacker, string rampProperty)
     {
-        if (playerAttacker.GetEquippedItemsRatingSum(PropertyInt.GearFamiliarity) > 0)
+        if (playerAttacker.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearFamiliarity) > 0)
         {
             rampProperty = "Familiarity";
         }
@@ -532,7 +532,7 @@ partial class Jewel
     /// </summary>
     private static string CheckForRatingPierceMeleeStamps(Player playerAttacker, DamageType damageType, string rampProperty)
     {
-        if (playerAttacker.GetEquippedItemsRatingSum(PropertyInt.GearPierce) > 0)
+        if (playerAttacker.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearPierce) > 0)
         {
             if (damageType == DamageType.Pierce)
             {
@@ -549,7 +549,7 @@ partial class Jewel
     /// </summary>
     private static string CheckForRatingBludgeonMeleeStamps(Player playerAttacker, DamageType damageType, string rampProperty)
     {
-        if (playerAttacker.GetEquippedItemsRatingSum(PropertyInt.GearBludgeon) > 0)
+        if (playerAttacker.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearBludgeon) > 0)
         {
             if (damageType == DamageType.Bludgeon)
             {
@@ -566,12 +566,12 @@ partial class Jewel
     /// </summary>
     private static void CheckForRatingProsperityFindStamps(Player playerAttacker, Creature defender, float damage)
     {
-        if (playerAttacker.GetEquippedItemsRatingSum(PropertyInt.GearPyrealFind) <= 0)
+        if (playerAttacker.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearPyrealFind) <= 0)
         {
             return;
         }
 
-        var pyrealFind = playerAttacker.GetEquippedItemsRatingSum(PropertyInt.GearPyrealFind);
+        var pyrealFind = playerAttacker.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearPyrealFind);
 
         defender.QuestManager.Stamp($"{playerAttacker.Name}/Prosperity/{pyrealFind}/{damage}");
     }
@@ -582,12 +582,12 @@ partial class Jewel
     /// </summary>
     private static void CheckForRatingMagicFindStamps(Player playerAttacker, Creature defender, float damage)
     {
-        if (playerAttacker.GetEquippedItemsRatingSum(PropertyInt.GearMagicFind) <= 0)
+        if (playerAttacker.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearMagicFind) <= 0)
         {
             return;
         }
 
-        var magicFind = playerAttacker.GetEquippedItemsRatingSum(PropertyInt.GearMagicFind);
+        var magicFind = playerAttacker.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearMagicFind);
 
         defender.QuestManager.Stamp($"{playerAttacker.Name}/MagicFind/{magicFind}/{damage}");
     }
@@ -598,10 +598,10 @@ partial class Jewel
     /// </summary>
     private static void CheckForRatingElementalHotspot(Player playerAttacker, Creature defender, DamageType damageType)
     {
-        if (playerAttacker.GetEquippedItemsRatingSum(PropertyInt.GearFire) <= 0
-            && playerAttacker.GetEquippedItemsRatingSum(PropertyInt.GearFrost) <= 0
-            && playerAttacker.GetEquippedItemsRatingSum(PropertyInt.GearAcid) <= 0
-            && playerAttacker.GetEquippedItemsRatingSum(PropertyInt.GearLightning) <= 0)
+        if (playerAttacker.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearFire) <= 0
+            && playerAttacker.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearFrost) <= 0
+            && playerAttacker.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearAcid) <= 0
+            && playerAttacker.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearLightning) <= 0)
         {
             return;
         }
@@ -622,12 +622,12 @@ partial class Jewel
     private static void CheckForRatingSelfHarm(Player playerAttacker, float damage)
     {
         // JEWEL - Hematite: Self-harm damage
-        if (playerAttacker.GetEquippedItemsRatingSum(PropertyInt.GearSelfHarm) <= 0)
+        if (playerAttacker.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearSelfHarm) <= 0)
         {
             return;
         }
 
-        var jewelSelfHarm = (playerAttacker.GetEquippedItemsRatingSum(PropertyInt.GearSelfHarm) * 0.01f);
+        var jewelSelfHarm = (playerAttacker.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearSelfHarm) * 0.01f);
         var selfHarm = (int)(jewelSelfHarm * damage);
 
         playerAttacker.UpdateVitalDelta(playerAttacker.Health, -selfHarm);
@@ -649,12 +649,12 @@ partial class Jewel
     /// </summary>
     private static void CheckForRatingManaOnHit(Player playerAttacker, Creature defender, float damage)
     {
-        if (playerAttacker.GetEquippedItemsRatingSum(PropertyInt.GearManasteal) <= 0)
+        if (playerAttacker.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearManasteal) <= 0)
         {
             return;
         }
 
-        var chance = (float)playerAttacker.GetEquippedItemsRatingSum(PropertyInt.GearManasteal);
+        var chance = (float)playerAttacker.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearManasteal);
 
         if (playerAttacker == defender || !(chance >= ThreadSafeRandom.Next(0.0f, 1.0f)))
         {
@@ -679,12 +679,12 @@ partial class Jewel
     /// </summary>
     private static void CheckForRatingLifeOnHit(Player playerAttacker, Creature defender, float damage)
     {
-        if (playerAttacker.GetEquippedItemsRatingSum(PropertyInt.GearLifesteal) <= 0)
+        if (playerAttacker.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearLifesteal) <= 0)
         {
             return;
         }
 
-        var chance = playerAttacker.GetEquippedItemsRatingSum(PropertyInt.GearLifesteal) * 0.01f;
+        var chance = playerAttacker.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearLifesteal) * 0.01f;
 
         if (playerAttacker == defender || !(chance >= ThreadSafeRandom.Next(0.0f, 1.0f)))
         {
@@ -709,12 +709,12 @@ partial class Jewel
     /// </summary>
     public static void CheckForRatingHealthToMana(Player playerDefender, Creature attacker, float damage)
     {
-        if (playerDefender.GetEquippedItemsRatingSum(PropertyInt.GearHealthToMana) <= 0)
+        if (playerDefender.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearHealthToMana) <= 0)
         {
             return;
         }
 
-        var chance = playerDefender.GetEquippedItemsRatingSum(PropertyInt.GearHealthToMana) * 0.01f;
+        var chance = playerDefender.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearHealthToMana) * 0.01f;
 
         if (attacker == playerDefender || !(chance >= ThreadSafeRandom.Next(0.0f, 1.0f)))
         {
@@ -738,12 +738,12 @@ partial class Jewel
     /// </summary>
     public static void CheckForRatingHealthToStamina(Player playerDefender, Creature attacker, float damage)
     {
-        if (playerDefender.GetEquippedItemsRatingSum(PropertyInt.GearHealthToStamina) <= 0)
+        if (playerDefender.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearHealthToStamina) <= 0)
         {
             return;
         }
 
-        var chance = playerDefender.GetEquippedItemsRatingSum(PropertyInt.GearHealthToStamina) * 0.01f;
+        var chance = playerDefender.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearHealthToStamina) * 0.01f;
 
         if (attacker == playerDefender || !(chance >= ThreadSafeRandom.Next(0.0f, 1.0f)))
         {
@@ -795,7 +795,7 @@ partial class Jewel
 
         // multiply gear last stand as % by the modifier--if negative (above 50% HP), mod goes sub 1, which added to the 1f in DamageEvent results in a damage penalty.
 
-        var lastStandMod = (modifiedLastStand * ((float)playerAttacker.GetEquippedItemsRatingSum(PropertyInt.GearLastStand) / 50));
+        var lastStandMod = (modifiedLastStand * ((float)playerAttacker.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearLastStand) / 50));
 
         return lastStandMod;
     }

--- a/apps/server/WorldObjects/Monster_Awareness.cs
+++ b/apps/server/WorldObjects/Monster_Awareness.cs
@@ -241,9 +241,9 @@ partial class Creature
     /// </summary>
     private float CheckForRatingThreatReduction(Player targetPlayer)
     {
-        if (targetPlayer != null && targetPlayer.GetEquippedItemsRatingSum(PropertyInt.GearThreatReduction) > 0)
+        if (targetPlayer != null && targetPlayer.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearThreatReduction) > 0)
         {
-            return (float)(targetPlayer.GetEquippedItemsRatingSum(PropertyInt.GearThreatReduction)) / 10;
+            return (float)(targetPlayer.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearThreatReduction)) / 10;
         }
 
         return 0.0f;
@@ -255,9 +255,9 @@ partial class Creature
     /// </summary>
     private float CheckForRatingThreatGainBonus(Player targetPlayer)
     {
-        if (targetPlayer != null && targetPlayer.GetEquippedItemsRatingSum(PropertyInt.GearThreatGain) > 0)
+        if (targetPlayer != null && targetPlayer.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearThreatGain) > 0)
         {
-            return (float)(targetPlayer.GetEquippedItemsRatingSum(PropertyInt.GearThreatGain)) / 10;
+            return (float)(targetPlayer.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearThreatGain)) / 10;
         }
 
         return 0.0f;

--- a/apps/server/WorldObjects/Player_Melee.cs
+++ b/apps/server/WorldObjects/Player_Melee.cs
@@ -369,14 +369,14 @@ partial class Player
         // JEWEL - Citrine: Stamina cost reduction
         if (this is Player)
         {
-            if (this.GetEquippedItemsRatingSum(PropertyInt.GearStamReduction) > 0)
+            if (this.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearStamReduction) > 0)
             {
                 if (this.QuestManager.HasQuest($"{this.Name},StamReduction"))
                 {
                     var jewelRampMod = (float)this.QuestManager.GetCurrentSolves($"{this.Name},StamReduction") / 500;
                     var stamReductionMod =
                         1f
-                        - (jewelRampMod * (float)this.GetEquippedItemsRatingSum(PropertyInt.GearStamReduction) / 100);
+                        - (jewelRampMod * (float)this.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearStamReduction) / 100);
                     var modifiedStamCost = (float)staminaCost * stamReductionMod;
                     staminaCost = (int)modifiedStamCost;
                 }
@@ -440,7 +440,7 @@ partial class Player
 
                     if (
                         weapon != null && weapon.IsCleaving
-                        || (GetEquippedItemsRatingSum(PropertyInt.GearSlash) > 0)
+                        || (GetEquippedAndActivatedItemRatingSum(PropertyInt.GearSlash) > 0)
                             && damageEvent.DamageType == DamageType.Slash
                     )
                     {

--- a/apps/server/WorldObjects/Player_Missile.cs
+++ b/apps/server/WorldObjects/Player_Missile.cs
@@ -473,14 +473,14 @@ partial class Player
     /// </summary>
     private int CheckForRatingSlashCleaveBonus(WorldObject launcher, WorldObject ammo)
     {
-        if (this.GetEquippedItemsRatingSum(PropertyInt.GearSlash) <= 0
+        if (this.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearSlash) <= 0
             || launcher.W_DamageType != DamageType.Slash
             || ammo.W_DamageType != DamageType.Slash)
         {
             return 0;
         }
 
-        return GetEquippedItemsRatingSum(PropertyInt.GearSlash) >= ThreadSafeRandom.Next(0, 100) ? 1 : 0;
+        return GetEquippedAndActivatedItemRatingSum(PropertyInt.GearSlash) >= ThreadSafeRandom.Next(0, 100) ? 1 : 0;
     }
 
     // TODO: the damage pipeline currently uses the creature ammo instead of the projectile

--- a/apps/server/WorldObjects/Player_Tick.cs
+++ b/apps/server/WorldObjects/Player_Tick.cs
@@ -826,12 +826,12 @@ partial class Player
     /// </summary>
     private double CheckForRatingItemManaUsage()
     {
-        if (GetEquippedItemsRatingSum(PropertyInt.GearItemManaUsage) <= 0)
+        if (GetEquippedAndActivatedItemRatingSum(PropertyInt.GearItemManaUsage) <= 0)
         {
             return 1.0f;
         }
 
-        var moonstoneRating = GetEquippedItemsRatingSum(PropertyInt.GearItemManaUsage);
+        var moonstoneRating = GetEquippedAndActivatedItemRatingSum(PropertyInt.GearItemManaUsage);
         var moonstoneMod = 100f / (100 + moonstoneRating * 5);
 
         return moonstoneMod;

--- a/apps/server/WorldObjects/Player_Xp.cs
+++ b/apps/server/WorldObjects/Player_Xp.cs
@@ -1057,9 +1057,9 @@ partial class Player
         }
 
         // JEWEL - Sunstone: Bonus experience gain
-        if (xpType == XpType.Kill && GetEquippedItemsRatingSum(PropertyInt.GearExperienceGain) > 0)
+        if (xpType == XpType.Kill && GetEquippedAndActivatedItemRatingSum(PropertyInt.GearExperienceGain) > 0)
         {
-            augBonus *= GetEquippedItemsRatingSum(PropertyInt.GearExperienceGain) / 2;
+            augBonus *= (float)GetEquippedAndActivatedItemRatingSum(PropertyInt.GearExperienceGain) / 2;
         }
 
         var modifier = 1.0f + enchantmentBonus + augBonus;

--- a/apps/server/WorldObjects/SpellProjectile.cs
+++ b/apps/server/WorldObjects/SpellProjectile.cs
@@ -1154,13 +1154,13 @@ public class SpellProjectile : WorldObject
             return 0.0f;
         }
 
-        if (targetPlayer.GetEquippedItemsRatingSum(PropertyInt.GearNullification) <= 0)
+        if (targetPlayer.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearNullification) <= 0)
         {
             return 0.0f;
         }
 
         var rampMod = (float)targetPlayer.QuestManager.GetCurrentSolves($"{targetPlayer.Name},Nullification") / 200; // up to 1.0f
-        var ratingMod = targetPlayer.GetEquippedItemsRatingSum(PropertyInt.GearNullification) * 0.02f; // 0.02f per rating
+        var ratingMod = targetPlayer.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearNullification) * 0.02f; // 0.02f per rating
 
         return rampMod * ratingMod;
     }
@@ -1199,13 +1199,13 @@ public class SpellProjectile : WorldObject
             return 0.0f;
         }
 
-        if (sourcePlayer.GetEquippedItemsRatingSum(PropertyInt.GearWardPen) <= 0)
+        if (sourcePlayer.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearWardPen) <= 0)
         {
             return 0.0f;
         }
 
         var rampMod = (float)target.QuestManager.GetCurrentSolves($"{sourcePlayer.Name},WardPen") / 500; // up to 1.0f
-        var ratingMod = sourcePlayer.GetEquippedItemsRatingSum(PropertyInt.GearWardPen) * 0.02f; // 0.02f per rating
+        var ratingMod = sourcePlayer.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearWardPen) * 0.02f; // 0.02f per rating
 
         return rampMod * ratingMod;
     }
@@ -1226,12 +1226,12 @@ public class SpellProjectile : WorldObject
             return false;
         }
 
-        if (targetPlayer.GetEquippedItemsRatingSum(PropertyInt.GearReprisal) <= 0)
+        if (targetPlayer.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearReprisal) <= 0)
         {
             return false;
         }
 
-        if ((targetPlayer.GetEquippedItemsRatingSum(PropertyInt.GearReprisal) / 2) < ThreadSafeRandom.Next(0, 100))
+        if ((targetPlayer.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearReprisal) / 2) < ThreadSafeRandom.Next(0, 100))
         {
             return false;
         }
@@ -1267,7 +1267,7 @@ public class SpellProjectile : WorldObject
             return criticalChance;
         }
 
-        if (sourcePlayer.GetEquippedItemsRatingSum(PropertyInt.GearReprisal) <= 0)
+        if (sourcePlayer.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearReprisal) <= 0)
         {
             return criticalChance;
         }
@@ -1293,7 +1293,7 @@ public class SpellProjectile : WorldObject
             return 0.0f;
         }
 
-        return sourcePlayer.GetEquippedItemsRatingSum(PropertyInt.GearLastStand) > 0 ? Jewel.GetJewelLastStand(sourcePlayer) : 0.0f;
+        return sourcePlayer.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearLastStand) > 0 ? Jewel.GetJewelLastStand(sourcePlayer) : 0.0f;
     }
 
     /// <summary>
@@ -1307,9 +1307,9 @@ public class SpellProjectile : WorldObject
             return 0.0f;
         }
 
-        if (sourcePlayer.GetEquippedItemsRatingSum(PropertyInt.GearSelfHarm) > 0)
+        if (sourcePlayer.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearSelfHarm) > 0)
         {
-            return (sourcePlayer.GetEquippedItemsRatingSum(PropertyInt.GearSelfHarm) * 0.01f);
+            return (sourcePlayer.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearSelfHarm) * 0.01f);
         }
 
         return 0.0f;
@@ -1327,7 +1327,7 @@ public class SpellProjectile : WorldObject
             return 0.0f;
         }
 
-        if (sourcePlayer.GetEquippedItemsRatingSum(PropertyInt.GearPierce) <= 0)
+        if (sourcePlayer.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearPierce) <= 0)
         {
             return 0.0f;
         }
@@ -1338,7 +1338,7 @@ public class SpellProjectile : WorldObject
         }
 
         var rampMod = (float)target.QuestManager.GetCurrentSolves($"{sourcePlayer.Name},Pierce") / 500; // up to 1.0f;
-        var ratingMod = sourcePlayer.GetEquippedItemsRatingSum(PropertyInt.GearPierce) * 0.02f; // 0.02f per rating;
+        var ratingMod = sourcePlayer.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearPierce) * 0.02f; // 0.02f per rating;
 
         return rampMod * ratingMod;
     }
@@ -1355,7 +1355,7 @@ public class SpellProjectile : WorldObject
             return 1.0f;
         }
 
-        if (sourcePlayer.GetEquippedItemsRatingSum(PropertyInt.GearBludgeon) <= 0)
+        if (sourcePlayer.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearBludgeon) <= 0)
         {
             return 1.0f;
         }
@@ -1366,7 +1366,7 @@ public class SpellProjectile : WorldObject
         }
 
         var rampMod = (float)target.QuestManager.GetCurrentSolves($"{sourcePlayer.Name},Bludgeon") / 500; // up to 1.0f
-        var ratingMod = (float)sourcePlayer.GetEquippedItemsRatingSum(PropertyInt.GearBludgeon) * 0.02f; // 0.02f per rating
+        var ratingMod = (float)sourcePlayer.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearBludgeon) * 0.02f; // 0.02f per rating
 
         return rampMod * ratingMod;
     }
@@ -1383,13 +1383,13 @@ public class SpellProjectile : WorldObject
             return 0.0f;
         }
 
-        if (sourcePlayer.GetEquippedItemsRatingSum(PropertyInt.GearElementalist) <= 0)
+        if (sourcePlayer.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearElementalist) <= 0)
         {
             return 0.0f;
         }
 
         var rampMod = (float)sourcePlayer.QuestManager.GetCurrentSolves($"{sourcePlayer.Name},Elementalist") / 500; // up to 1.0f
-        var ratingMod = sourcePlayer.GetEquippedItemsRatingSum(PropertyInt.GearElementalist) * 0.02f; // 0.02f per rating
+        var ratingMod = sourcePlayer.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearElementalist) * 0.02f; // 0.02f per rating
 
         return rampMod * ratingMod;
     }
@@ -1414,9 +1414,9 @@ public class SpellProjectile : WorldObject
             return 1.0f;
         }
 
-        if (targetPlayer.GetEquippedItemsRatingSum(PropertyInt.GearElementalWard) > 0)
+        if (targetPlayer.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearElementalWard) > 0)
         {
-            return (1 - ((float)targetPlayer.GetEquippedItemsRatingSum(PropertyInt.GearElementalWard) / 100));
+            return (1 - ((float)targetPlayer.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearElementalWard) / 100));
         }
 
         return 1.0f;
@@ -1441,9 +1441,9 @@ public class SpellProjectile : WorldObject
             return 1.0f;
         }
 
-        if (targetPlayer.GetEquippedItemsRatingSum(PropertyInt.GearPhysicalWard) > 0)
+        if (targetPlayer.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearPhysicalWard) > 0)
         {
-            return (1 - ((float)targetPlayer.GetEquippedItemsRatingSum(PropertyInt.GearPhysicalWard) / 100));
+            return (1 - ((float)targetPlayer.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearPhysicalWard) / 100));
         }
 
         return 1.0f;

--- a/apps/server/WorldObjects/WorldObject.cs
+++ b/apps/server/WorldObjects/WorldObject.cs
@@ -1734,4 +1734,20 @@ public abstract partial class WorldObject : IActor
             }
         }
     }
+
+    public bool SpecialPropertiesRequireMana
+    {
+        get => GetProperty(PropertyBool.SpecialPropertiesRequireMana) ?? false;
+        set
+        {
+            if (!value)
+            {
+                RemoveProperty(PropertyBool.SpecialPropertiesRequireMana);
+            }
+            else
+            {
+                SetProperty(PropertyBool.SpecialPropertiesRequireMana, value);
+            }
+        }
+    }
 }

--- a/apps/server/WorldObjects/WorldObject_Magic.cs
+++ b/apps/server/WorldObjects/WorldObject_Magic.cs
@@ -393,7 +393,7 @@ partial class WorldObject
             return 0.0f;
         }
 
-        if (targetPlayer.GetEquippedItemsRatingSum(PropertyInt.GearFamiliarity) <= 0)
+        if (targetPlayer.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearFamiliarity) <= 0)
         {
             return 0.0f;
         }
@@ -404,7 +404,7 @@ partial class WorldObject
         }
 
         var rampMod = (float)casterCreature.QuestManager.GetCurrentSolves($"{targetPlayer.Name},Familiarity") / 500; // up to 1.0f
-        var ratingMod = targetPlayer.GetEquippedItemsRatingSum(PropertyInt.GearFamiliarity) * 0.01f; // 0.01 per rating
+        var ratingMod = targetPlayer.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearFamiliarity) * 0.01f; // 0.01 per rating
 
         return rampMod * ratingMod;
     }
@@ -1111,13 +1111,13 @@ partial class WorldObject
             return 1.0f;
         }
 
-        if (tPlayer.GetEquippedItemsRatingSum(PropertyInt.GearNullification) <= 0)
+        if (tPlayer.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearNullification) <= 0)
         {
             return 1.0f;
         }
 
         var rampMod = (float)tPlayer.QuestManager.GetCurrentSolves($"{tPlayer.Name},Nullification") / 200; // up to 1.0f
-        var ratingMod = tPlayer.GetEquippedItemsRatingSum(PropertyInt.GearNullification) * 0.02f; // 0.02f per rating
+        var ratingMod = tPlayer.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearNullification) * 0.02f; // 0.02f per rating
 
         return rampMod * ratingMod;
     }
@@ -1133,12 +1133,12 @@ partial class WorldObject
             return 1.0f;
         }
 
-        if (player.GetEquippedItemsRatingSum(PropertyInt.GearVitalsTransfer) <= 0)
+        if (player.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearVitalsTransfer) <= 0)
         {
             return 1.0f;
         }
 
-        var ratingMod = player.GetEquippedItemsRatingSum(PropertyInt.GearVitalsTransfer) * 0.02f;
+        var ratingMod = player.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearVitalsTransfer) * 0.02f;
 
         return 1.0f - ratingMod;
     }
@@ -1154,12 +1154,12 @@ partial class WorldObject
             return 1.0f;
         }
 
-        if (player.GetEquippedItemsRatingSum(PropertyInt.GearHealBubble) <= 0 || targetCreature.IsMonster)
+        if (player.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearHealBubble) <= 0 || targetCreature.IsMonster)
         {
             return 1.0f;
         }
 
-        var ratingMod = player.GetEquippedItemsRatingSum(PropertyInt.GearHealBubble) * 0.01f;
+        var ratingMod = player.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearHealBubble) * 0.01f;
 
         if (weapon is { Tier: not null })
         {
@@ -1180,12 +1180,12 @@ partial class WorldObject
             return 1.0f;
         }
 
-        if (player.GetEquippedItemsRatingSum(PropertyInt.GearSelflessness) <= 0 || targetCreature.IsMonster)
+        if (player.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearSelflessness) <= 0 || targetCreature.IsMonster)
         {
             return 1.0f;
         }
 
-        var ratingMod = player.GetEquippedItemsRatingSum(PropertyInt.GearSelflessness) * 0.02f;
+        var ratingMod = player.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearSelflessness) * 0.02f;
 
         if (targetCreature == this)
         {
@@ -1772,12 +1772,12 @@ partial class WorldObject
             return 1.0f;
         }
 
-        if (player.GetEquippedItemsRatingSum(PropertyInt.GearVitalsTransfer) <= 0)
+        if (player.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearVitalsTransfer) <= 0)
         {
             return 1.0f;
         }
 
-        var ratingMod = player.GetEquippedItemsRatingSum(PropertyInt.GearVitalsTransfer) * 0.02f;
+        var ratingMod = player.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearVitalsTransfer) * 0.02f;
 
         return 1.0f + ratingMod;
     }
@@ -1927,12 +1927,12 @@ partial class WorldObject
             return;
         }
 
-        if (caster.GetEquippedItemsRatingSum(PropertyInt.GearSlash) <= 0)
+        if (caster.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearSlash) <= 0)
         {
             return;
         }
 
-        if (caster.GetEquippedItemsRatingSum(PropertyInt.GearSlash) <= ThreadSafeRandom.Next(1, 100))
+        if (caster.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearSlash) <= ThreadSafeRandom.Next(1, 100))
         {
             return;
         }

--- a/apps/server/WorldObjects/WorldObject_Weapon.cs
+++ b/apps/server/WorldObjects/WorldObject_Weapon.cs
@@ -389,6 +389,11 @@ partial class WorldObject
         {
             var criticalStrikeBonus = DefaultPhysicalCritFrequency + GetCriticalStrikeMod(skill, wielder, target);
 
+            if (weapon is { SpecialPropertiesRequireMana: true, ItemCurMana: 0 })
+            {
+                criticalStrikeBonus = DefaultPhysicalCritFrequency;
+            }
+
             critRate = Math.Max(critRate, criticalStrikeBonus);
         }
 
@@ -438,6 +443,11 @@ partial class WorldObject
 
             var criticalStrikeMod = DefaultMagicCritFrequency + GetCriticalStrikeMod(skill, wielder, target, isPvP);
 
+            if (weapon is { SpecialPropertiesRequireMana: true, ItemCurMana: 0 })
+            {
+                criticalStrikeMod = DefaultMagicCritFrequency;
+            }
+
             critRate = Math.Max(critRate, criticalStrikeMod);
         }
 
@@ -469,6 +479,11 @@ partial class WorldObject
         if (weapon != null && weapon.HasImbuedEffect(ImbuedEffectType.CripplingBlow))
         {
             var cripplingBlowMod = DefaultCritDamageMultiplier + GetCripplingBlowMod(skill, wielder, target);
+
+            if (weapon is { SpecialPropertiesRequireMana: true, ItemCurMana: 0 })
+            {
+                cripplingBlowMod = DefaultCritDamageMultiplier;
+            }
 
             critDamageMod = Math.Max(critDamageMod, cripplingBlowMod);
         }
@@ -676,6 +691,11 @@ partial class WorldObject
         if (rendDamageType != ImbuedEffectType.Undef && weapon.HasImbuedEffect(rendDamageType) && skill != null)
         {
             var rendingMod = DefaultModifier + GetRendingMod(skill, wielder, target);
+
+            if (weapon is { SpecialPropertiesRequireMana: true, ItemCurMana: 0 })
+            {
+                rendingMod = DefaultModifier;
+            }
 
             resistMod = Math.Max(resistMod, rendingMod);
         }
@@ -927,6 +947,11 @@ partial class WorldObject
 
     public float GetArmorCleavingMod(WorldObject weapon)
     {
+        if (weapon is { SpecialPropertiesRequireMana: true, ItemCurMana: 0 })
+        {
+            return 1.0f;
+        }
+
         // investigate: should this value be on creatures directly?
         var creatureMod = GetArmorCleavingMod();
         var weaponMod = weapon != null ? weapon.GetArmorCleavingMod() : 1.0f;
@@ -1017,7 +1042,12 @@ partial class WorldObject
 
     public float GetIgnoreWardMod(WorldObject weapon)
     {
-        if (weapon == null || weapon.IgnoreWard == null)
+        if (weapon is { SpecialPropertiesRequireMana: true, ItemCurMana: 0 })
+        {
+            return 1.0f;
+        }
+
+        if (weapon.IgnoreWard == null)
         {
             return 1.0f;
         }

--- a/libs/entity/Enum/Properties/PropertyBool.cs
+++ b/libs/entity/Enum/Properties/PropertyBool.cs
@@ -233,6 +233,7 @@ public enum PropertyBool : ushort
     IsPlayerTierChest = 153,
     UpgradeableQuestItem = 154,
     FellowshipRequired = 155,
+    SpecialPropertiesRequireMana = 156,
 
     /* custom */
     [ServerOnly]


### PR DESCRIPTION
- New bool: SpecialPropertiesRequireMana.
- If bool is true, the item must have mana for all special properties to activate. (imbues, ratings, etc)
   - To be used with quest gear items mostly.