### PR TITLE
feat: update monster MoveToHome mechanics

### DIFF
--- a/apps/server/WorldObjects/Creature_Navigation.cs
+++ b/apps/server/WorldObjects/Creature_Navigation.cs
@@ -8,6 +8,7 @@ using ACE.Server.Entity.Actions;
 using ACE.Server.Network.GameMessages.Messages;
 using ACE.Server.Physics.Animation;
 using ACE.Server.Physics.Extensions;
+using Time = ACE.Common.Time;
 
 namespace ACE.Server.WorldObjects;
 
@@ -535,5 +536,22 @@ partial class Creature
 
         // broadcast blip to new position
         SendUpdatePosition(true);
+    }
+
+    private void CheckCannotReachTarget()
+    {
+        const double timeToReset = 10.0;
+        var cannotReachTarget = LastAttackedCreatureTime != 0 && LastAttackedCreatureTime < Time.GetUnixTime() - timeToReset;
+        var meleeCombatMode = CombatMode == CombatMode.Melee;
+
+        if (!meleeCombatMode || !cannotReachTarget)
+        {
+            return;
+        }
+        LastAttackedCreatureTime = 0;
+
+        SetMaxVitals();
+
+        MoveToHome();
     }
 }

--- a/apps/server/WorldObjects/Monster_Navigation.cs
+++ b/apps/server/WorldObjects/Monster_Navigation.cs
@@ -574,6 +574,8 @@ partial class Creature
 
         if (homeDistSq > HomeRadiusSq)
         {
+            SetMaxVitals();
+
             MoveToHome();
         }
     }

--- a/apps/server/WorldObjects/Monster_Tick.cs
+++ b/apps/server/WorldObjects/Monster_Tick.cs
@@ -61,6 +61,8 @@ partial class Creature
 
         HandleFindTarget();
 
+        CheckCannotReachTarget();
+
         CheckMissHome(); // tickrate?
 
         if (currentUnixTime > NextMonsterThreatTickTime)


### PR DESCRIPTION
- When a monster tries to return to their home location, they now fully heal instantly.
- If a monster is attempting to melee attack a player and doesn't land an attack within 10 seconds, they will move to their home location and heal.