### PR TITLE
feat: add sharpen ammo crafting for woodworking

### DIFF
--- a/apps/server/Entity/DamageEvent.cs
+++ b/apps/server/Entity/DamageEvent.cs
@@ -21,6 +21,7 @@ public class DamageEvent
     private readonly ILogger _log = Log.ForContext<DamageEvent>();
 
     private float _accuracyMod;
+    private float _ammoEffectMod;
     private List<WorldObject> _armor;
     private float _armorMod;
     private Creature _attacker;
@@ -553,7 +554,7 @@ public class DamageEvent
         _attackHeightDamageBonus += GetHighAttackHeightBonus(playerAttacker);
         _ratingElementalDamageBonus = Jewel.HandleElementalBonuses(playerAttacker, DamageType);
         _levelScalingMod = GetLevelScalingMod(attacker, defender, playerDefender);
-
+        _ammoEffectMod = GetAmmoEffectMod(Weapon, playerAttacker);
 
         if (!_pkBattle)
         {
@@ -806,6 +807,7 @@ public class DamageEvent
                * _combatAbilityMultishotDamagePenalty
                * _combatAbilityProvokeDamageBonus
                * _combatAbilityFuryDamageBonus
+               * _ammoEffectMod
                * _levelScalingMod;
     }
 
@@ -1857,6 +1859,27 @@ public class DamageEvent
         }
 
         return 0.0f;
+    }
+
+    public static float GetAmmoEffectMod(WorldObject weapon, Player player)
+    {
+        if (weapon is {IsAmmoLauncher: not true} || player is null)
+        {
+            return 1.0f;
+        }
+
+        var ammo = player.GetEquippedAmmo() as Ammunition;
+
+        if (ammo?.AmmoEffectUsesRemaining is null)
+        {
+            return 1.0f;
+        }
+
+        switch ((AmmoEffect)(ammo.AmmoEffect ?? 0))
+        {
+            case AmmoEffect.Sharpened: return 1.1f;
+            default: return 1.0f;
+        }
     }
 
     private bool WeaponIsSpecialized(Player playerAttacker)

--- a/apps/server/Managers/RecipeManager.cs
+++ b/apps/server/Managers/RecipeManager.cs
@@ -813,6 +813,10 @@ public partial class RecipeManager
                 Jewel.HandleUnsocketing(player, source, target);
                 break;
 
+            case 0x39000004: // Ammo Sharpening
+                Ammunition.HandleAmmoSharpening(player, source, target);
+                break;
+
             default:
                 _log.Error(
                     $"{player.Name}.RecipeManager.Tinkering_ModifyItem({source.Name} ({source.Guid}), {target.Name} ({target.Guid})) - unknown mutation id: {dataId:X8}"

--- a/apps/server/Network/Structure/AppraiseInfo.cs
+++ b/apps/server/Network/Structure/AppraiseInfo.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using ACE.Database;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
@@ -834,6 +835,9 @@ public class AppraiseInfo
         // Attack Mod for Bows
         SetBowAttackModUseText(wo);
 
+        // Ammo
+        SetAmmoEffectUseText(wo);
+
         SetWeaponWarMagicUseText();
         SetWeaponLifeMagicUseText();
         SetWeaponPhysicalDefenseUseText(wo);
@@ -1511,6 +1515,41 @@ public class AppraiseInfo
         }
 
         _hasExtraPropertiesText = true;
+    }
+
+    private void SetAmmoEffectUseText(WorldObject wo)
+    {
+        if (!PropertiesInt.TryGetValue(PropertyInt.AmmoEffectUsesRemaining, out var ammoEffectUsesRemaining) ||
+            !(ammoEffectUsesRemaining > 0))
+        {
+            return;
+        }
+
+        if (!PropertiesInt.TryGetValue(PropertyInt.AmmoEffect, out var ammoEffect) ||
+            !(ammoEffect >= 0))
+        {
+            return;
+        }
+
+        var ammoEffectString = Regex.Replace(((AmmoEffect)ammoEffect).ToString(), "(\\B[A-Z])", " $1");
+
+        if (wo.WeenieType is WeenieType.Ammunition)
+        {
+            _extraPropertiesText += $"Ammo Effect: {ammoEffectString}\n";
+            _extraPropertiesText += $"Effect Uses Remaining: {ammoEffectUsesRemaining}\n";
+
+            var propertyDescription = "";
+
+            switch ((AmmoEffect)ammoEffect)
+            {
+                case AmmoEffect.Sharpened:
+                    propertyDescription = "~Sharpened: Increases damage by 10%.";
+                    break;
+            }
+
+            _additionalPropertiesLongDescriptionsText += $"{propertyDescription}";
+            _hasExtraPropertiesText = true;
+        }
     }
 
     private void SetSpellProcRateUseText(WorldObject wo)

--- a/apps/server/WorldObjects/Ammunition.cs
+++ b/apps/server/WorldObjects/Ammunition.cs
@@ -1,5 +1,8 @@
 using ACE.Entity;
+using ACE.Entity.Enum;
+using ACE.Entity.Enum.Properties;
 using ACE.Entity.Models;
+using ACE.Server.Network.GameMessages.Messages;
 
 namespace ACE.Server.WorldObjects;
 
@@ -39,4 +42,92 @@ public class Ammunition : Stackable
     {
         // Do nothing
     }
+
+    public static void HandleAmmoSharpening(Player player, WorldObject source, WorldObject target)
+    {
+        var targetAmmo = target as Ammunition;
+        if (targetAmmo is null)
+        {
+            player.Session.Network.EnqueueSend(
+                new GameMessageSystemChat(
+                    $"{target.Name} is not a type of ammunition.",
+                    ChatMessageType.Craft
+                )
+            );
+
+            return;
+        }
+
+        var playerskill = (int)player.GetCreatureSkill((Skill.Woodworking)).Current;
+        var difficulty = GetSharpenDifficulty(target.WieldDifficulty ?? 0);
+
+        if (playerskill < difficulty)
+        {
+            player.Session.Network.EnqueueSend(
+                new GameMessageSystemChat(
+                    $"You are not skilled enough with Woodworking to sharpen the {target.Name}.",
+                    ChatMessageType.Craft
+                )
+            );
+        }
+        else
+        {
+            var maxUses = target.AmmoType is ACE.Entity.Enum.AmmoType.Arrow ? 1000 : 500;
+
+            target.SetProperty(PropertyInt.AmmoEffect, (int)WorldObjects.AmmoEffect.Sharpened);
+            target.SetProperty(PropertyInt.AmmoEffectUsesRemaining, maxUses);
+        }
+    }
+
+    private static int GetSharpenDifficulty(int targetWieldDifficulty)
+    {
+        switch (targetWieldDifficulty)
+        {
+            case 270: return 175;
+            case 250: return 150;
+            case 230: return 130;
+            case 215: return 115;
+            case 200: return 100;
+            case 175: return 75;
+            case 125: return 25;
+            default: return 0;
+        }
+    }
+
+    public int? AmmoEffectUsesRemaining
+    {
+        get => GetProperty(PropertyInt.AmmoEffectUsesRemaining);
+        set
+        {
+            if (!value.HasValue)
+            {
+                RemoveProperty(PropertyInt.AmmoEffectUsesRemaining);
+            }
+            else
+            {
+                SetProperty(PropertyInt.AmmoEffectUsesRemaining, value.Value);
+            }
+        }
+    }
+
+    public int? AmmoEffect
+    {
+        get => GetProperty(PropertyInt.AmmoEffect);
+        set
+        {
+            if (!value.HasValue)
+            {
+                RemoveProperty(PropertyInt.AmmoEffect);
+            }
+            else
+            {
+                SetProperty(PropertyInt.AmmoEffect, value.Value);
+            }
+        }
+    }
+}
+
+public enum AmmoEffect
+{
+    Sharpened = 0
 }

--- a/apps/server/WorldObjects/Player_Missile.cs
+++ b/apps/server/WorldObjects/Player_Missile.cs
@@ -517,6 +517,16 @@ partial class Player
         // hide previously held ammo
         EnqueueBroadcast(new GameMessagePickupEvent(ammo));
 
+        if (ammo is Ammunition {AmmoEffectUsesRemaining: not null} ammunition)
+        {
+            ammunition.AmmoEffectUsesRemaining -= 1;
+
+            if (ammunition.AmmoEffectUsesRemaining < 1)
+            {
+                ammunition.AmmoEffectUsesRemaining = null;
+            }
+        }
+
         if (ammo.UnlimitedUse)
         {
             return;

--- a/libs/entity/Enum/Properties/PropertyInt.cs
+++ b/libs/entity/Enum/Properties/PropertyInt.cs
@@ -824,6 +824,8 @@ public enum PropertyInt : ushort
     RemainingConfirmations = 465,
     SigilTrinketType = 466,
     TrophyQuality = 467,
+    AmmoEffect = 468,
+    AmmoEffectUsesRemaining = 469,
 
     [ServerOnly]
     PCAPRecordedAutonomousMovement = 8007,


### PR DESCRIPTION
- Woodworkers can use an Intricate Carving tool on ammo to give it a 10% damage bonus for a limited number of uses. Requires sufficient woodworking skill for each ammo wield tier.
- More "ammo effect" recipes to come.