### PR TITLE
fix: cantrip level chances for t3+

### DIFF
--- a/apps/server/Factories/Tables/Cantrips/CantripChance.cs
+++ b/apps/server/Factories/Tables/Cantrips/CantripChance.cs
@@ -59,17 +59,16 @@ public static class CantripChance
 
     private static ChanceTable<int> T5_CantripLevel = new ChanceTable<int>() { (1, 0.50f), (2, 0.50f), };
 
-    private static ChanceTable<int> T6_CantripLevel = new ChanceTable<int>() { (1, 0.40f), (2, 0.50f), (3, 0.10f), };
+    private static ChanceTable<int> T6_CantripLevel = new ChanceTable<int>() { (1, 0.25f), (2, 0.74f), (3, 0.01f), };
 
-    private static ChanceTable<int> T7_CantripLevel = new ChanceTable<int>() { (1, 0.20f), (2, 0.40f), (3, 0.40f), };
+    private static ChanceTable<int> T7_CantripLevel = new ChanceTable<int>() { (2, 0.75f), (3, 0.25f), };
 
-    private static ChanceTable<int> T8_CantripLevel = new ChanceTable<int>() { (2, 0.40f), (3, 0.50f), (4, 0.10f) };
+    private static ChanceTable<int> T8_CantripLevel = new ChanceTable<int>() { (2, 0.50f), (3, 0.49f), (4, 0.01f) };
 
     private static readonly List<ChanceTable<int>> _cantripLevels = new List<ChanceTable<int>>()
     {
         T1_CantripLevel,
         T2_CantripLevel,
-        T3_CantripLevel,
         T3_CantripLevel,
         T4_CantripLevel,
         T5_CantripLevel,


### PR DESCRIPTION
- t3: Minor = 75%, Major = 25%.
- t4: Minor = 50%, Major = 50%.
- t5: Minor = 25%, Major = 74%, Epic = 1%.
- t6 Major = 75%, Epic = 25%.
- t7: Major = 50%, Epic = 49%, Leg = 1%.