### PR TITLE
feat: add xDpsPerTier factor to level scaling formula

### DIFF
--- a/apps/server/Entity/DamageEvent.cs
+++ b/apps/server/Entity/DamageEvent.cs
@@ -715,7 +715,11 @@ public class DamageEvent
             ? 1.0f
             : LevelScaling.GetMonsterDamageTakenTtkScalar(attacker, defender);
 
-        return monsterHealthScalingMod * timeToKillMonsterScalingMod;
+        var monsterDpsPerTierScalingMod = playerDefender != null
+            ? 1.0f
+            : LevelScaling.GetMonsterDamageDealtDpsPerTierScalar(attacker, defender);
+
+        return monsterHealthScalingMod * timeToKillMonsterScalingMod * monsterDpsPerTierScalingMod;
     }
 
     private float GetCriticalChance(Creature attacker, Creature defender)

--- a/apps/server/WorldObjects/Creature_ArchetypeSystem.cs
+++ b/apps/server/WorldObjects/Creature_ArchetypeSystem.cs
@@ -23,7 +23,7 @@ partial class Creature
     private static readonly int[] enemyAssessDeception = { 10, 50, 100, 150, 200, 250, 300, 350, 400 };
     private static readonly int[] enemyRun = { 10, 100, 150, 200, 250, 300, 400, 500, 600 };
 
-    private static readonly float[] enemyDamage = { 1.0f, 1.5f, 3.0f, 3.3f, 3.6f, 3.9f, 4.2f, 5.0f, 6.0f }; // percentage of player health to be taken per second after all stats (of player and enemy) are considered
+    private static readonly float[] enemyDamage = { 1.0f, 1.5f, 2.0f, 2.5f, 3.0f, 3.5f, 4.0f, 4.5f, 5.0f }; // percentage of player health to be taken per second after all stats (of player and enemy) are considered
 
     private static readonly int[] avgPlayerHealth = { 25, 45, 95, 125, 155, 185, 215, 245, 320 };
     private static readonly float[] avgPlayerArmorReduction = { 0.75f, 0.57f, 0.40f, 0.31f, 0.25f, 0.21f, 0.18f, 0.16f, 0.1f };

--- a/apps/server/WorldObjects/SpellProjectile.cs
+++ b/apps/server/WorldObjects/SpellProjectile.cs
@@ -949,7 +949,11 @@ public class SpellProjectile : WorldObject
             ? 1.0f
             : LevelScaling.GetMonsterDamageTakenTtkScalar(attacker, defender);
 
-        return monsterHealthScalingMod * timeToKillMonsterScalingMod;
+        var monsterDpsPerTierScalingMod = playerDefender != null
+            ? 1.0f
+            : LevelScaling.GetMonsterDamageDealtDpsPerTierScalar(attacker, defender);
+
+        return monsterHealthScalingMod * timeToKillMonsterScalingMod * monsterDpsPerTierScalingMod;
     }
 
     /// <summary>


### PR DESCRIPTION
- Prevents higher level players from receiving dramatically more damage than lower level players when being scaled down to a low level.
- Additionally, smoothened out dps per tier curve for archetype system.