### PR TITLE
Revise xp rules

### DIFF
--- a/apps/server/WorldObjects/Creature_Death.cs
+++ b/apps/server/WorldObjects/Creature_Death.cs
@@ -274,7 +274,7 @@ partial class Creature
 
             var killXpMod = KillXpMod ?? 1.0;
 
-            var totalXP = GetCreatureDeathXP(Level ?? 0, Tier ?? 1) * damagePercent * (float)killXpMod;
+            var totalXp = GetCreatureDeathXP(Level ?? 0, playerDamager.Level ?? 1) * damagePercent * (float)killXpMod;
 
             if (BossKillXpReward == true)
             {
@@ -320,7 +320,7 @@ partial class Creature
             }
             else
             {
-                playerDamager.EarnXP((long)Math.Round(totalXP), XpType.Kill, Level, ShareType.All, WeenieClassId);
+                playerDamager.EarnXP((long)Math.Round(totalXp), XpType.Kill, Level, ShareType.All, WeenieClassId);
             }
 
             // handle luminance
@@ -332,49 +332,41 @@ partial class Creature
         }
     }
 
-    public static int GetCreatureDeathXP(int level, int tier = 1)
+    public static int GetCreatureDeathXP(int creatureLevel, int killerLevel = 1)
     {
         var baseXp = 0.0;
 
         ulong levelTotalXP;
 
-        if (level <= 125)
-        {
-            levelTotalXP =
-                DatManager.PortalDat.XpTable.CharacterLevelXPList[level + 1]
-                - DatManager.PortalDat.XpTable.CharacterLevelXPList[level];
-        }
-        else
-        {
-            levelTotalXP =
-                DatManager.PortalDat.XpTable.CharacterLevelXPList[126]
-                - DatManager.PortalDat.XpTable.CharacterLevelXPList[125];
-        }
+        creatureLevel = Math.Clamp(creatureLevel, 1, 125);
 
-        switch (tier)
+        levelTotalXP = DatManager.PortalDat.XpTable.CharacterLevelXPList[creatureLevel + 1]
+                       - DatManager.PortalDat.XpTable.CharacterLevelXPList[creatureLevel];
+
+        switch (killerLevel)
         {
-            case 1:
+            case < 10:
                 baseXp = levelTotalXP * 0.05f;
                 break;
-            case 2:
+            case < 20:
                 baseXp = levelTotalXP * 0.01f;
                 break;
-            case 3:
+            case < 30:
                 baseXp = levelTotalXP * 0.005f;
                 break;
-            case 4:
+            case < 40:
                 baseXp = levelTotalXP * 0.004f;
                 break;
-            case 5:
+            case < 50:
                 baseXp = levelTotalXP * 0.003f;
                 break;
-            case 6:
+            case < 75:
                 baseXp = levelTotalXP * 0.002f;
                 break;
-            case 7:
+            case < 100:
                 baseXp = levelTotalXP * 0.001f;
                 break;
-            case 8:
+            default:
                 baseXp = levelTotalXP * 0.0005f;
                 break;
         }

--- a/apps/server/WorldObjects/Player_Xp.cs
+++ b/apps/server/WorldObjects/Player_Xp.cs
@@ -184,14 +184,14 @@ partial class Player
         if (xpType == XpType.Kill)
         {
             // Gain full xp for creatures up to 5 levels higher than the player. Above that, the same xp as a creature 5 levels higher.
-            if (Level != null)
-            {
-                var softlevelCap = PropertyManager.GetLong("soft_level_cap").Item;
-                var maxFullXpKillLevel = Math.Min(Level.Value + 5, (int)softlevelCap);
-                var maxXpPerKill = (long)GetCreatureDeathXP(maxFullXpKillLevel, maxFullXpKillLevel);
-
-                m_amount = Math.Min(m_amount, maxXpPerKill);
-            }
+            // if (Level != null)
+            // {
+            //     var softlevelCap = PropertyManager.GetLong("soft_level_cap").Item;
+            //     var maxFullXpKillLevel = Math.Min(Level.Value + 5, (int)softlevelCap);
+            //     var maxXpPerKill = (long)GetCreatureDeathXP(maxFullXpKillLevel, maxFullXpKillLevel);
+            //
+            //     m_amount = Math.Min(m_amount, maxXpPerKill);
+            // }
         }
 
         // Max possible quest xp gained is equal to 50% of your current level cost (200% of current level cost if under level 10)


### PR DESCRIPTION
- Disable "Maximum xp per kill" rule. (may need to re-enable if power-leveling is too abusable)
- Adjust "Over-level Penalties":
   - Allow it to apply to quests as well, if quest has a 'source level' set. (not set on any quests atm)
   - Increase the penalty when a player has reached the 'soft_level_cap', from 10% to 50% per level difference.
- Reword some variables and add some null reference checks.