### PR TITLE
feat: add magic school primacy affix

### DIFF
--- a/apps/server/Network/Structure/AppraiseInfo.cs
+++ b/apps/server/Network/Structure/AppraiseInfo.cs
@@ -781,6 +781,7 @@ public class AppraiseInfo
         SetWardCleavingUseLongText(wo);
 
         SetStaminaReductionUseLongText(wo);
+        SetNoCompsRequiredSchoolUseLongText(wo);
 
         SetGearRatingText(PropertyInt.GearStrength, "Mighty Thews", "Grants a +(ONE) bonus to current Strength.");
         SetGearRatingText(PropertyInt.GearEndurance, "Perseverance", "Grants a +(ONE) bonus to current Endurance.");
@@ -1897,6 +1898,39 @@ public class AppraiseInfo
         _additionalPropertiesLongDescriptionsText +=
             $"~ Ward Rending: Increases ward ignored by +{amountFormatted}%, additively. " +
             $"Value is based on wielder attack skill (20% to 40%).\n";
+    }
+
+    private void SetNoCompsRequiredSchoolUseLongText(WorldObject wo)
+    {
+        if (!PropertiesInt.TryGetValue(PropertyInt.NoCompsRequiredForMagicSchool, out var noCompsForPortalSpells) ||
+            noCompsForPortalSpells is 0)
+        {
+            return;
+        }
+
+        switch (noCompsForPortalSpells)
+        {
+            case (int)MagicSchool.WarMagic:
+                _additionalPropertiesList.Add("War Primacy");
+                _additionalPropertiesLongDescriptionsText +=
+                    $"~ War Primacy: War Magic spells cast do not require or consume components. Spells from other schools cannot be cast.";
+                break;
+            case (int)MagicSchool.LifeMagic:
+                _additionalPropertiesList.Add("Life Primacy");
+                _additionalPropertiesLongDescriptionsText +=
+                    $"~ Life Primacy: Life Magic spells cast do not require or consume components. Spells from other schools cannot be cast.";
+                break;
+            case (int)MagicSchool.PortalMagic:
+                _additionalPropertiesList.Add("Portal Primacy");
+                _additionalPropertiesLongDescriptionsText +=
+                    $"~ Portal Primacy: Portal Magic spells cast do not require or consume components. Spells from other schools cannot be cast.";
+                break;
+        }
+
+
+        _hasExtraPropertiesText = true;
+        _hasAdditionalProperties = true;
+
     }
 
     private void SetProtectionLevelsUseText(WorldObject wo)

--- a/apps/server/WorldObjects/Player_Inventory.cs
+++ b/apps/server/WorldObjects/Player_Inventory.cs
@@ -405,6 +405,9 @@ partial class Player
             manaScarab.OnEquip(this);
         }
 
+        // handle special cases
+        OnEquipNoCompsForPortalSpellsItem(item);
+
         HandleGearAttributeRatings(item, SpellId.RatingStrength, PropertyInt.GearStrength, SpellCategory.GearRatingStrength);
         HandleGearAttributeRatings(item, SpellId.RatingEndurance, PropertyInt.GearEndurance, SpellCategory.GearRatingEndurance);
         HandleGearAttributeRatings(item, SpellId.RatingCoordination, PropertyInt.GearCoordination, SpellCategory.GearRatingCoordination);
@@ -413,6 +416,23 @@ partial class Player
         HandleGearAttributeRatings(item, SpellId.RatingSelf, PropertyInt.GearSelf, SpellCategory.GearRatingSelf);
 
         return true;
+    }
+
+    private void OnEquipNoCompsForPortalSpellsItem(WorldObject item)
+    {
+        if (item is {NoCompsRequiredForMagicSchool: null})
+        {
+            return;
+        }
+
+        Session.Player.SpellComponentsRequired = false;
+        Session.Player.EnqueueBroadcast(
+            new GameMessagePublicUpdatePropertyBool(
+                Session.Player,
+                PropertyBool.SpellComponentsRequired,
+                Session.Player.SpellComponentsRequired
+            )
+        );
     }
 
     private void HandleGearAttributeRatings(WorldObject item, SpellId spellId, PropertyInt propertyInt, SpellCategory spellCategory)
@@ -631,6 +651,8 @@ partial class Player
             }
         }
 
+        OnDequipNoCompsForPortalSpellsItem(item);
+
         HandleGearAttributeRatings(item, SpellId.RatingStrength, PropertyInt.GearStrength, SpellCategory.GearRatingStrength);
         HandleGearAttributeRatings(item, SpellId.RatingEndurance, PropertyInt.GearEndurance, SpellCategory.GearRatingEndurance);
         HandleGearAttributeRatings(item, SpellId.RatingCoordination, PropertyInt.GearCoordination, SpellCategory.GearRatingCoordination);
@@ -639,6 +661,23 @@ partial class Player
         HandleGearAttributeRatings(item, SpellId.RatingSelf, PropertyInt.GearSelf, SpellCategory.GearRatingSelf);
 
         return true;
+    }
+
+    private void OnDequipNoCompsForPortalSpellsItem(WorldObject item)
+    {
+        if (item is {NoCompsRequiredForMagicSchool: null})
+        {
+            return;
+        }
+
+        Session.Player.SpellComponentsRequired = true;
+        Session.Player.EnqueueBroadcast(
+            new GameMessagePublicUpdatePropertyBool(
+                Session.Player,
+                PropertyBool.SpellComponentsRequired,
+                Session.Player.SpellComponentsRequired
+            )
+        );
     }
 
     /// <summary>

--- a/apps/server/WorldObjects/Player_Magic.cs
+++ b/apps/server/WorldObjects/Player_Magic.cs
@@ -654,7 +654,15 @@ partial class Player
         // portal spells never fizzle
         if (spell.School == MagicSchool.PortalMagic)
         {
-            castingPreCheckStatus = CastingPreCheckStatus.Success;
+            castingPreCheckStatus = GetEquippedWand() is { NoCompsRequiredForMagicSchool: (int)MagicSchool.PortalMagic, ItemCurMana: 0 } ? CastingPreCheckStatus.CastFailed : CastingPreCheckStatus.Success;
+        }
+
+        // casting non-portal spells with a NoCompsForPortalSpells caster will always fizzle
+        if (spell.School is not MagicSchool.WarMagic && GetEquippedWand() is { NoCompsRequiredForMagicSchool: (int)MagicSchool.WarMagic}
+            || spell.School is not MagicSchool.LifeMagic && GetEquippedWand() is { NoCompsRequiredForMagicSchool: (int)MagicSchool.LifeMagic}
+            || spell.School is not MagicSchool.PortalMagic && GetEquippedWand() is { NoCompsRequiredForMagicSchool: (int)MagicSchool.PortalMagic})
+        {
+            castingPreCheckStatus = CastingPreCheckStatus.CastFailed;
         }
 
         // build-in spells never fizzle
@@ -1193,6 +1201,47 @@ partial class Player
             default:
                 EnqueueBroadcast(new GameMessageScript(Guid, PlayScript.Fizzle, 0.5f));
                 SendWeenieError(WeenieError.YourSpellFizzled);
+Console.WriteLine(caster?.NoCompsRequiredForMagicSchool);
+                switch (caster.NoCompsRequiredForMagicSchool)
+                {
+                    case (int)MagicSchool.WarMagic:
+                        if (spell.School is MagicSchool.LifeMagic or MagicSchool.PortalMagic)
+                        {
+                            SendMessage($"{caster.Name} can only cast War Magic spells.");
+                        }
+
+                        if (caster is { ItemCurMana: 0 } && spell.School is MagicSchool.WarMagic)
+                        {
+                            SendMessage($"{caster.Name} cannot cast spells while it is out of mana.");
+                        }
+
+                        break;
+                    case (int)MagicSchool.LifeMagic:
+                        if (spell.School is MagicSchool.WarMagic or MagicSchool.PortalMagic)
+                        {
+                            SendMessage($"{caster.Name} can only cast Life Magic spells.");
+                        }
+
+                        if (caster is { ItemCurMana: 0 } && spell.School is MagicSchool.LifeMagic)
+                        {
+                            SendMessage($"{caster.Name} cannot cast spells while it is out of mana.");
+                        }
+
+                        break;
+                    case (int)MagicSchool.PortalMagic:
+                        if (spell.School is MagicSchool.LifeMagic or MagicSchool.WarMagic)
+                        {
+                            SendMessage($"{caster.Name} can only cast Portal Magic spells.");
+                        }
+
+                        if (caster is { ItemCurMana: 0 } && spell.School is MagicSchool.PortalMagic)
+                        {
+                            SendMessage($"{caster.Name} cannot cast spells while it is out of mana.");
+                        }
+
+                        break;
+                }
+
                 break;
         }
 

--- a/apps/server/WorldObjects/WorldObject_Properties.cs
+++ b/apps/server/WorldObjects/WorldObject_Properties.cs
@@ -9018,4 +9018,20 @@ partial class WorldObject
             }
         }
     }
+
+    public int? NoCompsRequiredForMagicSchool
+    {
+        get => GetProperty(PropertyInt.NoCompsRequiredForMagicSchool);
+        set
+        {
+            if (!value.HasValue)
+            {
+                RemoveProperty(PropertyInt.NoCompsRequiredForMagicSchool);
+            }
+            else
+            {
+                SetProperty(PropertyInt.NoCompsRequiredForMagicSchool, value.Value);
+            }
+        }
+    }
 }

--- a/libs/entity/Enum/Properties/PropertyInt.cs
+++ b/libs/entity/Enum/Properties/PropertyInt.cs
@@ -829,6 +829,7 @@ public enum PropertyInt : ushort
     AltCurrencyValue = 470,
     GearYellowFury = 471,
     GearBlueFury = 472,
+    NoCompsRequiredForMagicSchool = 473,
 
     [ServerOnly]
     PCAPRecordedAutonomousMovement = 8007,


### PR DESCRIPTION
- Casters with this setting enable can cast spells of a specific school without the need for spell components.
- Spells from other schools cannot be cast.