### PR TITLE
fix: banking improvements

### DIFF
--- a/apps/server/WorldObjects/Player_Inventory_Banking.cs
+++ b/apps/server/WorldObjects/Player_Inventory_Banking.cs
@@ -381,8 +381,8 @@ public partial class Player
                         "(BANKING - SPLIT from BANK-MAIN to BANK-SIDE )\n PLAYER: {@Player}\n SPLIT STACK: {@Stack}\n FROM CONTAINER: {@PrevContainer}\n TO NEW STACK: {@NewStack}\n IN CONTAINER: {@NewContainer}",
                         bankLogPlayer,
                         bankLogSourceStack,
-                        bankLogNewStack,
                         bankLogSourceContainer,
+                        bankLogNewStack,
                         bankLogTargetContainer
                     );
                 }
@@ -393,8 +393,8 @@ public partial class Player
                         "(BANKING - SPLIT from BANK-MAIN to PLAYER )\n PLAYER: {@Player}\n SPLIT STACK: {@Stack}\n FROM CONTAINER: {@PrevContainer}\n TO NEW STACK: {@NewStack}\n IN CONTAINER: {@NewContainer}",
                         bankLogPlayer,
                         bankLogSourceStack,
-                        bankLogNewStack,
                         bankLogSourceContainer,
+                        bankLogNewStack,
                         bankLogTargetContainer
                     );
                 }
@@ -437,8 +437,8 @@ public partial class Player
                     "(BANKING - Split from PLAYER to BANK-SIDE)\n PLAYER: {@Player}\n SPLIT STACK: {@Stack}\n FROM CONTAINER: {@PrevContainer}\n TO NEW STACK: {@NewStack}\n IN CONTAINER: {@NewContainer}",
                     bankLogPlayer,
                     bankLogSourceStack,
-                    bankLogNewStack,
                     bankLogSourceContainer,
+                    bankLogNewStack,
                     bankLogTargetContainer
                 );
             }
@@ -453,8 +453,8 @@ public partial class Player
                     "(BANKING - Split from BANK-SIDE to PLAYER)\n PLAYER: {@Player}\n SPLIT STACK: {@Stack}\n FROM CONTAINER: {@PrevContainer}\n TO NEW STACK: {@NewStack}\n IN CONTAINER: {@NewContainer}",
                     bankLogPlayer,
                     bankLogSourceStack,
-                    bankLogNewStack,
                     bankLogSourceContainer,
+                    bankLogNewStack,
                     bankLogTargetContainer
                 );
             }
@@ -470,8 +470,8 @@ public partial class Player
                     "(BANKING - Split from BANK-SIDE to BANK-SIDE)\n PLAYER: {@Player}\n SPLIT STACK: {@Stack}\n FROM CONTAINER: {@PrevContainer}\n TO NEW STACK: {@NewStack}\n IN CONTAINER: {@NewContainer}",
                     bankLogPlayer,
                     bankLogSourceStack,
-                    bankLogNewStack,
                     bankLogSourceContainer,
+                    bankLogNewStack,
                     bankLogTargetContainer
                 );
             }

--- a/apps/server/WorldObjects/Player_Tracking.cs
+++ b/apps/server/WorldObjects/Player_Tracking.cs
@@ -132,6 +132,11 @@ partial class Player
                 RemoveTrackedEquippedObject(creature, wieldedItem);
             }
         }
+
+        if (wo is Storage storage)
+        {
+            storage.OnDestroy();
+        }
     }
 
     public void TrackEquippedObject(Creature wielder, WorldObject wieldedItem)

--- a/apps/server/WorldObjects/Storage.cs
+++ b/apps/server/WorldObjects/Storage.cs
@@ -36,6 +36,11 @@ public class Storage : Container
         SetEphemeralValues();
     }
 
+    public void OnDestroy()
+    {
+        BankChests.Remove(this);
+    }
+
     private void SetEphemeralValues()
     {
         SetProperty(PropertyInt.ShowableOnRadar, 1);
@@ -45,6 +50,8 @@ public class Storage : Container
         IsOpen = false;
 
         BumpVelocity = true;
+
+        Translucency = 0F;
 
         BankChests.Add(this);
     }

--- a/apps/server/WorldObjects/WorldObject.cs
+++ b/apps/server/WorldObjects/WorldObject.cs
@@ -1028,6 +1028,11 @@ public abstract partial class WorldObject : IActor
             {
                 item.Destroy();
             }
+
+            if (this is Storage storage)
+            {
+                storage.OnDestroy();
+            }
         }
 
         if (this is Creature creature)


### PR DESCRIPTION
- Remove BankChests from the bank list when a bank is unloaded from a landblock.
- Ensure golem translucency is always visible when generated.
- Fix various bank log formats.