### PR TITLE
feat: update some loot gen categories and consolidate stackables

### DIFF
--- a/apps/server/Entity/GeneratorProfile.cs
+++ b/apps/server/Entity/GeneratorProfile.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Numerics;
 using ACE.Common;
 using ACE.Database;
@@ -276,6 +277,36 @@ public class GeneratorProfile
             {
                 Generator.GeneratedTreasureItem = true;
                 GeneratedTreasureItem = true;
+            }
+
+            // Consolidate stackable items
+            var stacksToRemove = new List<WorldObject>();
+            if (objects != null)
+            {
+                foreach (var objectOne in objects.Where(objectOne => objectOne.MaxStackSize > 1 && !stacksToRemove.Contains(objectOne)))
+                {
+                    foreach (var objectTwo in objects)
+                    {
+                        if (objectOne.Guid == objectTwo.Guid || objectOne.WeenieClassId != objectTwo.WeenieClassId || stacksToRemove.Contains(objectTwo))
+                        {
+                            continue;
+                        }
+
+                        var newStack = objectOne.StackSize + objectTwo.StackSize;
+                        objectOne.SetStackSize(newStack);
+
+                        stacksToRemove.Add(objectTwo);
+                        break;
+                    }
+                }
+            }
+
+            foreach (var item in stacksToRemove)
+            {
+                if (objects != null && objects.Contains(item))
+                {
+                    objects.Remove(item);
+                }
             }
         }
         else

--- a/apps/server/Factories/LootGenerationFactory.cs
+++ b/apps/server/Factories/LootGenerationFactory.cs
@@ -2138,17 +2138,8 @@ public static partial class LootGenerationFactory
                     case TreasureWeaponType.Sword:
                         wcid = SwordWcids.Roll(heritage, treasureDeath.Tier, out weaponType);
                         break;
-                    case TreasureWeaponType.Staff:
-                        wcid = StaffWcids.Roll(heritage, treasureDeath.Tier);
-                        break;
-                    case TreasureWeaponType.Atlatl:
-                        wcid = AtlatlWcids.Roll(treasureDeath.Tier, out weaponType);
-                        break; // all thrown weapons
-                    case TreasureWeaponType.Crossbow:
-                        wcid = CrossbowWcids.Roll(treasureDeath.Tier, out weaponType);
-                        break;
-                    case TreasureWeaponType.Bow:
-                        wcid = BowWcids.Roll(heritage, treasureDeath.Tier, out weaponType);
+                    case TreasureWeaponType.Thrown:
+                        wcid = ThrownWcids.Roll(treasureDeath.Tier, out weaponType);
                         break;
                 }
 
@@ -2172,6 +2163,9 @@ public static partial class LootGenerationFactory
                         break;
                     case TreasureWeaponType.Dagger:
                         wcid = DaggerWcids.Roll(heritage, treasureDeath.Tier, out weaponType);
+                        break;
+                    case TreasureWeaponType.Staff:
+                        wcid = StaffWcids.Roll(heritage, treasureDeath.Tier);
                         break;
                     case TreasureWeaponType.Atlatl:
                         wcid = AtlatlWcids.Roll(treasureDeath.Tier, out weaponType);

--- a/apps/server/Factories/Tables/Wcids/Weapons/AtlatlWcids.cs
+++ b/apps/server/Factories/Tables/Wcids/Weapons/AtlatlWcids.cs
@@ -8,44 +8,8 @@ public static class AtlatlWcids
 {
     private static ChanceTable<WeenieClassName> T1_T4_Chances = new ChanceTable<WeenieClassName>(ChanceTableType.Weight)
     {
-        (WeenieClassName.atlatl, 4.0f),
-        (WeenieClassName.atlatlroyal, 4.0f),
-        (WeenieClassName.dart, 4.0f),
-        (WeenieClassName.dartacid, 1.0f),
-        (WeenieClassName.dartflame, 1.0f),
-        (WeenieClassName.dartfrost, 1.0f),
-        (WeenieClassName.dartelectric, 1.0f),
-        (WeenieClassName.axethrowing, 4.0f),
-        (WeenieClassName.axethrowingacid, 1.0f),
-        (WeenieClassName.axethrowingfire, 1.0f),
-        (WeenieClassName.axethrowingfrost, 1.0f),
-        (WeenieClassName.axethrowingelectric, 1.0f),
-        (WeenieClassName.clubthrowing, 4.0f),
-        (WeenieClassName.clubthrowingacid, 1.0f),
-        (WeenieClassName.clubthrowingfire, 1.0f),
-        (WeenieClassName.clubthrowingfrost, 1.0f),
-        (WeenieClassName.clubthrowingelectric, 1.0f),
-        (WeenieClassName.daggerthrowing, 4.0f),
-        (WeenieClassName.daggerthrowingacid, 1.0f),
-        (WeenieClassName.daggerthrowingfire, 1.0f),
-        (WeenieClassName.daggerthrowingfrost, 1.0f),
-        (WeenieClassName.daggerthrowingelectric, 1.0f),
-        (WeenieClassName.javelin, 4.0f),
-        (WeenieClassName.javelinacid, 1.0f),
-        (WeenieClassName.javelinfire, 1.0f),
-        (WeenieClassName.javelinfrost, 1.0f),
-        (WeenieClassName.javelinelectric, 1.0f),
-        (WeenieClassName.shuriken, 4.0f),
-        (WeenieClassName.shurikenacid, 1.0f),
-        (WeenieClassName.shurikenfire, 1.0f),
-        (WeenieClassName.shurikenfrost, 1.0f),
-        (WeenieClassName.shurikenelectric, 1.0f),
-
-        //( WeenieClassName.djarid,                    4.0f ),
-        //( WeenieClassName.djaridacid,                1.0f ),
-        //( WeenieClassName.djaridfire,                1.0f ),
-        //( WeenieClassName.djaridfrost,               1.0f ),
-        //( WeenieClassName.djaridelectric,            1.0f ),
+        (WeenieClassName.atlatl, 1.0f),
+        (WeenieClassName.atlatlroyal, 1.0f)
     };
 
     private static ChanceTable<WeenieClassName> T5_Chances = new ChanceTable<WeenieClassName>(ChanceTableType.Weight)
@@ -58,43 +22,7 @@ public static class AtlatlWcids
         (WeenieClassName.atlatlacid, 1.0f),
         (WeenieClassName.atlatlfire, 1.0f),
         (WeenieClassName.atlatlfrost, 1.0f),
-        (WeenieClassName.atlatlelectric, 1.0f),
-        (WeenieClassName.dart, 4.0f),
-        (WeenieClassName.dartacid, 1.0f),
-        (WeenieClassName.dartflame, 1.0f),
-        (WeenieClassName.dartfrost, 1.0f),
-        (WeenieClassName.dartelectric, 1.0f),
-        (WeenieClassName.axethrowing, 4.0f),
-        (WeenieClassName.axethrowingacid, 1.0f),
-        (WeenieClassName.axethrowingfire, 1.0f),
-        (WeenieClassName.axethrowingfrost, 1.0f),
-        (WeenieClassName.axethrowingelectric, 1.0f),
-        (WeenieClassName.clubthrowing, 4.0f),
-        (WeenieClassName.clubthrowingacid, 1.0f),
-        (WeenieClassName.clubthrowingfire, 1.0f),
-        (WeenieClassName.clubthrowingfrost, 1.0f),
-        (WeenieClassName.clubthrowingelectric, 1.0f),
-        (WeenieClassName.daggerthrowing, 4.0f),
-        (WeenieClassName.daggerthrowingacid, 1.0f),
-        (WeenieClassName.daggerthrowingfire, 1.0f),
-        (WeenieClassName.daggerthrowingfrost, 1.0f),
-        (WeenieClassName.daggerthrowingelectric, 1.0f),
-        (WeenieClassName.javelin, 4.0f),
-        (WeenieClassName.javelinacid, 1.0f),
-        (WeenieClassName.javelinfire, 1.0f),
-        (WeenieClassName.javelinfrost, 1.0f),
-        (WeenieClassName.javelinelectric, 1.0f),
-        (WeenieClassName.shuriken, 4.0f),
-        (WeenieClassName.shurikenacid, 1.0f),
-        (WeenieClassName.shurikenfire, 1.0f),
-        (WeenieClassName.shurikenfrost, 1.0f),
-        (WeenieClassName.shurikenelectric, 1.0f),
-
-        //( WeenieClassName.djarid,                     4.0f ),
-        //( WeenieClassName.djaridacid,                  1.0f ),
-        //( WeenieClassName.djaridfire,                  1.0f ),
-        //( WeenieClassName.djaridfrost,                 1.0f ),
-        //( WeenieClassName.djaridelectric,              1.0f ),
+        (WeenieClassName.atlatlelectric, 1.0f)
     };
 
     private static ChanceTable<WeenieClassName> T6_T8_Chances = new ChanceTable<WeenieClassName>(ChanceTableType.Weight)
@@ -105,43 +33,7 @@ public static class AtlatlWcids
         (WeenieClassName.atlatlacid, 1.0f),
         (WeenieClassName.atlatlfire, 1.0f),
         (WeenieClassName.atlatlfrost, 1.0f),
-        (WeenieClassName.atlatlelectric, 1.0f),
-        (WeenieClassName.dart, 1.0f),
-        (WeenieClassName.dartacid, 1.0f),
-        (WeenieClassName.dartflame, 1.0f),
-        (WeenieClassName.dartfrost, 1.0f),
-        (WeenieClassName.dartelectric, 1.0f),
-        (WeenieClassName.axethrowing, 1.0f),
-        (WeenieClassName.axethrowingacid, 1.0f),
-        (WeenieClassName.axethrowingfire, 1.0f),
-        (WeenieClassName.axethrowingfrost, 1.0f),
-        (WeenieClassName.axethrowingelectric, 1.0f),
-        (WeenieClassName.clubthrowing, 1.0f),
-        (WeenieClassName.clubthrowingacid, 1.0f),
-        (WeenieClassName.clubthrowingfire, 1.0f),
-        (WeenieClassName.clubthrowingfrost, 1.0f),
-        (WeenieClassName.clubthrowingelectric, 1.0f),
-        (WeenieClassName.daggerthrowing, 1.0f),
-        (WeenieClassName.daggerthrowingacid, 1.0f),
-        (WeenieClassName.daggerthrowingfire, 1.0f),
-        (WeenieClassName.daggerthrowingfrost, 1.0f),
-        (WeenieClassName.daggerthrowingelectric, 1.0f),
-        (WeenieClassName.javelin, 1.0f),
-        (WeenieClassName.javelinacid, 1.0f),
-        (WeenieClassName.javelinfire, 1.0f),
-        (WeenieClassName.javelinfrost, 1.0f),
-        (WeenieClassName.javelinelectric, 1.0f),
-        (WeenieClassName.shuriken, 1.0f),
-        (WeenieClassName.shurikenacid, 1.0f),
-        (WeenieClassName.shurikenfire, 1.0f),
-        (WeenieClassName.shurikenfrost, 1.0f),
-        (WeenieClassName.shurikenelectric, 1.0f),
-
-        //( WeenieClassName.djarid,                     1.0f ),
-        //( WeenieClassName.djaridacid,                 1.0f ),
-        //( WeenieClassName.djaridfire,                 1.0f ),
-        //( WeenieClassName.djaridfrost,                1.0f ),
-        //( WeenieClassName.djaridelectric,             1.0f ),
+        (WeenieClassName.atlatlelectric, 1.0f)
     };
 
     private static readonly List<ChanceTable<WeenieClassName>> atlatlTiers = new List<ChanceTable<WeenieClassName>>()
@@ -162,45 +54,8 @@ public static class AtlatlWcids
 
         switch (roll) // Modify weapon type so we get correct mutations.
         {
-            case WeenieClassName.dart:
-            case WeenieClassName.dartacid:
-            case WeenieClassName.dartflame:
-            case WeenieClassName.dartfrost:
-            case WeenieClassName.dartelectric:
-            case WeenieClassName.axethrowing:
-            case WeenieClassName.axethrowingacid:
-            case WeenieClassName.axethrowingfire:
-            case WeenieClassName.axethrowingfrost:
-            case WeenieClassName.axethrowingelectric:
-            case WeenieClassName.clubthrowing:
-            case WeenieClassName.clubthrowingacid:
-            case WeenieClassName.clubthrowingfire:
-            case WeenieClassName.clubthrowingfrost:
-            case WeenieClassName.clubthrowingelectric:
-            case WeenieClassName.daggerthrowing:
-            case WeenieClassName.daggerthrowingacid:
-            case WeenieClassName.daggerthrowingfire:
-            case WeenieClassName.daggerthrowingfrost:
-            case WeenieClassName.daggerthrowingelectric:
-            case WeenieClassName.javelin:
-            case WeenieClassName.javelinacid:
-            case WeenieClassName.javelinfire:
-            case WeenieClassName.javelinfrost:
-            case WeenieClassName.javelinelectric:
-            case WeenieClassName.shuriken:
-            case WeenieClassName.shurikenacid:
-            case WeenieClassName.shurikenfire:
-            case WeenieClassName.shurikenfrost:
-            case WeenieClassName.shurikenelectric:
-            case WeenieClassName.djarid:
-            case WeenieClassName.djaridacid:
-            case WeenieClassName.djaridfire:
-            case WeenieClassName.djaridfrost:
-            case WeenieClassName.djaridelectric:
-                weaponType = TreasureWeaponType.Thrown;
-                break;
             case WeenieClassName.atlatl:
-                weaponType = TreasureWeaponType.AtlatlRegular;
+                weaponType = TreasureWeaponType.Atlatl;
                 break;
             default:
                 weaponType = TreasureWeaponType.Atlatl;

--- a/apps/server/Factories/Tables/Wcids/Weapons/ThrownWcids.cs
+++ b/apps/server/Factories/Tables/Wcids/Weapons/ThrownWcids.cs
@@ -1,0 +1,210 @@
+﻿using System.Collections.Generic;
+using ACE.Server.Factories.Entity;
+using ACE.Server.Factories.Enum;
+
+namespace ACE.Server.Factories.Tables.Wcids.Weapons;
+
+public static class ThrownWcids
+{
+    private static ChanceTable<WeenieClassName> T1_T4_Chances = new ChanceTable<WeenieClassName>(ChanceTableType.Weight)
+    {
+        (WeenieClassName.dart, 4.0f),
+        (WeenieClassName.dartacid, 1.0f),
+        (WeenieClassName.dartflame, 1.0f),
+        (WeenieClassName.dartfrost, 1.0f),
+        (WeenieClassName.dartelectric, 1.0f),
+        (WeenieClassName.axethrowing, 4.0f),
+        (WeenieClassName.axethrowingacid, 1.0f),
+        (WeenieClassName.axethrowingfire, 1.0f),
+        (WeenieClassName.axethrowingfrost, 1.0f),
+        (WeenieClassName.axethrowingelectric, 1.0f),
+        (WeenieClassName.clubthrowing, 4.0f),
+        (WeenieClassName.clubthrowingacid, 1.0f),
+        (WeenieClassName.clubthrowingfire, 1.0f),
+        (WeenieClassName.clubthrowingfrost, 1.0f),
+        (WeenieClassName.clubthrowingelectric, 1.0f),
+        (WeenieClassName.daggerthrowing, 4.0f),
+        (WeenieClassName.daggerthrowingacid, 1.0f),
+        (WeenieClassName.daggerthrowingfire, 1.0f),
+        (WeenieClassName.daggerthrowingfrost, 1.0f),
+        (WeenieClassName.daggerthrowingelectric, 1.0f),
+        (WeenieClassName.javelin, 4.0f),
+        (WeenieClassName.javelinacid, 1.0f),
+        (WeenieClassName.javelinfire, 1.0f),
+        (WeenieClassName.javelinfrost, 1.0f),
+        (WeenieClassName.javelinelectric, 1.0f),
+        (WeenieClassName.shuriken, 4.0f),
+        (WeenieClassName.shurikenacid, 1.0f),
+        (WeenieClassName.shurikenfire, 1.0f),
+        (WeenieClassName.shurikenfrost, 1.0f),
+        (WeenieClassName.shurikenelectric, 1.0f),
+
+        //( WeenieClassName.djarid,                    4.0f ),
+        //( WeenieClassName.djaridacid,                1.0f ),
+        //( WeenieClassName.djaridfire,                1.0f ),
+        //( WeenieClassName.djaridfrost,               1.0f ),
+        //( WeenieClassName.djaridelectric,            1.0f ),
+    };
+
+    private static ChanceTable<WeenieClassName> T5_Chances = new ChanceTable<WeenieClassName>(ChanceTableType.Weight)
+    {
+        (WeenieClassName.dart, 4.0f),
+        (WeenieClassName.dartacid, 1.0f),
+        (WeenieClassName.dartflame, 1.0f),
+        (WeenieClassName.dartfrost, 1.0f),
+        (WeenieClassName.dartelectric, 1.0f),
+        (WeenieClassName.axethrowing, 4.0f),
+        (WeenieClassName.axethrowingacid, 1.0f),
+        (WeenieClassName.axethrowingfire, 1.0f),
+        (WeenieClassName.axethrowingfrost, 1.0f),
+        (WeenieClassName.axethrowingelectric, 1.0f),
+        (WeenieClassName.clubthrowing, 4.0f),
+        (WeenieClassName.clubthrowingacid, 1.0f),
+        (WeenieClassName.clubthrowingfire, 1.0f),
+        (WeenieClassName.clubthrowingfrost, 1.0f),
+        (WeenieClassName.clubthrowingelectric, 1.0f),
+        (WeenieClassName.daggerthrowing, 4.0f),
+        (WeenieClassName.daggerthrowingacid, 1.0f),
+        (WeenieClassName.daggerthrowingfire, 1.0f),
+        (WeenieClassName.daggerthrowingfrost, 1.0f),
+        (WeenieClassName.daggerthrowingelectric, 1.0f),
+        (WeenieClassName.javelin, 4.0f),
+        (WeenieClassName.javelinacid, 1.0f),
+        (WeenieClassName.javelinfire, 1.0f),
+        (WeenieClassName.javelinfrost, 1.0f),
+        (WeenieClassName.javelinelectric, 1.0f),
+        (WeenieClassName.shuriken, 4.0f),
+        (WeenieClassName.shurikenacid, 1.0f),
+        (WeenieClassName.shurikenfire, 1.0f),
+        (WeenieClassName.shurikenfrost, 1.0f),
+        (WeenieClassName.shurikenelectric, 1.0f),
+
+        //( WeenieClassName.djarid,                     4.0f ),
+        //( WeenieClassName.djaridacid,                  1.0f ),
+        //( WeenieClassName.djaridfire,                  1.0f ),
+        //( WeenieClassName.djaridfrost,                 1.0f ),
+        //( WeenieClassName.djaridelectric,              1.0f ),
+    };
+
+    private static ChanceTable<WeenieClassName> T6_T8_Chances = new ChanceTable<WeenieClassName>(ChanceTableType.Weight)
+    {
+        (WeenieClassName.dart, 1.0f),
+        (WeenieClassName.dartacid, 1.0f),
+        (WeenieClassName.dartflame, 1.0f),
+        (WeenieClassName.dartfrost, 1.0f),
+        (WeenieClassName.dartelectric, 1.0f),
+        (WeenieClassName.axethrowing, 1.0f),
+        (WeenieClassName.axethrowingacid, 1.0f),
+        (WeenieClassName.axethrowingfire, 1.0f),
+        (WeenieClassName.axethrowingfrost, 1.0f),
+        (WeenieClassName.axethrowingelectric, 1.0f),
+        (WeenieClassName.clubthrowing, 1.0f),
+        (WeenieClassName.clubthrowingacid, 1.0f),
+        (WeenieClassName.clubthrowingfire, 1.0f),
+        (WeenieClassName.clubthrowingfrost, 1.0f),
+        (WeenieClassName.clubthrowingelectric, 1.0f),
+        (WeenieClassName.daggerthrowing, 1.0f),
+        (WeenieClassName.daggerthrowingacid, 1.0f),
+        (WeenieClassName.daggerthrowingfire, 1.0f),
+        (WeenieClassName.daggerthrowingfrost, 1.0f),
+        (WeenieClassName.daggerthrowingelectric, 1.0f),
+        (WeenieClassName.javelin, 1.0f),
+        (WeenieClassName.javelinacid, 1.0f),
+        (WeenieClassName.javelinfire, 1.0f),
+        (WeenieClassName.javelinfrost, 1.0f),
+        (WeenieClassName.javelinelectric, 1.0f),
+        (WeenieClassName.shuriken, 1.0f),
+        (WeenieClassName.shurikenacid, 1.0f),
+        (WeenieClassName.shurikenfire, 1.0f),
+        (WeenieClassName.shurikenfrost, 1.0f),
+        (WeenieClassName.shurikenelectric, 1.0f),
+
+        //( WeenieClassName.djarid,                     1.0f ),
+        //( WeenieClassName.djaridacid,                 1.0f ),
+        //( WeenieClassName.djaridfire,                 1.0f ),
+        //( WeenieClassName.djaridfrost,                1.0f ),
+        //( WeenieClassName.djaridelectric,             1.0f ),
+    };
+
+    private static readonly List<ChanceTable<WeenieClassName>> atlatlTiers = new List<ChanceTable<WeenieClassName>>()
+    {
+        T1_T4_Chances,
+        T1_T4_Chances,
+        T1_T4_Chances,
+        T1_T4_Chances,
+        T5_Chances,
+        T6_T8_Chances,
+        T6_T8_Chances,
+        T6_T8_Chances,
+    };
+
+    public static WeenieClassName Roll(int tier, out TreasureWeaponType weaponType)
+    {
+        var roll = atlatlTiers[tier - 1].Roll();
+
+        switch (roll) // Modify weapon type so we get correct mutations.
+        {
+            case WeenieClassName.dart:
+            case WeenieClassName.dartacid:
+            case WeenieClassName.dartflame:
+            case WeenieClassName.dartfrost:
+            case WeenieClassName.dartelectric:
+            case WeenieClassName.axethrowing:
+            case WeenieClassName.axethrowingacid:
+            case WeenieClassName.axethrowingfire:
+            case WeenieClassName.axethrowingfrost:
+            case WeenieClassName.axethrowingelectric:
+            case WeenieClassName.clubthrowing:
+            case WeenieClassName.clubthrowingacid:
+            case WeenieClassName.clubthrowingfire:
+            case WeenieClassName.clubthrowingfrost:
+            case WeenieClassName.clubthrowingelectric:
+            case WeenieClassName.daggerthrowing:
+            case WeenieClassName.daggerthrowingacid:
+            case WeenieClassName.daggerthrowingfire:
+            case WeenieClassName.daggerthrowingfrost:
+            case WeenieClassName.daggerthrowingelectric:
+            case WeenieClassName.javelin:
+            case WeenieClassName.javelinacid:
+            case WeenieClassName.javelinfire:
+            case WeenieClassName.javelinfrost:
+            case WeenieClassName.javelinelectric:
+            case WeenieClassName.shuriken:
+            case WeenieClassName.shurikenacid:
+            case WeenieClassName.shurikenfire:
+            case WeenieClassName.shurikenfrost:
+            case WeenieClassName.shurikenelectric:
+            case WeenieClassName.djarid:
+            case WeenieClassName.djaridacid:
+            case WeenieClassName.djaridfire:
+            case WeenieClassName.djaridfrost:
+            case WeenieClassName.djaridelectric:
+                weaponType = TreasureWeaponType.Thrown;
+                break;
+            default:
+                weaponType = TreasureWeaponType.Thrown;
+                break;
+        }
+
+        return roll;
+    }
+
+    private static readonly Dictionary<WeenieClassName, TreasureWeaponType> _combined =
+        new Dictionary<WeenieClassName, TreasureWeaponType>();
+
+    static ThrownWcids()
+    {
+        foreach (var atlatlTier in atlatlTiers)
+        {
+            foreach (var entry in atlatlTier)
+            {
+                _combined.TryAdd(entry.result, TreasureWeaponType.Atlatl);
+            }
+        }
+    }
+
+    public static bool TryGetValue(WeenieClassName wcid, out TreasureWeaponType weaponType)
+    {
+        return _combined.TryGetValue(wcid, out weaponType);
+    }
+}

--- a/apps/server/Factories/Tables/WeaponTypeChance.cs
+++ b/apps/server/Factories/Tables/WeaponTypeChance.cs
@@ -48,25 +48,22 @@ public static class WeaponTypeChance
         (TreasureWeaponType.Atlatl, 0.33f),
     };
 
-    private static ChanceTable<TreasureWeaponType> WarriorChances = new ChanceTable<TreasureWeaponType>()
+    private static ChanceTable<TreasureWeaponType> WarriorChances = new ChanceTable<TreasureWeaponType>(ChanceTableType.Weight)
     {
-        (TreasureWeaponType.Sword, 0.125f),
-        (TreasureWeaponType.Mace, 0.125f),
-        (TreasureWeaponType.Axe, 0.125f),
-        (TreasureWeaponType.Spear, 0.125f),
-        (TreasureWeaponType.Staff, 0.125f),
-        (TreasureWeaponType.Atlatl, 0.125f),
-        (TreasureWeaponType.Bow, 0.125f),
-        (TreasureWeaponType.Crossbow, 0.125f),
+        (TreasureWeaponType.Sword, 1.0f),
+        (TreasureWeaponType.Mace, 1.0f),
+        (TreasureWeaponType.Axe, 1.0f),
+        (TreasureWeaponType.Spear, 1.0f),
     };
 
-    private static ChanceTable<TreasureWeaponType> RogueChances = new ChanceTable<TreasureWeaponType>()
+    private static ChanceTable<TreasureWeaponType> RogueChances = new ChanceTable<TreasureWeaponType>(ChanceTableType.Weight)
     {
-        (TreasureWeaponType.Unarmed, 0.35f),
-        (TreasureWeaponType.Dagger, 0.35f),
-        (TreasureWeaponType.Atlatl, 0.1f),
-        (TreasureWeaponType.Bow, 0.1f),
-        (TreasureWeaponType.Crossbow, 0.1f),
+        (TreasureWeaponType.Unarmed, 1.0f),
+        (TreasureWeaponType.Dagger, 1.0f),
+        (TreasureWeaponType.Staff, 1.0f),
+        (TreasureWeaponType.Atlatl, 1.0f),
+        (TreasureWeaponType.Bow, 1.0f),
+        (TreasureWeaponType.Crossbow, 1.0f),
     };
 
     public static TreasureWeaponType Roll(int tier, TreasureWeaponType filterToType = TreasureWeaponType.Undef)


### PR DESCRIPTION
- Warrior Profiles: remove bow/crossbow/ataltl/staff, add thrown.
- Rogue Profiles: remove thrown, add staff.
- In chest loot, consolidate all stackable items of the same WCID.