### PR TITLE
feat: implement improved trophy system

### DIFF
--- a/apps/server/Command/Handlers/DeveloperCommands.cs
+++ b/apps/server/Command/Handlers/DeveloperCommands.cs
@@ -20,6 +20,7 @@ using ACE.Server.Entity;
 using ACE.Server.Entity.Actions;
 using ACE.Server.Factories;
 using ACE.Server.Factories.Enum;
+using ACE.Server.Factories.Tables;
 using ACE.Server.Managers;
 using ACE.Server.Network;
 using ACE.Server.Network.GameEvent.Events;
@@ -1403,6 +1404,16 @@ public static class DeveloperCommands
             if (stackSizeForThisWeenieId > 1)
             {
                 loot.SetStackSize(stackSizeForThisWeenieId);
+            }
+
+
+            if (loot.TrophyQuality != null)
+            {
+                var trophyQuality = WorkmanshipChance.Roll(loot.Tier ?? 1);
+                loot.SetProperty(PropertyInt.TrophyQuality, trophyQuality);
+
+                var name = LootGenerationFactory.GetTrophyQualityName(trophyQuality);
+                loot.SetProperty(PropertyString.Name, name);
             }
 
             session.Player.TryCreateInInventoryWithNetworking(loot);
@@ -3392,6 +3403,7 @@ public static class DeveloperCommands
             && !Aetheria.IsAetheria(wo.WeenieClassId)
             && !SigilTrinket.IsSigilTrinket(wo.WeenieClassId)
             && !(wo is PetDevice)
+            && wo.TrophyQuality == null
         )
         {
             session.Network.EnqueueSend(

--- a/apps/server/Command/Handlers/DeveloperCommands.cs
+++ b/apps/server/Command/Handlers/DeveloperCommands.cs
@@ -20,7 +20,6 @@ using ACE.Server.Entity;
 using ACE.Server.Entity.Actions;
 using ACE.Server.Factories;
 using ACE.Server.Factories.Enum;
-using ACE.Server.Factories.Tables;
 using ACE.Server.Managers;
 using ACE.Server.Network;
 using ACE.Server.Network.GameEvent.Events;
@@ -1409,11 +1408,7 @@ public static class DeveloperCommands
 
             if (loot.TrophyQuality != null)
             {
-                var trophyQuality = WorkmanshipChance.Roll(loot.Tier ?? 1);
-                loot.SetProperty(PropertyInt.TrophyQuality, trophyQuality);
-
-                var name = LootGenerationFactory.GetTrophyQualityName(trophyQuality);
-                loot.SetProperty(PropertyString.Name, name);
+                LootGenerationFactory.MutateTrophy(loot);
             }
 
             session.Player.TryCreateInInventoryWithNetworking(loot);

--- a/apps/server/Factories/LootGenerationFactory.cs
+++ b/apps/server/Factories/LootGenerationFactory.cs
@@ -905,14 +905,7 @@ public static partial class LootGenerationFactory
         else if (item.TrophyQuality != null)
         {
             // mutate trophy quality
-            if (item.TrophyQuality != null)
-            {
-                var trophyQuality = WorkmanshipChance.Roll(item.Tier ?? 1);
-                item.SetProperty(PropertyInt.TrophyQuality, trophyQuality);
-
-                var name = GetTrophyQualityName(trophyQuality);
-                item.SetProperty(PropertyString.Name, name + " " + item.Name);
-            }
+            MutateTrophy(item);
         }
         // other mundane items (mana stones, food/drink, healing kits, lockpicks, and spell components/peas) don't get mutated
         // it should be safe to return false here, for the 1 caller that currently uses this method
@@ -2972,5 +2965,24 @@ public static partial class LootGenerationFactory
             10 => "Peerless",
             _ => "Damaged"
         };
+    }
+
+    public static void MutateTrophy(WorldObject wo)
+    {
+        if (wo.TrophyQuality == null)
+        {
+            return;
+        }
+
+        var trophyQuality = WorkmanshipChance.Roll(wo.Tier ?? 1);
+        wo.SetProperty(PropertyInt.TrophyQuality, trophyQuality);
+
+        var name = GetTrophyQualityName(trophyQuality);
+        wo.SetProperty(PropertyString.Name, name + " " + wo.Name);
+
+        var multiplier = trophyQuality * trophyQuality;
+        var value = (wo.Value ?? 0) * multiplier;
+        wo.SetProperty(PropertyInt.Value, value);
+        wo.SetProperty(PropertyInt.StackUnitValue, value);
     }
 }

--- a/apps/server/Factories/LootGenerationFactory.cs
+++ b/apps/server/Factories/LootGenerationFactory.cs
@@ -902,6 +902,18 @@ public static partial class LootGenerationFactory
             // mundane add-on
             MutateSigilTrinket(item, profile);
         }
+        else if (item.TrophyQuality != null)
+        {
+            // mutate trophy quality
+            if (item.TrophyQuality != null)
+            {
+                var trophyQuality = WorkmanshipChance.Roll(item.Tier ?? 1);
+                item.SetProperty(PropertyInt.TrophyQuality, trophyQuality);
+
+                var name = GetTrophyQualityName(trophyQuality);
+                item.SetProperty(PropertyString.Name, name + " " + item.Name);
+            }
+        }
         // other mundane items (mana stones, food/drink, healing kits, lockpicks, and spell components/peas) don't get mutated
         // it should be safe to return false here, for the 1 caller that currently uses this method
         // since it's not this function's responsibility to determine if an item is a lootgen item,
@@ -2943,5 +2955,22 @@ public static partial class LootGenerationFactory
                       break;
               }
           } */
+    }
+
+    public static string GetTrophyQualityName(int trophyQuality)
+    {
+        return trophyQuality switch
+        {
+            2 => "Inferior",
+            3 => "Poor",
+            4 => "Crude",
+            5 => "Ordinary",
+            6 => "Good",
+            7 => "Great",
+            8 => "Excellent",
+            9 => "Superb",
+            10 => "Peerless",
+            _ => "Damaged"
+        };
     }
 }

--- a/apps/server/Factories/Tables/WorkmanshipChance.cs
+++ b/apps/server/Factories/Tables/WorkmanshipChance.cs
@@ -6,32 +6,24 @@ namespace ACE.Server.Factories.Tables;
 
 public static class WorkmanshipChance
 {
-    private static ChanceTable<int> T1_Chances = new ChanceTable<int>() { (1, 0.95f), (2, 0.05f), };
+    private static ChanceTable<int> T1_Chances = [(1, 1.0f)];
 
-    private static ChanceTable<int> T2_Chances = new ChanceTable<int>() { (1, 0.9f), (2, 0.1f), };
+    private static ChanceTable<int> T2_Chances = [(1, 0.7f), (2, 0.29f), (3, 0.009f), (4, 0.001f)];
 
-    private static ChanceTable<int> T3_Chances = new ChanceTable<int>() { (1, 0.45f), (2, 0.5f), (3, 0.05f), };
+    private static ChanceTable<int> T3_Chances = [(1, 0.6f), (2, 0.3f), (3, 0.09f), (4, 0.009f), (5, 0.001f)];
 
-    private static ChanceTable<int> T4_Chances = new ChanceTable<int>() { (2, 0.45f), (3, 0.5f), (4, 0.05f), };
+    private static ChanceTable<int> T4_Chances = [(2, 0.6f), (3, 0.3f), (4, 0.09f), (5, 0.009f), (6, 0.001f)];
 
-    private static ChanceTable<int> T5_Chances = new ChanceTable<int>() { (3, 0.45f), (4, 0.5f), (5, 0.05f), };
+    private static ChanceTable<int> T5_Chances = [(3, 0.6f), (4, 0.3f), (5, 0.09f), (6, 0.009f), (7, 0.001f)];
 
-    private static ChanceTable<int> T6_Chances = new ChanceTable<int>() { (4, 0.45f), (5, 0.5f), (6, 0.05f), };
+    private static ChanceTable<int> T6_Chances = [(4, 0.6f), (5, 0.3f), (6, 0.09f), (7, 0.009f), (8, 0.001f)];
 
-    private static ChanceTable<int> T7_Chances = new ChanceTable<int>() { (5, 0.45f), (6, 0.5f), (7, 0.05f), };
+    private static ChanceTable<int> T7_Chances = [(5, 0.6f), (6, 0.3f), (7, 0.09f), (8, 0.009f), (9, 0.001f)];
 
-    private static ChanceTable<int> T8_Chances = new ChanceTable<int>()
-    {
-        (5, 0.3f),
-        (6, 0.5f),
-        (7, 0.15f),
-        (8, 0.04f),
-        (9, 0.008f),
-        (10, 0.002f),
-    };
+    private static ChanceTable<int> T8_Chances = [(6, 0.6f), (7, 0.3f), (8, 0.09f), (9, 0.009f), (10, 0.001f)];
 
-    private static readonly List<ChanceTable<int>> workmanshipChances = new List<ChanceTable<int>>()
-    {
+    private static readonly List<ChanceTable<int>> workmanshipChances =
+    [
         T1_Chances,
         T2_Chances,
         T3_Chances,
@@ -39,8 +31,8 @@ public static class WorkmanshipChance
         T5_Chances,
         T6_Chances,
         T7_Chances,
-        T8_Chances,
-    };
+        T8_Chances
+    ];
 
     /// <summary>
     /// Rolls for a 1-10 workmanship for an item
@@ -55,14 +47,15 @@ public static class WorkmanshipChance
 
         var workmanshipChance = workmanshipChances[tier - 1];
 
-        if (qualityMod >= 0)
+        var baseWorkmanship = workmanshipChance.Roll(qualityMod, true);
+
+        var cantripBonus = 0;
+        if (cantripLevel > 0)
         {
-            return workmanshipChance.Roll(qualityMod, true) + Math.Max(0, cantripLevel - 2);
+            cantripBonus = Math.Clamp(cantripLevel - 2, 1, 10);
         }
-        else
-        {
-            return workmanshipChance.Roll(qualityMod, false) + Math.Max(0, cantripLevel - 2);
-        }
+
+        return baseWorkmanship + cantripBonus;
     }
 
     /// <summary>

--- a/apps/server/Factories/WorldObjectFactory.cs
+++ b/apps/server/Factories/WorldObjectFactory.cs
@@ -1,10 +1,13 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using ACE.Database;
 using ACE.Database.Models.World;
 using ACE.Entity;
 using ACE.Entity.Enum;
+using ACE.Entity.Enum.Properties;
 using ACE.Entity.Models;
+using ACE.Server.Factories.Tables;
 using ACE.Server.Managers;
 using ACE.Server.WorldObjects;
 using Serilog;
@@ -503,6 +506,15 @@ public static class WorldObjectFactory
         if (!isTreasure)
         {
             wo.Shade = item.Shade;
+        }
+
+        if (wo.TrophyQuality != null)
+        {
+            var trophyQuality = WorkmanshipChance.Roll(wo.Tier ?? 1);
+            wo.SetProperty(PropertyInt.TrophyQuality, trophyQuality);
+
+            var name = LootGenerationFactory.GetTrophyQualityName(trophyQuality);
+            wo.SetProperty(PropertyString.Name, name);
         }
 
         return wo;

--- a/apps/server/Factories/WorldObjectFactory.cs
+++ b/apps/server/Factories/WorldObjectFactory.cs
@@ -4,9 +4,7 @@ using ACE.Database;
 using ACE.Database.Models.World;
 using ACE.Entity;
 using ACE.Entity.Enum;
-using ACE.Entity.Enum.Properties;
 using ACE.Entity.Models;
-using ACE.Server.Factories.Tables;
 using ACE.Server.Managers;
 using ACE.Server.WorldObjects;
 using Serilog;
@@ -509,11 +507,7 @@ public static class WorldObjectFactory
 
         if (wo.TrophyQuality != null)
         {
-            var trophyQuality = WorkmanshipChance.Roll(wo.Tier ?? 1);
-            wo.SetProperty(PropertyInt.TrophyQuality, trophyQuality);
-
-            var name = LootGenerationFactory.GetTrophyQualityName(trophyQuality);
-            wo.SetProperty(PropertyString.Name, name);
+            LootGenerationFactory.MutateTrophy(wo);
         }
 
         return wo;

--- a/apps/server/Factories/WorldObjectFactory.cs
+++ b/apps/server/Factories/WorldObjectFactory.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using ACE.Database;

--- a/apps/server/Network/Structure/AppraiseInfo.cs
+++ b/apps/server/Network/Structure/AppraiseInfo.cs
@@ -749,6 +749,9 @@ public class AppraiseInfo
             _extraPropertiesText = "";
         }
 
+        // Trophy Quality Level
+        SetTrophyQualityLevelText(wo);
+
         // Protection Levels ('Use' text)
         SetProtectionLevelsUseText(wo);
 
@@ -891,6 +894,17 @@ public class AppraiseInfo
 
                 PropertiesString[PropertyString.LongDesc] = _additionalPropertiesLongDescriptionsText;
             }
+        }
+    }
+
+    private void SetTrophyQualityLevelText(WorldObject wo)
+    {
+        if (PropertiesInt.TryGetValue(PropertyInt.TrophyQuality, out var trophyQuality) && trophyQuality > 0)
+        {
+            var qualityName = LootGenerationFactory.GetTrophyQualityName(trophyQuality);
+
+            _extraPropertiesText += $"\nQuality Level: {trophyQuality}";
+            PropertiesString[PropertyString.Use] = _extraPropertiesText;
         }
     }
 

--- a/apps/server/WorldObjects/Creature.cs
+++ b/apps/server/WorldObjects/Creature.cs
@@ -63,6 +63,11 @@ public partial class Creature : Container
     public float attacksReceivedPerSecond;
 
     /// <summary>
+    /// A stored reference of a "Refused" item, to allow the TakeItem emote to take the specific guid shown to NPC
+    /// </summary>
+    public (WorldObject, uint?) RefusalItem;
+
+    /// <summary>
     /// Currently used to handle some edge cases for faction mobs
     /// DamageHistory.HasDamager() has the following issues:
     /// - if a player attacks a same-factioned mob but is evaded, the mob would quickly de-aggro

--- a/apps/server/WorldObjects/Creature_Death.cs
+++ b/apps/server/WorldObjects/Creature_Death.cs
@@ -1094,16 +1094,13 @@ partial class Creature
                 {
                     var wo = WorldObjectFactory.CreateNewWorldObject(item);
 
-                    if (wo != null)
+                    if (corpse != null)
                     {
-                        if (corpse != null)
-                        {
-                            corpse.TryAddToInventory(wo);
-                        }
-                        else
-                        {
-                            droppedItems.Add(wo);
-                        }
+                        corpse.TryAddToInventory(wo);
+                    }
+                    else
+                    {
+                        droppedItems.Add(wo);
                     }
                 }
             }

--- a/apps/server/WorldObjects/Player_Inventory.cs
+++ b/apps/server/WorldObjects/Player_Inventory.cs
@@ -124,7 +124,7 @@ partial class Player
         return true;
     }
 
-    public bool TryConsumeFromInventoryWithNetworking(WorldObject item, int amount = int.MaxValue)
+    public bool TryConsumeFromInventoryWithNetworking(WorldObject item, int amount = int.MaxValue, uint? guid = null)
     {
         if (amount >= (item.StackSize ?? 1))
         {
@@ -172,7 +172,7 @@ partial class Player
         return true;
     }
 
-    public bool TryConsumeFromInventoryWithNetworking(uint wcid, int amount = int.MaxValue)
+    public bool TryConsumeFromInventoryWithNetworking(uint wcid, int amount = int.MaxValue, uint? guid = null)
     {
         var items = GetInventoryItemsOfWCID(wcid);
         //items = items.OrderBy(o => o.Value).ToList();
@@ -180,8 +180,13 @@ partial class Player
         var leftReq = amount;
         foreach (var item in items)
         {
+            if (guid != null && item.Guid.Full != guid)
+            {
+                continue;
+            }
+
             var removeNum = Math.Min(leftReq, item.StackSize ?? 1);
-            if (!TryConsumeFromInventoryWithNetworking(item, removeNum))
+            if (!TryConsumeFromInventoryWithNetworking(item, removeNum, guid))
             {
                 return false;
             }
@@ -5148,6 +5153,11 @@ partial class Player
             }
             else if (emoteResult.Category == EmoteCategory.Refuse)
             {
+                if (target is Creature creatureTarget)
+                {
+                    creatureTarget.RefusalItem = (item, item.Guid.Full);
+                }
+
                 if (!target.ExamineItemsSilently.HasValue || target.ExamineItemsSilently == false)
                 {
                     Session.Network.EnqueueSend(

--- a/apps/server/WorldObjects/WorldObject_Properties.cs
+++ b/apps/server/WorldObjects/WorldObject_Properties.cs
@@ -8954,4 +8954,20 @@ partial class WorldObject
             }
         }
     }
+
+    public int? TrophyQuality
+    {
+        get => GetProperty(PropertyInt.TrophyQuality);
+        set
+        {
+            if (!value.HasValue)
+            {
+                RemoveProperty(PropertyInt.TrophyQuality);
+            }
+            else
+            {
+                SetProperty(PropertyInt.TrophyQuality, value.Value);
+            }
+        }
+    }
 }

--- a/libs/entity/Enum/Properties/PropertyInt.cs
+++ b/libs/entity/Enum/Properties/PropertyInt.cs
@@ -823,6 +823,7 @@ public enum PropertyInt : ushort
     NearbyPlayerScalingAddWcid = 464,
     RemainingConfirmations = 465,
     SigilTrinketType = 466,
+    TrophyQuality = 467,
 
     [ServerOnly]
     PCAPRecordedAutonomousMovement = 8007,


### PR DESCRIPTION
- Trophies can now receive a quality level mutation when generated, depending on tier of the killed enemy.
   - The trophy receives an adjective to its name and mutated value based on quality level.
   - There are 10 unique adjectives. (i.e. an Armoredillo Hide could be "Crude", "Excellent", "Peerless", etc.)
- When presenting a trophy to a collector/npc, using the Refuse emote and YesNo confirmation, The confirmation box can display the name of the item and the proposed pyreal value from the NPC.
- If a player accepts the NPCs offer, the TakeItems emote can now take a specific GUID rather than just the first matching WCID in the player inventory. This allows the correct trophy to be taken if a player is holding different quality levels of the same trophy type.
- TODO: for NPCs that offer items in return for trophies, allow the reward to scale with quality level of the trophy.