### PR TITLE
fix: use absolute value for SpellDamageReceived with sigil trinket ef…

### DIFF
--- a/apps/server/WorldObjects/Player_SigilTrinket.cs
+++ b/apps/server/WorldObjects/Player_SigilTrinket.cs
@@ -342,7 +342,7 @@ partial class Player
             Player = this,
             Target = spellSource,
             TriggerSpell = spell,
-            SpellDamageReceived = Math.Max(damage, 0),
+            SpellDamageReceived = Math.Abs(damage),
             OnCrit = onCrit,
             Skill = skill,
             EffectId = effectId


### PR DESCRIPTION
…fects

- Harms send negative values so absolute value needs to used to have correct damage reference for sigil trinket effects.