### PR TITLE
fix: set target for shielding scarab when using non-targeting spells

### DIFF
--- a/apps/server/WorldObjects/WorldObject_Magic.cs
+++ b/apps/server/WorldObjects/WorldObject_Magic.cs
@@ -671,6 +671,16 @@ partial class WorldObject
             return;
         }
 
+        if (spell.Id == 5206) // Surge of Protection
+        {
+            target = caster;
+        }
+        else if (target == null)
+        {
+            _log.Warning("DoSpellEffects(spell = {Spell}, caster = {Caster}, target = null, projectileHit = {ProjectileHit}) - Target is null.", spell, caster, projectileHit);
+            return;
+        }
+
         var targetBroadcaster = target.Wielder ?? target;
 
         targetBroadcaster.EnqueueBroadcast(


### PR DESCRIPTION
- Set target to self for shielding scarab spell effect.
- Prevent other possible null references for spell effects without a target.