### PR TITLE
fix; sigil trinket issues

### DIFF
--- a/apps/server/Entity/SigilTrinketEvent.cs
+++ b/apps/server/Entity/SigilTrinketEvent.cs
@@ -40,6 +40,11 @@ public class SigilTrinketEvent
     /// </summary>
     public bool HasReadySigilTrinketEffect(SigilTrinket sigilTrinket)
     {
+        if (sigilTrinket.Structure < 1)
+        {
+            return false;
+        }
+
         if (!SigilTrinketValidationChecks(sigilTrinket))
         {
             return false;
@@ -499,7 +504,12 @@ public class SigilTrinketEvent
     // --- VALIDATION CHECKS ---
     private bool SigilTrinketValidationChecks(SigilTrinket sigilTrinket)
     {
-        if (sigilTrinket.SigilTrinketEffectId == null || sigilTrinket.WieldSkillType == null)
+        if (sigilTrinket.SigilTrinketEffectId is null || sigilTrinket.SigilTrinketEffectId != EffectId)
+        {
+            return false;
+        }
+
+        if (sigilTrinket.WieldSkillType is null || (Skill)sigilTrinket.WieldSkillType != Skill)
         {
             return false;
         }


### PR DESCRIPTION
- Prevent trinket from triggering if there are no remaining uses.
- Prevent effects from a different trinket from firing when more than one trinket is equipped.