### PR TITLE
feat: make all capstones similar difficulty, regardless of tier

### DIFF
--- a/apps/server/WorldObjects/Creature_ArchetypeSystem.cs
+++ b/apps/server/WorldObjects/Creature_ArchetypeSystem.cs
@@ -1185,9 +1185,9 @@ partial class Creature
     {
         // target enemy damage per second. If enemy uses nearby player scaling, use highest tier enemy damage.
         var weightedEnemyDamage = (enemyDamage[tier] + (enemyDamage[tier + 1] - enemyDamage[tier]) * statWeight);
-        if (UseNearbyPlayerScaling is true)
+        if (UseNearbyPlayerScaling is true && weightedEnemyDamage < 5.0f)
         {
-            weightedEnemyDamage = enemyDamage.Max();
+            weightedEnemyDamage = 5.0f; // level 50 enemy dps
         }
 
         var weightedPlayerHealth = (

--- a/apps/server/WorldObjects/Creature_ArchetypeSystem.cs
+++ b/apps/server/WorldObjects/Creature_ArchetypeSystem.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
 using ACE.Entity.Models;
@@ -1182,8 +1183,13 @@ partial class Creature
 
     private double GetNewBaseDamage(int tier, float statWeight, double lethality)
     {
-        // target enemy damage per second
+        // target enemy damage per second. If enemy uses nearby player scaling, use highest tier enemy damage.
         var weightedEnemyDamage = (enemyDamage[tier] + (enemyDamage[tier + 1] - enemyDamage[tier]) * statWeight);
+        if (UseNearbyPlayerScaling is true)
+        {
+            weightedEnemyDamage = enemyDamage.Max();
+        }
+
         var weightedPlayerHealth = (
             avgPlayerHealth[tier] + (avgPlayerHealth[tier + 1] - avgPlayerHealth[tier]) * statWeight
         );


### PR DESCRIPTION
- Use the same % damage dealt formulas for all tiers when calculating monster damage, if they are enemies that utilize nearby-player-scaling. (this effects all capstone monsters and some overland monsters such as ON).
- The result will increase damage of lower level capstone monsters substantially, bringing them on par with level 50 capstone monsters. Level 50 capstones will not see a change.