### PR TITLE
feat: add Might and Aggression sigil trinkets

### DIFF
--- a/apps/server/Factories/LootGenerationFactory_SigilTrinket.cs
+++ b/apps/server/Factories/LootGenerationFactory_SigilTrinket.cs
@@ -16,7 +16,7 @@ public static partial class LootGenerationFactory
         {
             { "black", 100690601 }, // black
             { "gray", 100690594 },
-            { "olive", 100690619 }, // brown
+            { "olive", 100690602 }, // brown
             { "white", 100690596 }, // white
             { "purple", 100690600 }, // purple
             { "blue", 100690595 }, // blue
@@ -511,6 +511,19 @@ public static partial class LootGenerationFactory
     {
         switch (sigilTrinket.SigilTrinketEffectId)
         {
+            case (int)SigilTrinketShieldEffect.Might:
+                sigilTrinket.PaletteTemplate = PaletteTemplateColors["red"];
+                sigilTrinket.IconId = IconColorIds[(int)SigilTrinketType.Compass]["red"];
+
+                sigilTrinket.SigilTrinketIntensity = GetIntensity(profile);
+
+                sigilTrinket.Name += " of Might";
+
+                var wieldReq = GetWieldDifficultyPerTier((sigilTrinket.SigilTrinketMaxTier ?? 1) + 1);
+                sigilTrinket.Use =
+                    $"Whenever the wielder attacks a creature with more than 50% power, there is a chance that a normal hit will be converted into a critical hit.\n\n" +
+                    $"Can only occur while using a shield, with a wield requirement of up to {wieldReq}.";
+                break;
             case (int)SigilTrinketShieldEffect.Aggression:
                 sigilTrinket.PaletteTemplate = PaletteTemplateColors["olive"];
                 sigilTrinket.IconId = IconColorIds[(int)SigilTrinketType.Compass]["olive"];
@@ -519,41 +532,31 @@ public static partial class LootGenerationFactory
 
                 sigilTrinket.Name += " of Aggression";
 
-                var wieldReq = GetWieldDifficultyPerTier((sigilTrinket.SigilTrinketMaxTier ?? 1) + 1);
+                wieldReq = GetWieldDifficultyPerTier((sigilTrinket.SigilTrinketMaxTier ?? 1) + 1);
                 sigilTrinket.Use =
                     $"Whenever the wielder performs an attack on an enemy, they have a chance to generate increased threat towards that enemy.\n\n"
                     + $"Can only occur while using a shield, with a wield requirement of up to {wieldReq}.";
                 break;
-            case (int)SigilTrinketShieldEffect.PH2:
-                sigilTrinket.PaletteTemplate = PaletteTemplateColors["blue"];
-                sigilTrinket.IconId = IconColorIds[(int)SigilTrinketType.Compass]["blue"];
-
-                sigilTrinket.SigilTrinketIntensity = GetIntensity(profile);
-
-                sigilTrinket.Name += " of PH2";
-                sigilTrinket.Use =
-                    $"(PH)";
-                break;
-            case (int)SigilTrinketShieldEffect.PH3:
-                sigilTrinket.PaletteTemplate = PaletteTemplateColors["green"];
-                sigilTrinket.IconId = IconColorIds[(int)SigilTrinketType.Compass]["green"];
-
-                sigilTrinket.SigilTrinketIntensity = GetIntensity(profile);
-
-                sigilTrinket.Name += " of PH3";
-                sigilTrinket.Use =
-                    $"(PH)";
-                break;
-            case (int)SigilTrinketShieldEffect.PH4:
-                sigilTrinket.PaletteTemplate = PaletteTemplateColors["black"];
-                sigilTrinket.IconId = IconColorIds[(int)SigilTrinketType.Compass]["black"];
-
-                sigilTrinket.SigilTrinketIntensity = GetIntensity(profile);
-
-                sigilTrinket.Name += " of PH4";
-                sigilTrinket.Use =
-                    $"(PH)";
-                break;
+            // case (int)SigilTrinketShieldEffect.PH3:
+            //     sigilTrinket.PaletteTemplate = PaletteTemplateColors["green"];
+            //     sigilTrinket.IconId = IconColorIds[(int)SigilTrinketType.Compass]["green"];
+            //
+            //     sigilTrinket.SigilTrinketIntensity = GetIntensity(profile);
+            //
+            //     sigilTrinket.Name += " of PH3";
+            //     sigilTrinket.Use =
+            //         $"(PH)";
+            //     break;
+            // case (int)SigilTrinketShieldEffect.PH4:
+            //     sigilTrinket.PaletteTemplate = PaletteTemplateColors["black"];
+            //     sigilTrinket.IconId = IconColorIds[(int)SigilTrinketType.Compass]["black"];
+            //
+            //     sigilTrinket.SigilTrinketIntensity = GetIntensity(profile);
+            //
+            //     sigilTrinket.Name += " of PH4";
+            //     sigilTrinket.Use =
+            //         $"(PH)";
+            //     break;
         }
     }
 
@@ -572,36 +575,39 @@ public static partial class LootGenerationFactory
                     $"Whenever the wielder attacks a creature with more than 50% power, there is a chance that a normal hit will be converted into a critical hit.\n\n" +
                     $"Can only occur while using a two-handed weapon, with a wield requirement of up to {wieldReq}.";
                 break;
-            case (int)SigilTrinketTwohandedCombatEffect.PH2:
-                sigilTrinket.PaletteTemplate = PaletteTemplateColors["blue"];
-                sigilTrinket.IconId = IconColorIds[(int)SigilTrinketType.Compass]["blue"];
+            case (int)SigilTrinketTwohandedCombatEffect.Aggression:
+                sigilTrinket.PaletteTemplate = PaletteTemplateColors["olive"];
+                sigilTrinket.IconId = IconColorIds[(int)SigilTrinketType.Compass]["olive"];
 
                 sigilTrinket.SigilTrinketIntensity = GetIntensity(profile);
 
-                sigilTrinket.Name += " of PH2";
+                sigilTrinket.Name += " of Aggression";
+
+                wieldReq = GetWieldDifficultyPerTier((sigilTrinket.SigilTrinketMaxTier ?? 1) + 1);
                 sigilTrinket.Use =
-                    $"(PH)";
+                    $"Whenever the wielder performs an attack on an enemy, they have a chance to generate increased threat towards that enemy.\n\n"
+                    + $"Can only occur while using a two-handed weapon, with a wield requirement of up to {wieldReq}.";
                 break;
-            case (int)SigilTrinketTwohandedCombatEffect.PH3:
-                sigilTrinket.PaletteTemplate = PaletteTemplateColors["green"];
-                sigilTrinket.IconId = IconColorIds[(int)SigilTrinketType.Compass]["green"];
-
-                sigilTrinket.SigilTrinketIntensity = GetIntensity(profile);
-
-                sigilTrinket.Name += " of PH3";
-                sigilTrinket.Use =
-                    $"(PH)";
-                break;
-            case (int)SigilTrinketTwohandedCombatEffect.PH4:
-                sigilTrinket.PaletteTemplate = PaletteTemplateColors["black"];
-                sigilTrinket.IconId = IconColorIds[(int)SigilTrinketType.Compass]["black"];
-
-                sigilTrinket.SigilTrinketIntensity = GetIntensity(profile);
-
-                sigilTrinket.Name += " of PH4";
-                sigilTrinket.Use =
-                    $"(PH)";
-                break;
+            // case (int)SigilTrinketTwohandedCombatEffect.PH3:
+            //     sigilTrinket.PaletteTemplate = PaletteTemplateColors["green"];
+            //     sigilTrinket.IconId = IconColorIds[(int)SigilTrinketType.Compass]["green"];
+            //
+            //     sigilTrinket.SigilTrinketIntensity = GetIntensity(profile);
+            //
+            //     sigilTrinket.Name += " of PH3";
+            //     sigilTrinket.Use =
+            //         $"(PH)";
+            //     break;
+            // case (int)SigilTrinketTwohandedCombatEffect.PH4:
+            //     sigilTrinket.PaletteTemplate = PaletteTemplateColors["black"];
+            //     sigilTrinket.IconId = IconColorIds[(int)SigilTrinketType.Compass]["black"];
+            //
+            //     sigilTrinket.SigilTrinketIntensity = GetIntensity(profile);
+            //
+            //     sigilTrinket.Name += " of PH4";
+            //     sigilTrinket.Use =
+            //         $"(PH)";
+            //     break;
         }
     }
 

--- a/apps/server/WorldObjects/Player_Combat.cs
+++ b/apps/server/WorldObjects/Player_Combat.cs
@@ -154,6 +154,9 @@ partial class Player
 
         var damageEvent = DamageEvent.CalculateDamage(this, target, damageSource);
 
+        CheckForSigilTrinketOnAttackEffects(target, damageEvent, Skill.TwoHandedCombat, (int)SigilTrinketTwohandedCombatEffect.Aggression);
+        CheckForSigilTrinketOnAttackEffects(target, damageEvent, Skill.Shield, (int)SigilTrinketShieldEffect.Aggression);
+
         target.OnAttackReceived(
             this,
             (damageSource == null || damageSource.ProjectileSource == null) ? CombatType.Melee : CombatType.Missile,
@@ -180,8 +183,6 @@ partial class Player
                     threat *= 1.2f;
                 }
             }
-
-            CheckForSigilTrinketOnAttackEffects(target, damageEvent, Skill.TwoHandedCombat, (int)SigilTrinketTwohandedCombatEffect.Might);
 
             target.IncreaseTargetThreatLevel(this, (int)threat);
 

--- a/apps/server/WorldObjects/Player_SigilTrinket.cs
+++ b/apps/server/WorldObjects/Player_SigilTrinket.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using ACE.Common;
@@ -225,7 +224,6 @@ partial class Player
             TriggerSpell = spell
         };
 
-        Console.WriteLine($"\n\nGetSigilTrinketManaReductionMod(Skill {skill}, EffectId {effectId})");
         foreach (var sigilTrinket in equippedSigilTrinkets)
         {
             if (sigilTrinketEvent.HasReadySigilTrinketEffect(sigilTrinket))
@@ -311,7 +309,7 @@ partial class Player
             Skill = skill,
             EffectId = effectId
         };
-Console.WriteLine($"CheckForSigilTrinketOnCastEffects(Spell {spell.Name}, Skill {skill}, EffectId {effectId}");
+
         foreach (var sigilTrinket in equippedSigilTrinkets)
         {
             if (sigilTrinketEvent.HasReadySigilTrinketEffect(sigilTrinket))

--- a/apps/server/WorldObjects/SigilTrinket.cs
+++ b/apps/server/WorldObjects/SigilTrinket.cs
@@ -54,18 +54,14 @@ public enum SigilTrinketWarMagicEffect
 
 public enum SigilTrinketShieldEffect
 {
-    Aggression,
-    PH2,
-    PH3,
-    PH4
+    Might,
+    Aggression
 }
 
 public enum SigilTrinketTwohandedCombatEffect
 {
     Might,
-    PH2,
-    PH3,
-    PH4
+    Aggression
 }
 
 public enum SigilTrinketDualWieldEffect


### PR DESCRIPTION
- Might: Health-based sigil trinket with two-hand/shield reqs. Chance to convert a normal hit into a crit while attacking at greater than 50% power.
- Aggression" Health-based sigil trinket with two-hand/shield reqs. Chance to add additional threat to your target while attacking greater than 50% power.