### PR TITLE
fix: reload bank object on close

### DIFF
--- a/apps/server/Entity/Landblock.cs
+++ b/apps/server/Entity/Landblock.cs
@@ -1527,6 +1527,33 @@ public class Landblock : IActor
         actionQueue.Clear();
     }
 
+    public void ReloadObject(WorldObject wo)
+    {
+        ProcessPendingWorldObjectAdditionsAndRemovals();
+        SaveDB();
+
+        if (!wo.BiotaOriginatedFromOrHasBeenSavedToDatabase())
+        {
+            wo.Destroy(false);
+        }
+        else
+        {
+            RemoveWorldObjectInternal(wo.Guid);
+        }
+
+        ProcessPendingWorldObjectAdditionsAndRemovals();
+        actionQueue.Clear();
+
+        DatabaseManager.World.ClearCachedInstancesByLandblock(Id.Landblock);
+
+        Task.Run(() =>
+        {
+            CreateWorldObjects();
+
+            SpawnDynamicShardObjects();
+        });
+    }
+
     private void SaveDB()
     {
         var biotas = new Collection<(Biota biota, ReaderWriterLockSlim rwLock)>();

--- a/apps/server/WorldObjects/Storage.cs
+++ b/apps/server/WorldObjects/Storage.cs
@@ -164,6 +164,9 @@ public class Storage : Container
             cont?.SortWorldObjectsIntoInventory(worldObjects);
         }
 
+        EncumbranceVal = 0;
+        Value = 0;
+
         SendBankVaultInventory(BankUser);
     }
 
@@ -242,7 +245,22 @@ public class Storage : Container
 
         FinishClose(BankUser);
 
+        var itemsToSend = new List<GameMessage>();
+
+        foreach (var item in Inventory.Values)
+        {
+            itemsToSend.Add(new GameMessageDeleteObject(item));
+        }
+
+        player.Session.Network.EnqueueSend(itemsToSend.ToArray());
+
         BankUser = null;
+
+        var landblock = CurrentLandblock;
+        if (landblock is not null)
+        {
+            landblock.ReloadObject(this);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
- Reload bank object on close to prevent caching issues.
- Always set bank encumbrance and value to 0 during bank transactions.