### PR TITLE
fix: elemental damage bonus buffs

### DIFF
--- a/apps/server/Network/Structure/AppraiseInfo.cs
+++ b/apps/server/Network/Structure/AppraiseInfo.cs
@@ -688,7 +688,9 @@ public class AppraiseInfo
 
             if (enchantmentBonus != 0)
             {
-                PropertiesFloat[PropertyFloat.ElementalDamageMod] += enchantmentBonus;
+                PropertiesFloat.TryGetValue(PropertyFloat.ElementalDamageMod, out var baseElementalDamageMod);
+
+                PropertiesFloat[PropertyFloat.ElementalDamageMod] = (baseElementalDamageMod - 1.0f) * (1.0f + enchantmentBonus) + 1.0f;
 
                 ResistHighlight = ResistMaskHelper.GetHighlightMask(wo);
                 ResistColor = ResistMaskHelper.GetColorMask(wo);

--- a/apps/server/WorldObjects/WorldObject_Weapon.cs
+++ b/apps/server/WorldObjects/WorldObject_Weapon.cs
@@ -513,13 +513,13 @@ partial class WorldObject
 
         var elementalDamageMod = weapon.ElementalDamageMod ?? 1.0f;
 
-        // additive to base multiplier
+        // multiplicative to base multiplier
         var wielderEnchantments = wielder.EnchantmentManager.GetElementalDamageMod();
         var weaponEnchantments = weapon.EnchantmentManager.GetElementalDamageMod();
 
         var enchantments = wielderEnchantments + weaponEnchantments;
 
-        var modifier = (float)(elementalDamageMod + enchantments);
+        var modifier = (float)((elementalDamageMod - 1.0f) * (1.0f + enchantments) + 1.0f);
 
         if (modifier > 1.0f && target is Player)
         {


### PR DESCRIPTION
- Make elemental damage bonus buffs provide a multiplicative buff of a weapons's elemental damage bonus stat, instead of additive.