### PR TITLE
feat: add safety measures to fellowship landblock booting

### DIFF
--- a/apps/server/WorldObjects/Player_Fellowship.cs
+++ b/apps/server/WorldObjects/Player_Fellowship.cs
@@ -61,6 +61,26 @@ partial class Player
 
     public void FellowshipQuit(bool disband)
     {
+        if (disband)
+        {
+            foreach (var member in Fellowship.GetFellowshipMembers())
+            {
+                if (member.Value.CurrentLandblock.IsFellowshipRequired())
+                {
+                    var leader = PlayerManager.GetOnlinePlayer(Fellowship.FellowshipLeaderGuid);
+
+                    leader.Session.Network.EnqueueSend(
+                        new GameMessageSystemChat(
+                            "A member of this fellowship is in an area that prevents disbanding.",
+                            ChatMessageType.Broadcast
+                        )
+                    );
+
+                    return;
+                }
+            }
+        }
+
         if (Fellowship != null)
         {
             Fellowship.QuitFellowship(this, disband);


### PR DESCRIPTION
- Prevent fellowships from being disbanded if any party member is in a FellowshipRequired landblock.
- Give players 1 minute to rejoin a fellowship if quit or dismissed in a FellowshipRequired landblock, before teleporting them to their sanctuary position.