### PR TITLE
fix: set correct read scroll messages

### DIFF
--- a/apps/server/WorldObjects/Player_Skills.cs
+++ b/apps/server/WorldObjects/Player_Skills.cs
@@ -687,11 +687,7 @@ partial class Player
         var skillAdvancementClass = IsAdvancedSpell(scroll.Spell)
             ? SkillAdvancementClass.Specialized
             : SkillAdvancementClass.Trained;
-        spec = skillAdvancementClass == SkillAdvancementClass.Specialized ? true : false;
-
-        Console.WriteLine(
-            $"{playerSkill.AdvancementClass}  {skillAdvancementClass} {playerSkill.Current}  {minSkill}  {spec}"
-        );
+        spec = skillAdvancementClass == SkillAdvancementClass.Specialized;
 
         return playerSkill.AdvancementClass >= skillAdvancementClass && playerSkill.Current >= minSkill;
     }

--- a/apps/server/WorldObjects/Scroll.cs
+++ b/apps/server/WorldObjects/Scroll.cs
@@ -108,7 +108,7 @@ public class Scroll : WorldObject
                 if (!player.CanReadScroll(this, out var spec))
                 {
                     var msg = "";
-                    if (spec)
+                    if (spec && playerSkill.AdvancementClass < SkillAdvancementClass.Specialized)
                     {
                         msg = $"You must be specialized in {playerSkill.Skill.ToSentence()} to learn this spell!";
                     }


### PR DESCRIPTION
- For scrolls that require magic specialization, display the correct error message if player's skill is too low.