### PR TITLE
feat: update capstone rewards

### DIFF
--- a/apps/server/Factories/Tables/VendorBaseItems.cs
+++ b/apps/server/Factories/Tables/VendorBaseItems.cs
@@ -213,8 +213,9 @@ public static class VendorBaseItems
         { (5, true, HeritageSho, 1055057, 0, 0.0, -1) }, // Large Component Pouch
         { (6, true, HeritageSho, 1055057, 0, 0.0, -1) }, // Large Component Pouch
         { (7, true, HeritageSho, 1055057, 0, 0.0, -1) }, // Large Component Pouch
-        // Pearl of Spell Purging
-        { (0, false, HeritageAny, 1054001, 0, 0.0, -1) }, // Large Component Pouch
+        // Pearls
+        { (0, false, HeritageAny, 1054000, 0, 0.0, -1) }, // Pearl of Spell Transference
+        { (0, false, HeritageAny, 1054005, 0, 0.0, -1) }, // Pearl of Spell Purging
     };
 
     // <(tier, onlyThisTier, heritage, wcid, paletteTemplate, shade, stackSize)>
@@ -228,6 +229,7 @@ public static class VendorBaseItems
         int
     )>()
     {
+        { (0, false, HeritageAny, 1054004, 0, 0.0, -1) }, // Upgrade Kit
         };
 
     // <(tier, onlyThisTier, heritage, wcid, paletteTemplate, shade, stackSize)>
@@ -254,6 +256,7 @@ public static class VendorBaseItems
         int
     )>()
     {
+        { (0, false, HeritageAny, 1054004, 0, 0.0, -1) }, // Upgrade Kit
         };
 
     // <(tier, onlyThisTier, heritage, wcid, paletteTemplate, shade, stackSize)>
@@ -780,5 +783,6 @@ public static class VendorBaseItems
         int
     )>()
     {
+        { (0, false, HeritageAny, 1054004, 0, 0.0, -1) }, // Upgrade Kit
         };
 }

--- a/apps/server/WorldObjects/Managers/EmoteManager.cs
+++ b/apps/server/WorldObjects/Managers/EmoteManager.cs
@@ -3237,15 +3237,13 @@ public class EmoteManager
     }
 
     /// <summary>
-    /// Trade note awards for completing a capstone dungeon. Amount equal to double the number of rewards.<br /><br />
+    /// Trade note awards for completing a capstone dungeon.<br /><br />
     /// Type Odds: 40% = I, 30% = V, 20% = X, 9% = L, 1% = C<br />
     /// Higher level players have improved luck, up to level 50.<br />
     /// </summary>
     private void AwardCapstoneTradeNotes(Player player, int amount)
     {
         var characterLevel = Math.Min(player.Level ?? 1, 50);
-
-        amount *= 2;
 
         for (var i = 0; i < amount; i++)
         {
@@ -3279,14 +3277,14 @@ public class EmoteManager
     /// </summary>
     private void AwardCapstoneItems(Player player, int numRewards)
     {
-        var itemPool = new List<uint>
+        var itemPool = new List<(uint,int)>
         {
-            1054000, // Pearl of Transference
-            1054002, // Sanguine Crystal
-            1054003, // Scourging Stone
-            1053972, // Tailoring Kit
-            1053973, // Tailoring Pattern
-            1054004  // Upgrade Kit
+            (1054000,2), // Pearl of Transference
+            (1054005,10), // Pearl of Spell Purging
+            (1054002,1), // Sanguine Crystal
+            (1054003,1), // Scourging Stone
+            (1053972,1), // Tailoring Kit
+            (1054004,2)  // Upgrade Kit
         };
 
         //numRewards *= GetCapstoneModifier(); // TODO: allow this to scale up when a fellowship has difficulty modifiers set
@@ -3318,7 +3316,9 @@ public class EmoteManager
 
             var randomItem = itemPool[randomIndex];
 
-            player.GiveFromEmote(WorldObject, randomItem, amount);
+            var amountToGive = amount * randomItem.Item2;
+
+            player.GiveFromEmote(WorldObject, randomItem.Item1, amountToGive);
         }
     }
 }

--- a/apps/server/WorldObjects/SpellPurge.cs
+++ b/apps/server/WorldObjects/SpellPurge.cs
@@ -76,7 +76,8 @@ public class SpellPurge : Stackable
     public static void UseObjectOnTarget(Player player, WorldObject source, WorldObject target, bool confirmed = false)
     {
         var pearlStackSize = source.StackSize ?? 1;
-        var amountToAdd = Math.Clamp((target.ItemWorkmanship ?? 1) - 1, 1, 10);
+        var targetWorkmanship = Math.Clamp((target.ItemWorkmanship ?? 1) - 1, 1, 10);
+        var amountToAdd = targetWorkmanship * targetWorkmanship;
 
         if (player.IsBusy)
         {

--- a/apps/server/WorldObjects/SpellTransference.cs
+++ b/apps/server/WorldObjects/SpellTransference.cs
@@ -115,7 +115,8 @@ public class SpellTransference : Stackable
         if (source.SpellExtracted == null)
         {
             var pearlStackSize = source.StackSize ?? 1;
-            var amountToAdd = Math.Clamp((target.ItemWorkmanship ?? 1) - 1, 1, 10);
+            var targetWorkmanship = Math.Clamp((target.ItemWorkmanship ?? 1) - 1, 1, 10);
+            var amountToAdd = targetWorkmanship * targetWorkmanship;
             var consumed = amountToAdd > 1 ? $"and consuming {amountToAdd} pearls" : "";
 
             if (player.IsBusy)

--- a/apps/server/WorldObjects/UpgradeKit.cs
+++ b/apps/server/WorldObjects/UpgradeKit.cs
@@ -775,24 +775,24 @@ public class UpgradeKit : Stackable
             switch (newWieldReq)
             {
                 case 125: return 1;
-                case 175: return 2;
-                case 200: return 3;
-                case 215: return 4;
-                case 230: return 5;
-                case 250: return 6;
-                case 270: return 7;
+                case 175: return 4;
+                case 200: return 9;
+                case 215: return 16;
+                case 230: return 15;
+                case 250: return 36;
+                case 270: return 49;
             }
         }
 
         switch (newWieldReq)
         {
             case 10: return 1;
-            case 20: return 2;
-            case 30: return 3;
-            case 40: return 4;
-            case 50: return 5;
-            case 75: return 6;
-            case 100: return 7;
+            case 20: return 4;
+            case 30: return 9;
+            case 40: return 16;
+            case 50: return 25;
+            case 75: return 36;
+            case 100: return 49;
         }
 
         return 1;


### PR DESCRIPTION
- Add some of the capstone rewards to vendors.
   - Pearl of Spell Transference to Archmages.
   - Pearl of Spell Purging to Archmages.
   - Upgrade Kits to Blacksmiths/Armorers/Weaponsmiths.
- Add Pearl of Spell Purging to capstone rewards.
- Tweak Capstone reward amounts.
- Increase number of pearls and upgrade kits required for crafting interactions.