### PR TITLE
feat: improve level scaling formula

### DIFF
--- a/apps/server/Entity/DamageEvent.cs
+++ b/apps/server/Entity/DamageEvent.cs
@@ -706,9 +706,15 @@ public class DamageEvent
 
     private static float GetLevelScalingMod(Creature attacker, Creature defender, Player playerDefender)
     {
-        return playerDefender != null
+        var monsterHealthScalingMod = playerDefender != null
             ? LevelScaling.GetMonsterDamageDealtHealthScalar(playerDefender, attacker)
             : LevelScaling.GetMonsterDamageTakenHealthScalar(attacker, defender);
+
+        var timeToKillMonsterScalingMod = playerDefender != null
+            ? LevelScaling.GetMonsterDamageTakenTtkScalar(playerDefender, attacker)
+            : LevelScaling.GetMonsterDamageTakenTtkScalar(attacker, defender);
+
+        return monsterHealthScalingMod * timeToKillMonsterScalingMod;
     }
 
     private float GetCriticalChance(Creature attacker, Creature defender)


### PR DESCRIPTION
- Add AvgTimeToKill factor based on data for different tiers.
- Increases damage of higher level payers when being scaled down to lower levels.
- Example: will increase damage that a level 50 deals vs a level 10 by 50% (when shrouded).