### PR TITLE
feat: remove starter guide books

### DIFF
--- a/apps/server/starterGear.json
+++ b/apps/server/starterGear.json
@@ -74,16 +74,6 @@
           "stacksize": "1"
         },
         {
-          "weenieId": "1050900",
-          "name": "CombatGuide",
-          "stacksize": "1"
-        },
-        {
-          "weenieId": "1050902",
-          "name": "MagicGuide",
-          "stacksize": "1"
-        },
-        {
           "weenieId": "151",
           "name": "Empty Flask",
           "stacksize": "10"


### PR DESCRIPTION
Potentially will be reintroduced when revised. Or come up with a better way to explain new mechanics in-game.