### PR TITLE
fix: opal jewel proc rate

### DIFF
--- a/apps/server/WorldObjects/Jewel_Bonuses.cs
+++ b/apps/server/WorldObjects/Jewel_Bonuses.cs
@@ -653,7 +653,7 @@ partial class Jewel
             return;
         }
 
-        var chance = (float)playerAttacker.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearManasteal);
+        var chance = (float)playerAttacker.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearManasteal) / 100;
 
         if (playerAttacker == defender || !(chance >= ThreadSafeRandom.Next(0.0f, 1.0f)))
         {


### PR DESCRIPTION
- Needed to divide the rating by 100.