### PR TITLE
feat: add custom stackables for vendor transactions

### DIFF
--- a/libs/entity/Models/WeenieExtensions.cs
+++ b/libs/entity/Models/WeenieExtensions.cs
@@ -205,6 +205,10 @@ public static class WeenieExtensions
             case WeenieType.Gem:
             case WeenieType.Missile:
             case WeenieType.SpellComponent:
+            case WeenieType.SpellPurge:
+            case WeenieType.SpellTransference:
+            case WeenieType.ArmorPatch:
+            case WeenieType.UpgradeKit:
 
                 return true;
         }


### PR DESCRIPTION
Allow pearls, upgrade kits, and armor patches to be purchased as stacks with only 1 backpack slot available.