### PR TITLE
feat: send players to sanctuary after reconnecting while in a capstone

### DIFF
--- a/apps/server/WorldObjects/Player_Location.cs
+++ b/apps/server/WorldObjects/Player_Location.cs
@@ -1033,22 +1033,7 @@ partial class Player
             return;
         }
 
-        var landblock = LandblockManager.GetLandblock(landblockId, false);
-
-        if (landblock.CapstonePlayers.ContainsKey(player.Name))
-        {
-            landblock.CapstonePlayers[player.Name] = 0;
-            return;
-        }
-
-        if (landblock.CapstonePlayers.Keys.Count < 9)
-        {
-            Landblock.CapstoneTeleport(player, landblock);
-        }
-        else
-        {
-            session.Player.Location = new Position(session.Player.Sanctuary);
-        }
+        session.Player.Location = new Position(session.Player.Sanctuary);
     }
 
     public static Dictionary<int, string> DungeonList = new Dictionary<int, string>


### PR DESCRIPTION
- Instead of placing player at the beginning of the dungeon, send them to sanctuary position.