### PR TITLE
feat: adjust how AL and WL mutate

### DIFF
--- a/apps/server/Factories/LootGenerationFactory.cs
+++ b/apps/server/Factories/LootGenerationFactory.cs
@@ -1115,14 +1115,20 @@ public static partial class LootGenerationFactory
         }
 
         // Armor Base Stats
-        if (wo.ItemType is ItemType.Armor or ItemType.Clothing)
+        if (wo.ItemType is ItemType.Armor or ItemType.Clothing or ItemType.Jewelry)
         {
             if (wo.ArmorLevel != null)
             {
                 var baseStat = wo.ArmorLevel.Value;
-                var bonusRange = (baseStat * 1.1f) - baseStat;
+                var baseStatPerTier = baseStat;
+
+                if (tier > 0)
+                {
+                    baseStatPerTier /= tier;
+                }
+
                 var roll = GetDiminishingRoll(null, lootQuality);
-                var bonus = bonusRange * roll;
+                var bonus = baseStatPerTier * roll;
                 var final = (int)Math.Round(baseStat + bonus);
 
                 wo.SetProperty(PropertyInt.ArmorLevel, final);
@@ -1131,9 +1137,15 @@ public static partial class LootGenerationFactory
             if (wo.WardLevel != null)
             {
                 var baseStat = wo.WardLevel.Value;
-                var bonusRange = (baseStat * 1.1f) - baseStat;
+                var baseStatPerTier = baseStat;
+
+                if (tier > 0)
+                {
+                    baseStatPerTier /= tier;
+                }
+
                 var roll = GetDiminishingRoll(null, lootQuality);
-                var bonus = bonusRange * roll;
+                var bonus = baseStatPerTier * roll;
                 var final = (int)Math.Round(baseStat + bonus);
 
                 wo.SetProperty(PropertyInt.WardLevel, final);
@@ -2874,22 +2886,22 @@ public static partial class LootGenerationFactory
     {
         switch (requiredLevel)
         {
-            case < 10:
-                return 1;
-            case 20:
+            case 10:
                 return 2;
-            case 30:
+            case 20:
                 return 3;
-            case 40:
+            case 30:
                 return 4;
-            case 50:
+            case 40:
                 return 5;
-            case 75:
+            case 50:
                 return 6;
-            case 100:
+            case 75:
                 return 7;
-            default:
+            case 100:
                 return 8;
+            default:
+                return 1;
         }
     }
 

--- a/apps/server/Factories/LootGenerationFactory_Clothing.cs
+++ b/apps/server/Factories/LootGenerationFactory_Clothing.cs
@@ -197,7 +197,7 @@ public static partial class LootGenerationFactory
             }
         }
 
-        AssignArmorLevel(wo, profile.Tier, armorType);
+        AssignArmorLevel(wo, profile);
 
         // Set Stamina/Mana Penalty
         var mod = GetArmorResourcePenalty(wo) * (wo.ArmorSlots ?? 1);
@@ -238,8 +238,10 @@ public static partial class LootGenerationFactory
     /// Used values given at https://asheron.fandom.com/wiki/Loot#Armor_Levels for setting the AL mod values
     /// so as to not exceed the values listed in that table
     /// </summary>
-    private static void AssignArmorLevel(WorldObject wo, int tier, LootTables.ArmorType armorType)
+    private static void AssignArmorLevel(WorldObject wo, TreasureDeath treasureDeath)
     {
+        var tier = treasureDeath.Tier;
+
         if (wo.ArmorType == null)
         {
             _log.Warning($"[LOOT] Missing PropertyInt.ArmorType on loot item {wo.WeenieClassId} - {wo.Name}");
@@ -323,12 +325,9 @@ public static partial class LootGenerationFactory
                 break;
         }
 
-        // Add some variance (+/- 10%)
-        var variance = 1.0f + ThreadSafeRandom.Next(-0.1f, 0.1f);
-
         // Final Calculation
-        var newArmorLevel = baseArmorLevel * (tier - 1) * variance;
-        var newWardLevel = baseWardLevel * (tier - 1) * armorSlots * variance;
+        var newArmorLevel = baseArmorLevel * (tier - 1) + GetDiminishingRoll(treasureDeath) * baseArmorLevel;
+        var newWardLevel = baseWardLevel * (tier - 1) * armorSlots + GetDiminishingRoll(treasureDeath) * baseWardLevel;
 
         // Assign levels
         wo.SetProperty(PropertyInt.ArmorLevel, (int)newArmorLevel);
@@ -453,7 +452,7 @@ public static partial class LootGenerationFactory
         // looks like society armor always had impen on it
         AssignMagic(wo, profile, roll, true, isMagical);
 
-        AssignArmorLevel(wo, profile.Tier, LootTables.ArmorType.SocietyArmor);
+        AssignArmorLevel(wo, profile);
 
         wo.LongDesc = GetLongDesc(wo);
 

--- a/apps/server/WorldObjects/UpgradeKit.cs
+++ b/apps/server/WorldObjects/UpgradeKit.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using ACE.Entity;
 using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
@@ -261,8 +262,8 @@ public class UpgradeKit : Stackable
             var currentRequiredLevel = target.WieldDifficulty ?? 1;
             var newRequiredLevel = GetRequiredLevelFromPlayerTier((player));
 
-            var currentTier = LootGenerationFactory.GetTierFromRequiredLevel(currentRequiredLevel);
-            var newTier = LootGenerationFactory.GetTierFromRequiredLevel(newRequiredLevel);
+            var currentTier = LootGenerationFactory.GetTierFromRequiredLevel(currentRequiredLevel) - 1;
+            var newTier = LootGenerationFactory.GetTierFromRequiredLevel(newRequiredLevel) - 1;
 
             ScaleUpJewelryWardLevel(target, currentTier, newTier);
             ScaleUpJewelryRating(PropertyInt.GearMaxHealth, target, currentTier, newTier);
@@ -607,7 +608,8 @@ public class UpgradeKit : Stackable
 
         var jewelryBaseWardLevelPerTier = LootTables.JewelryBaseWardLeverPerTier;
 
-        var currentBaseLevelFromTier = jewelryBaseWardLevelPerTier[currentTier];
+        var necklaceMultiplier = target.ValidLocations is EquipMask.Jewelry ? 2.0f : 1.0f;
+        var currentBaseLevelFromTier = jewelryBaseWardLevelPerTier[currentTier] * necklaceMultiplier;
         var currentRange = jewelryBaseWardLevelPerTier[currentTier + 1] - jewelryBaseWardLevelPerTier[currentTier];
         var currentRoll = currentBaseStat - currentBaseLevelFromTier;
 
@@ -736,21 +738,8 @@ public class UpgradeKit : Stackable
     /// </summary>
     private static void ScaleUpSpecialRatings(WorldObject target, int newTier)
     {
-        var ratingList = new List<PropertyInt>();
+        var ratingList = (from id in GearRatingIds let ratingValue = target.GetProperty(id) where ratingValue != null select id).ToList();
         // var totalRatings = 0; TODO: To be used if jewel ratings get added to mutable quest item system
-
-        foreach (var id in GearRatingIds)
-        {
-            var ratingValue = target.GetProperty(id);
-
-            if (ratingValue == null)
-            {
-                continue;
-            }
-
-            ratingList.Add(id);
-            //totalRatings += ratingValue.Value;
-        }
 
         if (ratingList.Count == 0)
         {


### PR DESCRIPTION
- Rather than doing a +/- 10% variance on mutation, allow armor and ward to roll between the base amount of the current tier and the base amount of the next tier. (with diminishing chances for a high roll)
- Update Upgrade Kit logic to reflect this change.