### PR TITLE
feat: overhaul cleave mechanic

### DIFF
--- a/apps/server/Entity/DamageEvent.cs
+++ b/apps/server/Entity/DamageEvent.cs
@@ -36,6 +36,7 @@ public class DamageEvent
     private float _attributeMod;
     private float _baseDamage;
     private BaseDamageMod _baseDamageMod;
+    private bool _cleaveHits;
     private float _combatAbilityFuryDamageBonus;
     private float _combatAbilityMultishotDamagePenalty;
     private float _combatAbilityProvokeDamageBonus;
@@ -143,21 +144,22 @@ public class DamageEvent
         Creature defender,
         WorldObject damageSource,
         MotionCommand? attackMotion = null,
-        AttackHook attackHook = null
+        AttackHook attackHook = null,
+        bool cleaveHits = false
     )
     {
         var damageEvent = new DamageEvent { _attackMotion = attackMotion, _attackHook = attackHook };
 
         damageSource ??= attacker;
 
-        damageEvent.DoCalculateDamage(attacker, defender, damageSource);
+        damageEvent.DoCalculateDamage(attacker, defender, damageSource, cleaveHits);
 
         damageEvent.HandleLogging(attacker, defender);
 
         return damageEvent;
     }
 
-    private float DoCalculateDamage(Creature attacker, Creature defender, WorldObject damageSource)
+    private float DoCalculateDamage(Creature attacker, Creature defender, WorldObject damageSource, bool cleaveHits = false)
     {
         if (PropertyManager.GetBool("debug_level_scaling_system").Item && (attacker is Player || defender is Player))
         {
@@ -195,8 +197,9 @@ public class DamageEvent
         }
 
         var mitigation = GetMitigation(attacker, defender);
+        var cleaveMod = cleaveHits ? 0.5f : 1.0f;
 
-        Damage = _damageBeforeMitigation * mitigation;
+        Damage = _damageBeforeMitigation * mitigation * cleaveMod;
         _damageMitigated = _damageBeforeMitigation - Damage;
 
         PostDamageMitigationEffects(attacker, defender, damageSource);

--- a/apps/server/Factories/LootGenerationFactory_Melee.cs
+++ b/apps/server/Factories/LootGenerationFactory_Melee.cs
@@ -1675,17 +1675,13 @@ public static partial class LootGenerationFactory
 
         // target dps per tier
         var targetBaseDps = GetWeaponBaseDps(wo.Tier ?? 1);
-        if (wo.CleaveTargets > 0)
-        {
-            targetBaseDps *= 0.6f;
-        }
 
         // animation speed
         var baseAnimLength = WeaponAnimationLength.GetAnimLength(wo);
 
-        int[] avgQuickPerTier = { 45, 65, 93, 118, 140, 160, 180, 195 };
+        int[] avgQuickPerTier = [45, 65, 93, 118, 140, 160, 180, 195];
         var quick = (float)avgQuickPerTier[profile.Tier - 1];
-        var speedMod = 0.8f + (1 - (wo.WeaponTime.Value / 100.0)) + quick / 600;
+        var speedMod = 1.0f + (1 - (wo.WeaponTime.Value / 100.0)) + quick / 600;
         var effectiveAttacksPerSecond = 1 / (baseAnimLength / speedMod);
 
         if (wo.IsTwoHanded || wo.W_AttackType == AttackType.DoubleStrike)
@@ -1698,7 +1694,7 @@ public static partial class LootGenerationFactory
         }
         else if (wo.W_WeaponType == WeaponType.Thrown)
         {
-            var reloadLength = 0.9777778f;
+            const float reloadLength = 0.9777778f;
             effectiveAttacksPerSecond = 1 / (baseAnimLength - reloadLength + (reloadLength * speedMod));
         }
 
@@ -1710,7 +1706,7 @@ public static partial class LootGenerationFactory
         var averageBaseMaxDamage = targetAverageHitDamage / ((((1 - weaponVariance) + 1) / 2 * 0.9) + 0.2);
 
         // get low-end and high-end max damage range
-        var damageRangePerTier = 0.25;
+        const double damageRangePerTier = 0.25;
         var maximumBaseMaxDamage = (averageBaseMaxDamage * 2) / (1.0 + (1 - damageRangePerTier));
         var minimumBaseMaxDamage = maximumBaseMaxDamage * (1 - damageRangePerTier);
 
@@ -1740,10 +1736,6 @@ public static partial class LootGenerationFactory
 
         // max possible damage (for workmanship)
         targetBaseDps = GetWeaponBaseDps(8);
-        if (wo.CleaveTargets > 1)
-        {
-            targetBaseDps *= 0.6f;
-        }
 
         targetAverageHitDamage = targetBaseDps / effectiveAttacksPerSecond;
         averageBaseMaxDamage = targetAverageHitDamage / ((((1 - weaponVariance) + 1) / 2 * 0.9) + 0.2);

--- a/apps/server/Factories/LootGenerationFactory_Missile.cs
+++ b/apps/server/Factories/LootGenerationFactory_Missile.cs
@@ -525,7 +525,7 @@ public static partial class LootGenerationFactory
 
         int[] avgQuickPerTier = { 45, 65, 93, 118, 140, 160, 180, 195 };
         var quick = (float)avgQuickPerTier[profile.Tier - 1];
-        var speedMod = 0.8f + (1 - (wo.WeaponTime.Value / 100.0)) + (quick / 600);
+        var speedMod = 1.0f + (1 - (wo.WeaponTime.Value / 100.0)) + (quick / 600);
         var effectiveAttacksPerSecond = 1 / (baseAnimLength - reloadAnimLength + (reloadAnimLength / speedMod));
 
         // target weapon hit damage
@@ -555,7 +555,7 @@ public static partial class LootGenerationFactory
         //    $" BaseAnimLength: {baseAnimLength}\n" +
         //    $" WeaponTime: {wo.WeaponTime.Value}\n" +
         //    $" Quick: {quick}\n" +
-        //    $" SpeedMod: {speedMod} FullFormula: 0.8f + ({1 - (wo.WeaponTime.Value /100.0)}) + ({quick / 600})\n" +
+        //    $" SpeedMod: {speedMod} FullFormula: 1.0f + ({1 - (wo.WeaponTime.Value /100.0)}) + ({quick / 600})\n" +
         //    $" AttacksPerSecond: {effectiveAttacksPerSecond}\n" +
         //    $" TargetAvgHitDamage: {targetAvgHitDamage}\n" +
         //    $" AmmoMaxDamage: {ammoMaxDamage} AmmoAvgDamage: {ammoAverageDamage} WeaponVariance: {weaponVariance}\n\n" +

--- a/apps/server/WorldObjects/Player_Combat.cs
+++ b/apps/server/WorldObjects/Player_Combat.cs
@@ -128,7 +128,7 @@ partial class Player
         }
     }
 
-    public DamageEvent DamageTarget(Creature target, WorldObject damageSource)
+    public DamageEvent DamageTarget(Creature target, WorldObject damageSource, bool cleaveHits = false)
     {
         if (target.Health.Current <= 0)
         {
@@ -152,7 +152,7 @@ partial class Player
             return null;
         }
 
-        var damageEvent = DamageEvent.CalculateDamage(this, target, damageSource);
+        var damageEvent = DamageEvent.CalculateDamage(this, target, damageSource, null, null, cleaveHits);
 
         CheckForSigilTrinketOnAttackEffects(target, damageEvent, Skill.TwoHandedCombat, (int)SigilTrinketTwohandedCombatEffect.Aggression);
         CheckForSigilTrinketOnAttackEffects(target, damageEvent, Skill.Shield, (int)SigilTrinketShieldEffect.Aggression);

--- a/apps/server/WorldObjects/Player_Melee.cs
+++ b/apps/server/WorldObjects/Player_Melee.cs
@@ -446,7 +446,7 @@ partial class Player
                             foreach (var cleaveHit in cleave)
                             {
                                 // target procs don't happen for cleaving
-                                DamageTarget(cleaveHit, weapon);
+                                DamageTarget(cleaveHit, weapon, true);
                             }
                         }
                     }


### PR DESCRIPTION
- Cleave hits deal 50% damage to additional targets.
- Lootgen Cleavers no longer have damage reduced to 60% upon generation.
- Also update base anim speed mod for lootgen weapon factory.