### PR TITLE
feat: improve pearl of transference

### DIFF
--- a/apps/server/Entity/Confirmation.cs
+++ b/apps/server/Entity/Confirmation.cs
@@ -149,13 +149,6 @@ public class Confirmation_CraftInteration : Confirmation
             return;
         }
 
-        if (!response)
-        {
-            player.SendWeenieError(WeenieError.YouChickenOut);
-
-            return;
-        }
-
         // inventory only?
         var source = player.FindObject(SourceGuid.Full, Player.SearchLocations.LocationsICanMove);
         var target = player.FindObject(TargetGuid.Full, Player.SearchLocations.LocationsICanMove);
@@ -165,37 +158,46 @@ public class Confirmation_CraftInteration : Confirmation
             return;
         }
 
-        if (source.WeenieType == WeenieType.SpellTransference)
+        var repeatConfirmation = source.RepeatConfirmation && target.RemainingConfirmations > 0;
+
+        if (!response && !repeatConfirmation)
         {
-            SpellTransference.UseObjectOnTarget(player, source, target, true);
+            player.SendWeenieError(WeenieError.YouChickenOut);
+
+            return;
         }
-        else if (source.WeenieType == WeenieType.Jewel)
+
+        if (response)
         {
-            Jewel.UseObjectOnTarget(player, source, target, true);
+            repeatConfirmation = false;
         }
-        else if (source.WeenieType == WeenieType.ArmorPatch)
+
+        switch (source.WeenieType)
         {
-            ArmorPatch.UseObjectOnTarget(player, source, target, true);
-        }
-        else if (source.WeenieType == WeenieType.TailoringKit)
-        {
-            TailoringKit.UseObjectOnTarget(player, source, target, true);
-        }
-        else if (source.WeenieType == WeenieType.Salvage)
-        {
-            Salvage.UseObjectOnTarget(player, source, target, true);
-        }
-        else if (source.WeenieType == WeenieType.CombatFocusAlterationGem)
-        {
-            CombatFocusAlterationGem.UseObjectOnTarget(player, source, target, true);
-        }
-        else if (source.WeenieType == WeenieType.UpgradeKit)
-        {
-            UpgradeKit.UseObjectOnTarget(player, source, target, true);
-        }
-        else
-        {
-            RecipeManager.UseObjectOnTarget(player, source, target, true);
+            case WeenieType.SpellTransference:
+                SpellTransference.UseObjectOnTarget(player, source, target, !repeatConfirmation);
+                break;
+            case WeenieType.Jewel:
+                Jewel.UseObjectOnTarget(player, source, target, true);
+                break;
+            case WeenieType.ArmorPatch:
+                ArmorPatch.UseObjectOnTarget(player, source, target, true);
+                break;
+            case WeenieType.TailoringKit:
+                TailoringKit.UseObjectOnTarget(player, source, target, true);
+                break;
+            case WeenieType.Salvage:
+                Salvage.UseObjectOnTarget(player, source, target, true);
+                break;
+            case WeenieType.CombatFocusAlterationGem:
+                CombatFocusAlterationGem.UseObjectOnTarget(player, source, target, true);
+                break;
+            case WeenieType.UpgradeKit:
+                UpgradeKit.UseObjectOnTarget(player, source, target, true);
+                break;
+            default:
+                RecipeManager.UseObjectOnTarget(player, source, target, true);
+                break;
         }
     }
 }

--- a/apps/server/WorldObjects/WorldObject.cs
+++ b/apps/server/WorldObjects/WorldObject.cs
@@ -1750,4 +1750,20 @@ public abstract partial class WorldObject : IActor
             }
         }
     }
+
+    public bool RepeatConfirmation
+    {
+        get => GetProperty(PropertyBool.RepeatConfirmation) ?? false;
+        set
+        {
+            if (!value)
+            {
+                RemoveProperty(PropertyBool.RepeatConfirmation);
+            }
+            else
+            {
+                SetProperty(PropertyBool.RepeatConfirmation, true);
+            }
+        }
+    }
 }

--- a/apps/server/WorldObjects/WorldObject_Properties.cs
+++ b/apps/server/WorldObjects/WorldObject_Properties.cs
@@ -8938,4 +8938,20 @@ partial class WorldObject
             }
         }
     }
+
+    public int? RemainingConfirmations
+    {
+        get => GetProperty(PropertyInt.RemainingConfirmations);
+        set
+        {
+            if (!value.HasValue)
+            {
+                RemoveProperty(PropertyInt.RemainingConfirmations);
+            }
+            else
+            {
+                SetProperty(PropertyInt.RemainingConfirmations, value.Value);
+            }
+        }
+    }
 }

--- a/libs/entity/Enum/Properties/PropertyBool.cs
+++ b/libs/entity/Enum/Properties/PropertyBool.cs
@@ -234,6 +234,7 @@ public enum PropertyBool : ushort
     UpgradeableQuestItem = 154,
     FellowshipRequired = 155,
     SpecialPropertiesRequireMana = 156,
+    RepeatConfirmation = 157,
 
     /* custom */
     [ServerOnly]

--- a/libs/entity/Enum/Properties/PropertyInt.cs
+++ b/libs/entity/Enum/Properties/PropertyInt.cs
@@ -821,6 +821,7 @@ public enum PropertyInt : ushort
     NearbyPlayerScalingThreshold = 462,
     NearbyPlayerScalingExtraPlayersPerAdd = 463,
     NearbyPlayerScalingAddWcid = 464,
+    RemainingConfirmations = 465,
 
     [ServerOnly]
     PCAPRecordedAutonomousMovement = 8007,


### PR DESCRIPTION
- Extracting: Rather than selecting a random spell, cycle through each spell when player selects "No", allowing players to easily target a spell to extract.
- Transferring: Provide preview of potential new arcane lore requirement on confirmation box.