### PR TITLE
feat: add Assailment and Treachery sigil trinkets

### DIFF
--- a/apps/server/Entity/DamageEvent.cs
+++ b/apps/server/Entity/DamageEvent.cs
@@ -87,6 +87,7 @@ public class DamageEvent
         (Weapon?.IgnoreMagicResist ?? false) || (_attacker?.IgnoreMagicResist ?? false); // ignores life armor / prots
 
     public bool Blocked { get; private set; }
+    public float CriticalDamageBonusFromTrinket { get; set; }
     public bool CriticalOverridedByTrinket { get; set; }
     public bool Evaded { get; private set; }
     public bool LifestoneProtection { get; private set; }
@@ -739,10 +740,14 @@ public class DamageEvent
         var playerAttacker = attacker as Player;
         var playerDefender = defender as Player;
 
+        CriticalDamageBonusFromTrinket = 1.0f;
+        playerAttacker?.CheckForSigilTrinketOnAttackEffects(defender, this, Skill.Lockpick, (int)SigilTrinketThieveryEffect.Treachery, true);
+
         _criticalDamageMod = 1.0f + WorldObject.GetWeaponCritDamageMod(Weapon, attacker, _attackSkill, defender);
         _criticalDamageMod += GetMaceSpecCriticalDamageBonus(playerAttacker);
         _criticalDamageMod += GetStaffSpecCriticalDamageBonus(playerAttacker);
         _criticalDamageMod += GetRatingBludgeonCriticalDamageBonus(defender, playerAttacker);
+        _criticalDamageMod *= CriticalDamageBonusFromTrinket;
 
         CheckForRatingReprisalCriticalDefense(attacker, playerDefender);
 

--- a/apps/server/Factories/LootGenerationFactory_SigilTrinket.cs
+++ b/apps/server/Factories/LootGenerationFactory_SigilTrinket.cs
@@ -249,13 +249,13 @@ public static partial class LootGenerationFactory
 
                 if (sigilTrinket.WieldSkillType == (int)Skill.Shield)
                 {
-                    sigilTrinket.SigilTrinketEffectId = ThreadSafeRandom.Next(0, SigilTrinket.maxShieldEffectId);
+                    sigilTrinket.SigilTrinketEffectId = ThreadSafeRandom.Next(0, SigilTrinket.MaxShieldEffectId);
 
                     SetShieldCompassStats(profile, sigilTrinket);
                 }
                 else
                 {
-                    sigilTrinket.SigilTrinketEffectId = ThreadSafeRandom.Next(0, SigilTrinket.maxTwohandedCombatEffectId);
+                    sigilTrinket.SigilTrinketEffectId = ThreadSafeRandom.Next(0, SigilTrinket.MaxTwohandedCombatEffectId);
 
                     SetTwohandedCombatCompassStats(profile, sigilTrinket);
                 }
@@ -266,13 +266,13 @@ public static partial class LootGenerationFactory
 
                 if (sigilTrinket.WieldSkillType == (int)Skill.DualWield)
                 {
-                    sigilTrinket.SigilTrinketEffectId = ThreadSafeRandom.Next(0, SigilTrinket.maxDualWieldEffectId);
+                    sigilTrinket.SigilTrinketEffectId = ThreadSafeRandom.Next(0, SigilTrinket.MaxDualWieldEffectId);
 
                     SetDualWieldPuzzleBoxStats(profile, sigilTrinket);
                 }
                 else
                 {
-                    sigilTrinket.SigilTrinketEffectId = ThreadSafeRandom.Next(0, SigilTrinket.maxThieveryEffectId);
+                    sigilTrinket.SigilTrinketEffectId = ThreadSafeRandom.Next(0, SigilTrinket.MaxThieveryEffectId);
 
                     SetThieveryPuzzleBoxStats(profile, sigilTrinket);
                 }
@@ -283,13 +283,13 @@ public static partial class LootGenerationFactory
 
                 if (sigilTrinket.WieldSkillType == (int)Skill.LifeMagic)
                 {
-                    sigilTrinket.SigilTrinketEffectId = ThreadSafeRandom.Next(0, SigilTrinket.maxLifeMagicEffectId);
+                    sigilTrinket.SigilTrinketEffectId = ThreadSafeRandom.Next(0, SigilTrinket.MaxLifeMagicEffectId);
 
                     SetLifeMagicScarabStats(profile, sigilTrinket);
                 }
                 else
                 {
-                    sigilTrinket.SigilTrinketEffectId = ThreadSafeRandom.Next(0, SigilTrinket.maxWarMagicEffectId);
+                    sigilTrinket.SigilTrinketEffectId = ThreadSafeRandom.Next(0, SigilTrinket.MaxWarMagicEffectId);
 
                     SetWarMagicScarabStats(profile, sigilTrinket);
                 }
@@ -298,7 +298,7 @@ public static partial class LootGenerationFactory
                 sigilTrinket.SigilTrinketHealthReserved = GetReservedVital(profile, true);
                 sigilTrinket.SigilTrinketStaminaReserved = GetReservedVital(profile, true);
                 sigilTrinket.WieldSkillType = (int)Skill.MeleeDefense;
-                sigilTrinket.SigilTrinketEffectId = ThreadSafeRandom.Next(0, SigilTrinket.maxPhysicalDefenseEffectId);
+                sigilTrinket.SigilTrinketEffectId = ThreadSafeRandom.Next(0, SigilTrinket.MaxPhysicalDefenseEffectId);
 
                 SetPhysicalDefensePocketWatchStats(profile, sigilTrinket);
                 break;
@@ -306,7 +306,7 @@ public static partial class LootGenerationFactory
                 sigilTrinket.SigilTrinketHealthReserved = GetReservedVital(profile, true);
                 sigilTrinket.SigilTrinketManaReserved = GetReservedVital(profile, true);
                 sigilTrinket.WieldSkillType = (int)Skill.MagicDefense;
-                sigilTrinket.SigilTrinketEffectId = ThreadSafeRandom.Next(0, SigilTrinket.maxMagicDefenseEffectId);
+                sigilTrinket.SigilTrinketEffectId = ThreadSafeRandom.Next(0, SigilTrinket.MaxMagicDefenseEffectId);
 
                 SetMagicDefenseTopStats(profile, sigilTrinket);
                 break;
@@ -317,13 +317,13 @@ public static partial class LootGenerationFactory
 
                 if (sigilTrinket.WieldSkillType == (int)Skill.AssessCreature)
                 {
-                    sigilTrinket.SigilTrinketEffectId = ThreadSafeRandom.Next(0, SigilTrinket.maxPerceptionEffectId);
+                    sigilTrinket.SigilTrinketEffectId = ThreadSafeRandom.Next(0, SigilTrinket.MaxPerceptionEffectId);
 
                     SetPerceptionGogglesStats(profile, sigilTrinket);
                 }
                 else
                 {
-                    sigilTrinket.SigilTrinketEffectId = ThreadSafeRandom.Next(0, SigilTrinket.maxDeceptionEffectId);
+                    sigilTrinket.SigilTrinketEffectId = ThreadSafeRandom.Next(0, SigilTrinket.MaxDeceptionEffectId);
 
                     SetDeceptionGogglesStats(profile, sigilTrinket);
                 }
@@ -532,7 +532,7 @@ public static partial class LootGenerationFactory
 
                 sigilTrinket.Name += " of Aggression";
 
-                wieldReq = GetWieldDifficultyPerTier((sigilTrinket.SigilTrinketMaxTier ?? 1) + 1);
+                var wieldReq = GetWieldDifficultyPerTier((sigilTrinket.SigilTrinketMaxTier ?? 1) + 1);
                 sigilTrinket.Use =
                     $"Whenever the wielder performs an attack on an enemy, they have a chance to generate increased threat towards that enemy.\n\n"
                     + $"Can only occur while using a shield, with a wield requirement of up to {wieldReq}.";
@@ -615,93 +615,99 @@ public static partial class LootGenerationFactory
     {
         switch (sigilTrinket.SigilTrinketEffectId)
         {
-            case (int)SigilTrinketDualWieldEffect.PH1:
+            case (int)SigilTrinketDualWieldEffect.Assailment:
                 sigilTrinket.PaletteTemplate = PaletteTemplateColors["red"];
                 sigilTrinket.IconId = IconColorIds[(int)SigilTrinketType.PuzzleBox]["red"];
 
                 sigilTrinket.SigilTrinketIntensity = GetIntensity(profile);
 
-                sigilTrinket.Name += " of PH1";
+                sigilTrinket.Name += " of Assailment";
+
+                var wieldReq = GetWieldDifficultyPerTier((sigilTrinket.SigilTrinketMaxTier ?? 1) + 1);
                 sigilTrinket.Use =
-                    $"(PH)";
+                    $"Whenever the wielder performs an critical hit on an enemy, they have a chance to gain a damage buff for 10 seconds.\n\n"
+                    + $"Can only occur while dual-wielding, with a wield requirement of up to {wieldReq}.";
                 break;
-            case (int)SigilTrinketDualWieldEffect.PH2:
-                sigilTrinket.PaletteTemplate = PaletteTemplateColors["blue"];
-                sigilTrinket.IconId = IconColorIds[(int)SigilTrinketType.PuzzleBox]["blue"];
-
-                sigilTrinket.SigilTrinketIntensity = GetIntensity(profile);
-
-                sigilTrinket.Name += " of PH2";
-                sigilTrinket.Use =
-                    $"(PH)";
-                break;
-            case (int)SigilTrinketDualWieldEffect.PH3:
-                sigilTrinket.PaletteTemplate = PaletteTemplateColors["green"];
-                sigilTrinket.IconId = IconColorIds[(int)SigilTrinketType.PuzzleBox]["green"];
-
-                sigilTrinket.SigilTrinketIntensity = GetIntensity(profile);
-
-                sigilTrinket.Name += " of PH3";
-                sigilTrinket.Use =
-                    $"(PH)";
-                break;
-            case (int)SigilTrinketDualWieldEffect.PH4:
-                sigilTrinket.PaletteTemplate = PaletteTemplateColors["black"];
-                sigilTrinket.IconId = IconColorIds[(int)SigilTrinketType.PuzzleBox]["black"];
-
-                sigilTrinket.SigilTrinketIntensity = GetIntensity(profile);
-
-                sigilTrinket.Name += " of PH4";
-                sigilTrinket.Use =
-                    $"(PH)";
-                break;
+            // case (int)SigilTrinketDualWieldEffect.PH2:
+            //     sigilTrinket.PaletteTemplate = PaletteTemplateColors["blue"];
+            //     sigilTrinket.IconId = IconColorIds[(int)SigilTrinketType.PuzzleBox]["blue"];
+            //
+            //     sigilTrinket.SigilTrinketIntensity = GetIntensity(profile);
+            //
+            //     sigilTrinket.Name += " of PH2";
+            //     sigilTrinket.Use =
+            //         $"(PH)";
+            //     break;
+            // case (int)SigilTrinketDualWieldEffect.PH3:
+            //     sigilTrinket.PaletteTemplate = PaletteTemplateColors["green"];
+            //     sigilTrinket.IconId = IconColorIds[(int)SigilTrinketType.PuzzleBox]["green"];
+            //
+            //     sigilTrinket.SigilTrinketIntensity = GetIntensity(profile);
+            //
+            //     sigilTrinket.Name += " of PH3";
+            //     sigilTrinket.Use =
+            //         $"(PH)";
+            //     break;
+            // case (int)SigilTrinketDualWieldEffect.PH4:
+            //     sigilTrinket.PaletteTemplate = PaletteTemplateColors["black"];
+            //     sigilTrinket.IconId = IconColorIds[(int)SigilTrinketType.PuzzleBox]["black"];
+            //
+            //     sigilTrinket.SigilTrinketIntensity = GetIntensity(profile);
+            //
+            //     sigilTrinket.Name += " of PH4";
+            //     sigilTrinket.Use =
+            //         $"(PH)";
+            //     break;
         }
     }
 
     private static void SetThieveryPuzzleBoxStats(TreasureDeath profile, SigilTrinket sigilTrinket)
     {
+        var wieldReq = GetWieldDifficultyPerTier((sigilTrinket.SigilTrinketMaxTier ?? 1) + 1);
+
         switch (sigilTrinket.SigilTrinketEffectId)
         {
-            case (int)SigilTrinketThieveryEffect.PH1:
-                sigilTrinket.PaletteTemplate = PaletteTemplateColors["red"];
-                sigilTrinket.IconId = IconColorIds[(int)SigilTrinketType.PuzzleBox]["red"];
-
-                sigilTrinket.SigilTrinketIntensity = GetIntensity(profile);
-
-                sigilTrinket.Name += " of PH1";
-                sigilTrinket.Use =
-                    $"(PH)";
-                break;
-            case (int)SigilTrinketThieveryEffect.PH2:
-                sigilTrinket.PaletteTemplate = PaletteTemplateColors["blue"];
-                sigilTrinket.IconId = IconColorIds[(int)SigilTrinketType.PuzzleBox]["blue"];
-
-                sigilTrinket.SigilTrinketIntensity = GetIntensity(profile);
-
-                sigilTrinket.Name += " of PH2";
-                sigilTrinket.Use =
-                    $"(PH)";
-                break;
-            case (int)SigilTrinketThieveryEffect.PH3:
+            case (int)SigilTrinketThieveryEffect.Treachery:
                 sigilTrinket.PaletteTemplate = PaletteTemplateColors["green"];
                 sigilTrinket.IconId = IconColorIds[(int)SigilTrinketType.PuzzleBox]["green"];
 
                 sigilTrinket.SigilTrinketIntensity = GetIntensity(profile);
 
-                sigilTrinket.Name += " of PH3";
+                sigilTrinket.Name += " of Treachery";
                 sigilTrinket.Use =
-                    $"(PH)";
+                    $"Whenever the wielder performs a sneak attack critical hit on an enemy, they have a chance to deal double critical damage.\n\n"
+                    + $"Can only occur while performing sneak attacks, using a weapon with a wield requirement of up to {wieldReq}.";
                 break;
-            case (int)SigilTrinketThieveryEffect.PH4:
-                sigilTrinket.PaletteTemplate = PaletteTemplateColors["black"];
-                sigilTrinket.IconId = IconColorIds[(int)SigilTrinketType.PuzzleBox]["black"];
-
-                sigilTrinket.SigilTrinketIntensity = GetIntensity(profile);
-
-                sigilTrinket.Name += " of PH4";
-                sigilTrinket.Use =
-                    $"(PH)";
-                break;
+            // case (int)SigilTrinketThieveryEffect.PH2:
+            //     sigilTrinket.PaletteTemplate = PaletteTemplateColors["blue"];
+            //     sigilTrinket.IconId = IconColorIds[(int)SigilTrinketType.PuzzleBox]["blue"];
+            //
+            //     sigilTrinket.SigilTrinketIntensity = GetIntensity(profile);
+            //
+            //     sigilTrinket.Name += " of PH2";
+            //     sigilTrinket.Use =
+            //         $"(PH)";
+            //     break;
+            // case (int)SigilTrinketThieveryEffect.PH3:
+            //     sigilTrinket.PaletteTemplate = PaletteTemplateColors["green"];
+            //     sigilTrinket.IconId = IconColorIds[(int)SigilTrinketType.PuzzleBox]["green"];
+            //
+            //     sigilTrinket.SigilTrinketIntensity = GetIntensity(profile);
+            //
+            //     sigilTrinket.Name += " of PH3";
+            //     sigilTrinket.Use =
+            //         $"(PH)";
+            //     break;
+            // case (int)SigilTrinketThieveryEffect.PH4:
+            //     sigilTrinket.PaletteTemplate = PaletteTemplateColors["black"];
+            //     sigilTrinket.IconId = IconColorIds[(int)SigilTrinketType.PuzzleBox]["black"];
+            //
+            //     sigilTrinket.SigilTrinketIntensity = GetIntensity(profile);
+            //
+            //     sigilTrinket.Name += " of PH4";
+            //     sigilTrinket.Use =
+            //         $"(PH)";
+            //     break;
         }
     }
 
@@ -719,36 +725,36 @@ public static partial class LootGenerationFactory
                 sigilTrinket.Use =
                     $"(PH)";
                 break;
-            case (int)SigilTrinketPhysicalDefenseEffect.PH2:
-                sigilTrinket.PaletteTemplate = PaletteTemplateColors["blue"];
-                sigilTrinket.IconId = IconColorIds[(int)SigilTrinketType.PocketWatch]["blue"];
-
-                sigilTrinket.SigilTrinketIntensity = GetIntensity(profile);
-
-                sigilTrinket.Name += " of PH2";
-                sigilTrinket.Use =
-                    $"(PH)";
-                break;
-            case (int)SigilTrinketPhysicalDefenseEffect.PH3:
-                sigilTrinket.PaletteTemplate = PaletteTemplateColors["green"];
-                sigilTrinket.IconId = IconColorIds[(int)SigilTrinketType.PocketWatch]["green"];
-
-                sigilTrinket.SigilTrinketIntensity = GetIntensity(profile);
-
-                sigilTrinket.Name += " of PH3";
-                sigilTrinket.Use =
-                    $"(PH)";
-                break;
-            case (int)SigilTrinketPhysicalDefenseEffect.PH4:
-                sigilTrinket.PaletteTemplate = PaletteTemplateColors["black"];
-                sigilTrinket.IconId = IconColorIds[(int)SigilTrinketType.PocketWatch]["black"];
-
-                sigilTrinket.SigilTrinketIntensity = GetIntensity(profile);
-
-                sigilTrinket.Name += " of PH4";
-                sigilTrinket.Use =
-                    $"(PH)";
-                break;
+            // case (int)SigilTrinketPhysicalDefenseEffect.PH2:
+            //     sigilTrinket.PaletteTemplate = PaletteTemplateColors["blue"];
+            //     sigilTrinket.IconId = IconColorIds[(int)SigilTrinketType.PocketWatch]["blue"];
+            //
+            //     sigilTrinket.SigilTrinketIntensity = GetIntensity(profile);
+            //
+            //     sigilTrinket.Name += " of PH2";
+            //     sigilTrinket.Use =
+            //         $"(PH)";
+            //     break;
+            // case (int)SigilTrinketPhysicalDefenseEffect.PH3:
+            //     sigilTrinket.PaletteTemplate = PaletteTemplateColors["green"];
+            //     sigilTrinket.IconId = IconColorIds[(int)SigilTrinketType.PocketWatch]["green"];
+            //
+            //     sigilTrinket.SigilTrinketIntensity = GetIntensity(profile);
+            //
+            //     sigilTrinket.Name += " of PH3";
+            //     sigilTrinket.Use =
+            //         $"(PH)";
+            //     break;
+            // case (int)SigilTrinketPhysicalDefenseEffect.PH4:
+            //     sigilTrinket.PaletteTemplate = PaletteTemplateColors["black"];
+            //     sigilTrinket.IconId = IconColorIds[(int)SigilTrinketType.PocketWatch]["black"];
+            //
+            //     sigilTrinket.SigilTrinketIntensity = GetIntensity(profile);
+            //
+            //     sigilTrinket.Name += " of PH4";
+            //     sigilTrinket.Use =
+            //         $"(PH)";
+            //     break;
         }
     }
 
@@ -766,36 +772,36 @@ public static partial class LootGenerationFactory
                 sigilTrinket.Use =
                     $"(PH)";
                 break;
-            case (int)SigilTrinketMagicDefenseEffect.PH2:
-                sigilTrinket.PaletteTemplate = PaletteTemplateColors["blue"];
-                sigilTrinket.IconId = IconColorIds[(int)SigilTrinketType.Top]["blue"];
-
-                sigilTrinket.SigilTrinketIntensity = GetIntensity(profile);
-
-                sigilTrinket.Name += " of PH2";
-                sigilTrinket.Use =
-                    $"(PH)";
-                break;
-            case (int)SigilTrinketMagicDefenseEffect.PH3:
-                sigilTrinket.PaletteTemplate = PaletteTemplateColors["green"];
-                sigilTrinket.IconId = IconColorIds[(int)SigilTrinketType.Top]["green"];
-
-                sigilTrinket.SigilTrinketIntensity = GetIntensity(profile);
-
-                sigilTrinket.Name += " of PH3";
-                sigilTrinket.Use =
-                    $"(PH)";
-                break;
-            case (int)SigilTrinketMagicDefenseEffect.PH4:
-                sigilTrinket.PaletteTemplate = PaletteTemplateColors["black"];
-                sigilTrinket.IconId = IconColorIds[(int)SigilTrinketType.Top]["black"];
-
-                sigilTrinket.SigilTrinketIntensity = GetIntensity(profile);
-
-                sigilTrinket.Name += " of PH4";
-                sigilTrinket.Use =
-                    $"(PH)";
-                break;
+            // case (int)SigilTrinketMagicDefenseEffect.PH2:
+            //     sigilTrinket.PaletteTemplate = PaletteTemplateColors["blue"];
+            //     sigilTrinket.IconId = IconColorIds[(int)SigilTrinketType.Top]["blue"];
+            //
+            //     sigilTrinket.SigilTrinketIntensity = GetIntensity(profile);
+            //
+            //     sigilTrinket.Name += " of PH2";
+            //     sigilTrinket.Use =
+            //         $"(PH)";
+            //     break;
+            // case (int)SigilTrinketMagicDefenseEffect.PH3:
+            //     sigilTrinket.PaletteTemplate = PaletteTemplateColors["green"];
+            //     sigilTrinket.IconId = IconColorIds[(int)SigilTrinketType.Top]["green"];
+            //
+            //     sigilTrinket.SigilTrinketIntensity = GetIntensity(profile);
+            //
+            //     sigilTrinket.Name += " of PH3";
+            //     sigilTrinket.Use =
+            //         $"(PH)";
+            //     break;
+            // case (int)SigilTrinketMagicDefenseEffect.PH4:
+            //     sigilTrinket.PaletteTemplate = PaletteTemplateColors["black"];
+            //     sigilTrinket.IconId = IconColorIds[(int)SigilTrinketType.Top]["black"];
+            //
+            //     sigilTrinket.SigilTrinketIntensity = GetIntensity(profile);
+            //
+            //     sigilTrinket.Name += " of PH4";
+            //     sigilTrinket.Use =
+            //         $"(PH)";
+            //     break;
         }
     }
 
@@ -813,36 +819,36 @@ public static partial class LootGenerationFactory
                 sigilTrinket.Use =
                     $"(PH)";
                 break;
-            case (int)SigilTrinketPerceptionEffect.PH2:
-                sigilTrinket.PaletteTemplate = PaletteTemplateColors["blue"];
-                sigilTrinket.IconId = IconColorIds[(int)SigilTrinketType.Goggles]["blue"];
-
-                sigilTrinket.SigilTrinketIntensity = GetIntensity(profile);
-
-                sigilTrinket.Name += " of PH2";
-                sigilTrinket.Use =
-                    $"(PH)";
-                break;
-            case (int)SigilTrinketPerceptionEffect.PH3:
-                sigilTrinket.PaletteTemplate = PaletteTemplateColors["green"];
-                sigilTrinket.IconId = IconColorIds[(int)SigilTrinketType.Goggles]["green"];
-
-                sigilTrinket.SigilTrinketIntensity = GetIntensity(profile);
-
-                sigilTrinket.Name += " of PH3";
-                sigilTrinket.Use =
-                    $"(PH)";
-                break;
-            case (int)SigilTrinketPerceptionEffect.PH4:
-                sigilTrinket.PaletteTemplate = PaletteTemplateColors["black"];
-                sigilTrinket.IconId = IconColorIds[(int)SigilTrinketType.Goggles]["black"];
-
-                sigilTrinket.SigilTrinketIntensity = GetIntensity(profile);
-
-                sigilTrinket.Name += " of PH4";
-                sigilTrinket.Use =
-                    $"(PH)";
-                break;
+            // case (int)SigilTrinketPerceptionEffect.PH2:
+            //     sigilTrinket.PaletteTemplate = PaletteTemplateColors["blue"];
+            //     sigilTrinket.IconId = IconColorIds[(int)SigilTrinketType.Goggles]["blue"];
+            //
+            //     sigilTrinket.SigilTrinketIntensity = GetIntensity(profile);
+            //
+            //     sigilTrinket.Name += " of PH2";
+            //     sigilTrinket.Use =
+            //         $"(PH)";
+            //     break;
+            // case (int)SigilTrinketPerceptionEffect.PH3:
+            //     sigilTrinket.PaletteTemplate = PaletteTemplateColors["green"];
+            //     sigilTrinket.IconId = IconColorIds[(int)SigilTrinketType.Goggles]["green"];
+            //
+            //     sigilTrinket.SigilTrinketIntensity = GetIntensity(profile);
+            //
+            //     sigilTrinket.Name += " of PH3";
+            //     sigilTrinket.Use =
+            //         $"(PH)";
+            //     break;
+            // case (int)SigilTrinketPerceptionEffect.PH4:
+            //     sigilTrinket.PaletteTemplate = PaletteTemplateColors["black"];
+            //     sigilTrinket.IconId = IconColorIds[(int)SigilTrinketType.Goggles]["black"];
+            //
+            //     sigilTrinket.SigilTrinketIntensity = GetIntensity(profile);
+            //
+            //     sigilTrinket.Name += " of PH4";
+            //     sigilTrinket.Use =
+            //         $"(PH)";
+            //     break;
         }
     }
 
@@ -860,36 +866,36 @@ public static partial class LootGenerationFactory
                 sigilTrinket.Use =
                     $"(PH)";
                 break;
-            case (int)SigilTrinketDeceptionEffect.PH2:
-                sigilTrinket.PaletteTemplate = PaletteTemplateColors["blue"];
-                sigilTrinket.IconId = IconColorIds[(int)SigilTrinketType.Goggles]["blue"];
-
-                sigilTrinket.SigilTrinketIntensity = GetIntensity(profile);
-
-                sigilTrinket.Name += " of PH2";
-                sigilTrinket.Use =
-                    $"(PH)";
-                break;
-            case (int)SigilTrinketDeceptionEffect.PH3:
-                sigilTrinket.PaletteTemplate = PaletteTemplateColors["green"];
-                sigilTrinket.IconId = IconColorIds[(int)SigilTrinketType.Goggles]["green"];
-
-                sigilTrinket.SigilTrinketIntensity = GetIntensity(profile);
-
-                sigilTrinket.Name += " of PH3";
-                sigilTrinket.Use =
-                    $"(PH)";
-                break;
-            case (int)SigilTrinketDeceptionEffect.PH4:
-                sigilTrinket.PaletteTemplate = PaletteTemplateColors["black"];
-                sigilTrinket.IconId = IconColorIds[(int)SigilTrinketType.Goggles]["black"];
-
-                sigilTrinket.SigilTrinketIntensity = GetIntensity(profile);
-
-                sigilTrinket.Name += " of PH4";
-                sigilTrinket.Use =
-                    $"(PH)";
-                break;
+            // case (int)SigilTrinketDeceptionEffect.PH2:
+            //     sigilTrinket.PaletteTemplate = PaletteTemplateColors["blue"];
+            //     sigilTrinket.IconId = IconColorIds[(int)SigilTrinketType.Goggles]["blue"];
+            //
+            //     sigilTrinket.SigilTrinketIntensity = GetIntensity(profile);
+            //
+            //     sigilTrinket.Name += " of PH2";
+            //     sigilTrinket.Use =
+            //         $"(PH)";
+            //     break;
+            // case (int)SigilTrinketDeceptionEffect.PH3:
+            //     sigilTrinket.PaletteTemplate = PaletteTemplateColors["green"];
+            //     sigilTrinket.IconId = IconColorIds[(int)SigilTrinketType.Goggles]["green"];
+            //
+            //     sigilTrinket.SigilTrinketIntensity = GetIntensity(profile);
+            //
+            //     sigilTrinket.Name += " of PH3";
+            //     sigilTrinket.Use =
+            //         $"(PH)";
+            //     break;
+            // case (int)SigilTrinketDeceptionEffect.PH4:
+            //     sigilTrinket.PaletteTemplate = PaletteTemplateColors["black"];
+            //     sigilTrinket.IconId = IconColorIds[(int)SigilTrinketType.Goggles]["black"];
+            //
+            //     sigilTrinket.SigilTrinketIntensity = GetIntensity(profile);
+            //
+            //     sigilTrinket.Name += " of PH4";
+            //     sigilTrinket.Use =
+            //         $"(PH)";
+            //     break;
         }
     }
 

--- a/apps/server/WorldObjects/Player_Combat.cs
+++ b/apps/server/WorldObjects/Player_Combat.cs
@@ -156,6 +156,8 @@ partial class Player
 
         CheckForSigilTrinketOnAttackEffects(target, damageEvent, Skill.TwoHandedCombat, (int)SigilTrinketTwohandedCombatEffect.Aggression);
         CheckForSigilTrinketOnAttackEffects(target, damageEvent, Skill.Shield, (int)SigilTrinketShieldEffect.Aggression);
+        CheckForSigilTrinketOnAttackEffects(target, damageEvent, Skill.DualWield, (int)SigilTrinketDualWieldEffect.Assailment, damageEvent.IsCritical);
+        CheckForSigilTrinketOnAttackEffects(target, damageEvent, Skill.Lockpick, (int)SigilTrinketThieveryEffect.Treachery, damageEvent.IsCritical);
 
         target.OnAttackReceived(
             this,

--- a/apps/server/WorldObjects/SigilTrinket.cs
+++ b/apps/server/WorldObjects/SigilTrinket.cs
@@ -56,74 +56,78 @@ public enum SigilTrinketShieldEffect
 {
     Might,
     Aggression
+    // PH3,
+    // PH4
 }
 
 public enum SigilTrinketTwohandedCombatEffect
 {
     Might,
     Aggression
+    // PH3,
+    // PH4
 }
 
 public enum SigilTrinketDualWieldEffect
 {
-    PH1,
-    PH2,
-    PH3,
-    PH4
+    Assailment
+    // PH2,
+    // PH3,
+    // PH4
 }
 
 public enum SigilTrinketThieveryEffect
 {
-    PH1,
-    PH2,
-    PH3,
-    PH4
+    Treachery,
+    // PH2,
+    // PH3,
+    // PH4
 }
 
 public enum SigilTrinketPerceptionEffect
 {
-    PH1,
-    PH2,
-    PH3,
-    PH4
+    PH1
+    // PH2,
+    // PH3,
+    // PH4
 }
 
 public enum SigilTrinketDeceptionEffect
 {
-    PH1,
-    PH2,
-    PH3,
-    PH4
+    PH1
+    // PH2,
+    // PH3,
+    // PH4
 }
 
 public enum SigilTrinketPhysicalDefenseEffect
 {
-    PH1,
-    PH2,
-    PH3,
-    PH4
+    PH1
+    // PH2,
+    // PH3,
+    // PH4
 }
 
 public enum SigilTrinketMagicDefenseEffect
 {
-    PH1,
-    PH2,
-    PH3,
-    PH4
+    PH1
+    // PH2,
+    // PH3,
+    // PH4
 }
 
 public class SigilTrinket : WorldObject
 {
-    public static int maxLifeMagicEffectId = Enum.GetValues(typeof(SigilTrinketLifeMagicEffect)).Cast<int>().Max();
-    public static int maxWarMagicEffectId = Enum.GetValues(typeof(SigilTrinketWarMagicEffect)).Cast<int>().Max();
-    public static int maxTwohandedCombatEffectId = Enum.GetValues(typeof(SigilTrinketTwohandedCombatEffect)).Cast<int>().Max();
-    public static int maxShieldEffectId = Enum.GetValues(typeof(SigilTrinketShieldEffect)).Cast<int>().Max();
-    public static int maxDualWieldEffectId = Enum.GetValues(typeof(SigilTrinketDualWieldEffect)).Cast<int>().Max();
-    public static int maxThieveryEffectId = Enum.GetValues(typeof(SigilTrinketThieveryEffect)).Cast<int>().Max();
-    public static int maxPerceptionEffectId = Enum.GetValues(typeof(SigilTrinketPerceptionEffect)).Cast<int>().Max();
-    public static int maxDeceptionEffectId = Enum.GetValues(typeof(SigilTrinketDeceptionEffect)).Cast<int>().Max();
-    public static int maxPhysicalDefenseEffectId = Enum.GetValues(typeof(SigilTrinketPhysicalDefenseEffect)).Cast<int>().Max();
-    public static int maxMagicDefenseEffectId = Enum.GetValues(typeof(SigilTrinketMagicDefenseEffect)).Cast<int>().Max();
+    public static readonly int MaxLifeMagicEffectId = Enum.GetValues(typeof(SigilTrinketLifeMagicEffect)).Cast<int>().Max();
+    public static readonly int MaxWarMagicEffectId = Enum.GetValues(typeof(SigilTrinketWarMagicEffect)).Cast<int>().Max();
+    public static readonly int MaxTwohandedCombatEffectId = Enum.GetValues(typeof(SigilTrinketTwohandedCombatEffect)).Cast<int>().Max();
+    public static readonly int MaxShieldEffectId = Enum.GetValues(typeof(SigilTrinketShieldEffect)).Cast<int>().Max();
+    public static readonly int MaxDualWieldEffectId = Enum.GetValues(typeof(SigilTrinketDualWieldEffect)).Cast<int>().Max();
+    public static readonly int MaxThieveryEffectId = Enum.GetValues(typeof(SigilTrinketThieveryEffect)).Cast<int>().Max();
+    public static readonly int MaxPerceptionEffectId = Enum.GetValues(typeof(SigilTrinketPerceptionEffect)).Cast<int>().Max();
+    public static readonly int MaxDeceptionEffectId = Enum.GetValues(typeof(SigilTrinketDeceptionEffect)).Cast<int>().Max();
+    public static readonly int MaxPhysicalDefenseEffectId = Enum.GetValues(typeof(SigilTrinketPhysicalDefenseEffect)).Cast<int>().Max();
+    public static readonly int MaxMagicDefenseEffectId = Enum.GetValues(typeof(SigilTrinketMagicDefenseEffect)).Cast<int>().Max();
 
 
     public static readonly List<SpellCategory> LifeBeneficialTriggerSpells =


### PR DESCRIPTION
- Assailment: Stamina-based sigil trinket with dual wield req. Chance on critical hit to gain a damage buff for 10 seconds.
- Treachery: Stamina-based sigil trinket with sneak attack req. Chance on sneak attack critical hit to deal double critical damage.