### PR TITLE
fix: set correct animation length for calculating missile stamina usage

### DIFF
--- a/apps/server/Entity/StaminaTable.cs
+++ b/apps/server/Entity/StaminaTable.cs
@@ -58,8 +58,9 @@ public static class StaminaTable
         var powerLevelMod = (float)Math.Pow(powerAccuracyLevel, 2);
 
         // WeaponAnimationLength mod
-        var divisor = 4.0f;
+        var divisor = 5.0f;
         var animLengthMod = (animLength + powerAccuracyLevel) / (divisor + powerAccuracyLevel);
+        //Console.WriteLine($"AnimLengthMod: ({animLength} + {powerAccuracyLevel}) / ({divisor} + {powerAccuracyLevel}) = {animLengthMod}");
 
         // Weight class resource penalty mod
         var weightClassPenaltyMod = weightClassPenalty ?? 1.0f;
@@ -67,14 +68,15 @@ public static class StaminaTable
         // Final calculation
         var finalCost = baseCost * powerLevelMod * animLengthMod * weightClassPenaltyMod;
 
-        //Console.WriteLine($"GetStaminaCost()\n" +
-        //    $" -Base Cost: {baseCost}\n" +
-        //    $" -WeaponTier: {weaponTier}\n" +
-        //    $" -WeightClassPenalty: {weightClassPenalty}\n" +
-        //    $" -PowerLevel: {powerAccuracyLevel} PowerLevelMod: {powerLevelMod}\n" +
-        //    $" -WeaponAnim: {animLength} AnimLengthMod: {animLengthMod}\n" +
-        //    $" -Final Cost: {finalCost}\n\n" +
-        //    $" Cost per min: {60 / (animLength + powerAccuracyLevel) * finalCost}");
+        // Console.WriteLine($"GetStaminaCost()\n" +
+        //     $" -Base Cost: {baseCost}\n" +
+        //     $" -WeaponTier: {weaponTier}\n" +
+        //     $" -WeightClassPenalty: {weightClassPenalty}\n" +
+        //     $" -PowerLevel: {powerAccuracyLevel} PowerLevelMod: {powerLevelMod}\n" +
+        //     $" -WeaponAnim: {animLength} AnimLengthMod: {animLengthMod}\n" +
+        //     $" -Final Cost: {finalCost}\n" +
+        //     $" -AttacksPerMin: {60 / (animLength + powerAccuracyLevel)}\n" +
+        //     $" -Cost per min: {(60 / (animLength + powerAccuracyLevel)) * finalCost}");
 
         return finalCost;
     }

--- a/apps/server/WorldObjects/Player_Missile.cs
+++ b/apps/server/WorldObjects/Player_Missile.cs
@@ -378,8 +378,8 @@ partial class Player
         var linkTime = MotionTable.GetAnimationLength(MotionTableId, motionStance, MotionCommand.Reload, MotionCommand.Ready);
         //var cycleTime = MotionTable.GetCycleLength(MotionTableId, CurrentMotionState.Stance, MotionCommand.Ready);
 
-        LastAttackAnimationLength = launchTime + reloadTime + linkTime;
-        //Console.WriteLine($"LaunchTime: {launchTime}, Reload: {reloadTime} (BaseReload: {reloadTime*animSpeed}), Link: {linkTime}");
+        LastAttackAnimationLength = linkTime;
+        //Console.WriteLine($"LaunchTime: {launchTime}, Reload: {reloadTime} (BaseReload: {reloadTime*animSpeed}), Link: {linkTime}, TOTAL: {LastAttackAnimationLength}");
 
         var staminaCost = GetAttackStamina(GetAccuracyRange(), (float)LastAttackAnimationLength, weapon);
         UpdateVitalDelta(Stamina, -staminaCost);


### PR DESCRIPTION
-  Additionally, slightly reduce stamina costs of all melee/missile attacks.