### PR TITLE
feat: Adjust logic for portal spells with FellowshipRequired portals

### DIFF
--- a/apps/server/WorldObjects/Portal.cs
+++ b/apps/server/WorldObjects/Portal.cs
@@ -136,6 +136,8 @@ public partial class Portal : WorldObject
     /// </summary>
     private const float minTimeSinceLastPortal = 3.5f;
 
+    public bool PlayerUsingTieOrSummonSpell;
+
     public override ActivationResult CheckUseRequirements(WorldObject activator)
     {
         if (!(activator is Player player))
@@ -315,7 +317,7 @@ public partial class Portal : WorldObject
         }
 
         // handle attempting to enter a capstone dungeon without being in a fellowship
-        if (FellowshipRequired && player.Fellowship == null)
+        if (FellowshipRequired && player.Fellowship == null && !PlayerUsingTieOrSummonSpell)
         {
             player.Session.Network.EnqueueSend(
                 new GameMessageSystemChat(
@@ -325,6 +327,8 @@ public partial class Portal : WorldObject
             );
             return new ActivationResult(false);
         }
+
+        PlayerUsingTieOrSummonSpell = false;
 
         // handle quest initial flagging
         if (Quest != null && !IsGateway)

--- a/apps/server/WorldObjects/WorldObject_Magic.cs
+++ b/apps/server/WorldObjects/WorldObject_Magic.cs
@@ -2076,6 +2076,8 @@ partial class WorldObject
                         break;
                     }
 
+                    tiePortal.PlayerUsingTieOrSummonSpell = true;
+
                     var result = tiePortal.CheckUseRequirements(player);
 
                     if (!result.Success && result.Message != null)
@@ -2365,6 +2367,8 @@ partial class WorldObject
                 return;
             }
 
+            summonPortal.PlayerUsingTieOrSummonSpell = true;
+
             var result = summonPortal.CheckUseRequirements(player);
             if (!result.Success)
             {
@@ -2439,6 +2443,7 @@ partial class WorldObject
         gateway.MinLevel = portal.MinLevel;
         gateway.MaxLevel = portal.MaxLevel;
         gateway.PortalRestrictions = portal.PortalRestrictions;
+        gateway.FellowshipRequired = portal.FellowshipRequired;
         gateway.AccountRequirements = portal.AccountRequirements;
         gateway.AdvocateQuest = portal.AdvocateQuest;
 


### PR DESCRIPTION
- Players can no longer enter a summoned gateway of a FellowshipRequired portal without being in a fellowship.
- Players can now tie to and summon FellowshipRequired portals without being in a fellowship.