### PR TITLE
feat: improve menhir mana field interactions

### DIFF
--- a/apps/server/WorldObjects/Creature_Equipment.cs
+++ b/apps/server/WorldObjects/Creature_Equipment.cs
@@ -264,6 +264,21 @@ partial class Creature
         return equippedEmpoweredScarabs;
     }
 
+    public EmpoweredScarab GetEquippedEmpoweredScarabOfType(EmpoweredScarabColor empoweredScarabColor)
+    {
+        var equippedEmpoweredScarabs = GetEquippedEmpoweredScarabs();
+
+        foreach (var empoweredScarab in equippedEmpoweredScarabs.ToList())
+        {
+            if (empoweredScarab?.EmpoweredScarabColor != null && empoweredScarab.EmpoweredScarabColor == (int)empoweredScarabColor)
+            {
+                return empoweredScarab;
+            }
+        }
+
+        return null;
+    }
+
     public List<EmpoweredScarab> GetHeldEmpoweredScarabsBlue()
     {
         uint empoweredScarabBlue_Life_wcid = 1050250;

--- a/apps/server/WorldObjects/EmpoweredScarab.cs
+++ b/apps/server/WorldObjects/EmpoweredScarab.cs
@@ -365,11 +365,7 @@ public class EmpoweredScarab : WorldObject
             return;
         }
 
-        var forwardCommand =
-            playerWielder.CurrentMovementData.MovementType == MovementType.Invalid
-            && playerWielder.CurrentMovementData.Invalid != null
-                ? playerWielder.CurrentMovementData.Invalid.State.ForwardCommand
-                : MotionCommand.Invalid;
+        var forwardCommand = playerWielder.CurrentMotionState.MotionState.ForwardCommand;
         if (forwardCommand != MotionCommand.MeditateState)
         {
             return;
@@ -401,6 +397,9 @@ public class EmpoweredScarab : WorldObject
     public void SetScarabBonus(int bonusStat, int amount)
     {
         ResetScarabBonus();
+
+        EmpoweredScarabBonusStat = bonusStat;
+        EmpoweredScarabBonusStatAmount = amount;
 
         switch (bonusStat)
         {

--- a/apps/server/WorldObjects/Managers/ConfirmationManager.cs
+++ b/apps/server/WorldObjects/Managers/ConfirmationManager.cs
@@ -17,7 +17,7 @@ public class ConfirmationManager
 
     private readonly ILogger _log = Log.ForContext<ConfirmationManager>();
 
-    private const double confirmationTimeout = 30;
+    private const double confirmationTimeout = 60;
 
     private UIntSequence contextSequence = new UIntSequence();
 

--- a/apps/server/WorldObjects/Managers/EmoteManager.cs
+++ b/apps/server/WorldObjects/Managers/EmoteManager.cs
@@ -1339,7 +1339,14 @@ public class EmoteManager
 
                 var motionCommand = MotionCommandHelper.GetMotion(emote.Motion.Value);
                 var motion = new Motion(targetObject, motionCommand, emote.Extent);
-                targetObject.EnqueueBroadcastMotion(motion);
+                if (player != null)
+                {
+                    player.ExecuteMotion(motion);
+                }
+                else
+                {
+                    targetObject.EnqueueBroadcastMotion(motion);
+                }
                 break;
 
             /* plays an animation on the source object */


### PR DESCRIPTION
- Upon entering a mana field hot spot, server checks if there are any equipped/held mana scarabs that can be recharged or altered.
   - If there are, a confirmation box will appear, describing the effects of the current menhir ring. Selecting 'Yes' will force the player into a mediation emote and begin charging scarabs.
   - If there aren't, a transient error message will appear notifying the player that they do not have any scarabs that can interact with the menhir ring at the moment.