### PR TITLE
feat: add monster boundary system

### DIFF
--- a/apps/server/WorldObjects/Hotspot.cs
+++ b/apps/server/WorldObjects/Hotspot.cs
@@ -66,6 +66,12 @@ public class Hotspot : WorldObject
             return;
         }
 
+        if (AffectsOnlyAis && creature is {ResetFromHotspot: true})
+        {
+            creature.SetMaxVitals();
+            creature.MoveToHome();
+        }
+
         if (!Creatures.Contains(creature.Guid))
         {
             //Console.WriteLine($"{Name} ({Guid}).OnCollideObject({creature.Name})");

--- a/apps/server/WorldObjects/WorldObject.cs
+++ b/apps/server/WorldObjects/WorldObject.cs
@@ -1803,4 +1803,20 @@ public abstract partial class WorldObject : IActor
             }
         }
     }
+
+    public bool? ResetFromHotspot
+    {
+        get => GetProperty(PropertyBool.ResetFromHotspot);
+        set
+        {
+            if (!value.HasValue)
+            {
+                RemoveProperty(PropertyBool.ResetFromHotspot);
+            }
+            else
+            {
+                SetProperty(PropertyBool.ResetFromHotspot, value.Value);
+            }
+        }
+    }
 }

--- a/libs/entity/Enum/Properties/PropertyBool.cs
+++ b/libs/entity/Enum/Properties/PropertyBool.cs
@@ -237,6 +237,7 @@ public enum PropertyBool : ushort
     RepeatConfirmation = 157,
     SilentCombat = 158,
     ReturnHomeWhenStuck = 159,
+    ResetFromHotspot = 160,
 
     /* custom */
     [ServerOnly]


### PR DESCRIPTION
- Allow creatures with the setting enabled to reset when they enter an AI hotspot.
  - Upon reset, creature full heals and runs to home position.