### PR TITLE
fix: adjust wield req training checks

### DIFF
--- a/apps/server/Factories/LootGenerationFactory_Caster.cs
+++ b/apps/server/Factories/LootGenerationFactory_Caster.cs
@@ -176,7 +176,7 @@ public static partial class LootGenerationFactory
         wo.WieldSkillType = GetWeaponPrimaryAttribute((Skill)wo.WieldSkillType2);
 
         wo.WieldRequirements2 = WieldRequirement.Training;
-        wo.WieldDifficulty2 = 1;
+        wo.WieldDifficulty2 = 2;
 
         // Roll Elemental Damage Mod
         TryMutateCasterWeaponDamage(wo, profile, out var damagePercentile);

--- a/apps/server/Factories/LootGenerationFactory_Melee.cs
+++ b/apps/server/Factories/LootGenerationFactory_Melee.cs
@@ -151,7 +151,7 @@ public static partial class LootGenerationFactory
         wo.WieldSkillType = GetWeaponPrimaryAttribute(wo.WeaponSkill);
 
         wo.WieldRequirements2 = WieldRequirement.Training;
-        wo.WieldDifficulty2 = 1;
+        wo.WieldDifficulty2 = 2;
         wo.WieldSkillType2 = GetWeaponWieldSkill(wo.WeaponSkill);
 
         // Max damage

--- a/apps/server/Factories/LootGenerationFactory_Missile.cs
+++ b/apps/server/Factories/LootGenerationFactory_Missile.cs
@@ -125,7 +125,7 @@ public static partial class LootGenerationFactory
         wo.WieldSkillType = GetWeaponPrimaryAttribute(wo.WeaponSkill);
 
         wo.WieldRequirements2 = WieldRequirement.Training;
-        wo.WieldDifficulty2 = 1;
+        wo.WieldDifficulty2 = 2;
         wo.WieldSkillType2 = GetWeaponWieldSkill(wo.WeaponSkill);
 
         // Damage

--- a/apps/server/Factories/LootGenerationFactory_Spells.cs
+++ b/apps/server/Factories/LootGenerationFactory_Spells.cs
@@ -77,7 +77,7 @@ public partial class LootGenerationFactory
         var procSpellId = SpellId.Undef;
 
         wo.WieldRequirements3 = WieldRequirement.Training;
-        wo.WieldDifficulty3 = 1;
+        wo.WieldDifficulty3 = 2;
 
         var warSpell = ThreadSafeRandom.Next(0, 1) == 0 ? true : false;
         if (warSpell)

--- a/apps/server/WorldObjects/Player_Inventory.cs
+++ b/apps/server/WorldObjects/Player_Inventory.cs
@@ -3110,7 +3110,7 @@ partial class Player
                 // verify skill is trained / specialized
                 skill = GetCreatureSkill(ConvertToMoASkill((Skill)skillOrAttribute), false);
 
-                if ((int)skill.AdvancementClass < difficulty + 1)
+                if ((int)skill.AdvancementClass < difficulty)
                 {
                     return WeenieError.SkillTooLow;
                 }

--- a/apps/server/WorldObjects/SpellTransference.cs
+++ b/apps/server/WorldObjects/SpellTransference.cs
@@ -589,7 +589,7 @@ public class SpellTransference : Stackable
                             target.ProcSpell = (uint)spellToAddId;
                             target.ProcSpellSelfTargeted = spellToAdd.IsSelfTargeted;
                             target.WieldRequirements2 = WieldRequirement.Training;
-                            target.WieldDifficulty2 = 1;
+                            target.WieldDifficulty2 = 2;
 
                             if (spellToAdd.School == MagicSchool.LifeMagic)
                             {


### PR DESCRIPTION
- Client seems to use wield difficulty 1 and 2 to display a "Training required" message on gear. We were previously assigning diff 1 to lootgen gear for training req when we should've be assigning diff 2.
- Lootgen now assigns correct diff 2 for training wield reqs.
- Previously obtained loot with trained wield reqs will be equippable without trained skill.