### PR TITLE
feat: monster lethality and attribute mod for life

### DIFF
--- a/apps/server/WorldObjects/SpellProjectile.cs
+++ b/apps/server/WorldObjects/SpellProjectile.cs
@@ -715,6 +715,8 @@ public class SpellProjectile : WorldObject
         combatAbilityDamageMod -= CheckForCombatAbilityBatteryDamagePenalty(sourcePlayer);
         combatAbilityDamageMod += CheckForCombatAbilityEnchantedWeaponDamageBonus(sourcePlayer);
 
+        var lethalityMod = Convert.ToSingle(sourceCreature!.ArchetypeLethality ?? 1.0f);
+
         var specDefenseMod = CheckForMagicDefenseSpecDefenseMod(targetPlayer, sourceCreature);
 
         var levelScalingMod = GetLevelScalingMod(sourceCreature, target, targetPlayer);
@@ -760,6 +762,7 @@ public class SpellProjectile : WorldObject
                 * wardMod
                 * resistedMod
                 * specDefenseMod
+                * lethalityMod
                 * levelScalingMod;
         }
         // war/void magic projectiles

--- a/apps/server/WorldObjects/WorldObject_Magic.cs
+++ b/apps/server/WorldObjects/WorldObject_Magic.cs
@@ -1011,6 +1011,16 @@ partial class WorldObject
 
         ResetRatingElementalistQuestStamps(player);
 
+        var lethalityMod = Convert.ToSingle(creature!.ArchetypeLethality ?? 1.0f);
+        tryBoost = Convert.ToInt32(tryBoost * lethalityMod);
+
+        // Attribute Mod
+        if (player is not null)
+        {
+            var attributeMod = player.GetAttributeMod(weapon, true, targetCreature);
+            tryBoost = Convert.ToInt32(tryBoost * attributeMod);
+        }
+
         // LEVEL SCALING - Reduces harms against enemies, and restoration for players
         var scalar = LevelScaling.GetPlayerBoostSpellScalar(player, targetCreature);
         tryBoost = (int)(tryBoost * scalar);
@@ -1555,6 +1565,13 @@ partial class WorldObject
 
                 destVitalChange = CheckForCombatAbilityBatteryVitalTransferPenalty(combatAbility, player, srcVitalChange, ref destVitalChange);
                 destVitalChange = CheckForCombatAbilityEnchantVitalTransferBonus(player, srcVitalChange, ref destVitalChange);
+            }
+
+            // Attribute Mod
+            if (player is not null)
+            {
+                var attributeMod = player.GetAttributeMod(weapon, true, targetCreature);
+                destVitalChange = Convert.ToUInt32(destVitalChange * attributeMod);
             }
 
             // LEVEL SCALING - Reduce Drain effectiveness vs. monsters, and increase vs. player


### PR DESCRIPTION
- Monster spell casting is now affected by the lethality archetype.
- Boost and Transfer spells are now affected by attribute mod (self).