### PR TITLE
feat: allow deleteself emote to remove 1 object from a stack

### DIFF
--- a/apps/server/WorldObjects/Managers/EmoteManager.cs
+++ b/apps/server/WorldObjects/Managers/EmoteManager.cs
@@ -501,7 +501,14 @@ public class EmoteManager
                         out var wasEquipped
                     );
 
-                    WorldObject.DeleteObject(rootOwner);
+                    if (wo?.StackSize > 1)
+                    {
+                        player.TryConsumeFromInventoryWithNetworking(wo, 1);
+                    }
+                    else
+                    {
+                        WorldObject.DeleteObject(rootOwner);
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
- Rather than always deleting an entire stack, force the DeleteSelf emote to remove a single object if an item stack size is greater than one.