### PR TITLE
feat: rework proc spell logic

### DIFF
--- a/apps/server/Factories/LootGenerationFactory_Jewelry.cs
+++ b/apps/server/Factories/LootGenerationFactory_Jewelry.cs
@@ -130,7 +130,7 @@ public static partial class LootGenerationFactory
             var finalAmount = ratingRoll + minRating;
             var ratingPercentile = finalAmount / 14.0;
 
-            var type = ThreadSafeRandom.Next(1, 2); // disabled case 3 until finished development
+            var type = ThreadSafeRandom.Next(1, 2);
             switch (type)
             {
                 case 1:
@@ -138,22 +138,6 @@ public static partial class LootGenerationFactory
                     break;
                 case 2:
                     wo.GearMaxHealth = (int)finalAmount * 2;
-                    break;
-                case 3:
-                    if (!isMagical)
-                    {
-                        //Console.WriteLine(wo.NameWithMaterial);
-                        // Apply Spell
-                        var element = ThreadSafeRandom.Next(1, 7);
-                        var spellType = tier < 4 ? 1 : ThreadSafeRandom.Next(1, 4);
-                        //wo.ProcSpell = (uint)GetSpellDID(tier, element, spellType);
-                        wo.UiEffects = GetUiEffects(element);
-                        //wo.ProcSpellRate = (GetSpellProcChance(tier, spellType) / 2) * rollPercentile + (GetSpellProcChance(tier, spellType) / 2);
-                        wo.ItemDifficulty = GetSpellProcDifficulty(tier);
-                        wo.LongDesc =
-                            "This item cannot contain additional spells.\n\n(This item's ability is still in development)\n\n"
-                            + wo.LongDesc;
-                    }
                     break;
             }
             totalRollPercentile += ratingPercentile;
@@ -173,7 +157,7 @@ public static partial class LootGenerationFactory
             var finalAmount = ratingRoll + minRating;
             var ratingPercentile = finalAmount / 7.0;
 
-            var type = ThreadSafeRandom.Next(1, 2); // disabled case 3 until finished development
+            var type = ThreadSafeRandom.Next(1, 2);
             switch (type)
             {
                 case 1:
@@ -181,22 +165,6 @@ public static partial class LootGenerationFactory
                     break;
                 case 2:
                     wo.GearCritDamageResist = (int)finalAmount;
-                    break;
-                case 3:
-                    if (!isMagical)
-                    {
-                        //Console.WriteLine(wo.NameWithMaterial);
-                        // Apply Spell Proc DID and Proc Rate
-                        var element = ThreadSafeRandom.Next(1, 7);
-                        var spellType = tier < 4 ? 1 : ThreadSafeRandom.Next(1, 4);
-                        wo.ProcSpell = (uint)GetSpellDID(tier, element, spellType);
-                        wo.UiEffects = GetUiEffects(element);
-                        wo.ProcSpellRate =
-                            (GetSpellProcChance(tier, spellType) / 2) * rollPercentile
-                            + (GetSpellProcChance(tier, spellType) / 2);
-                        wo.ItemDifficulty = GetSpellProcDifficulty(tier);
-                        wo.LongDesc = "This item cannot contain additional spells.\n\n" + wo.LongDesc;
-                    }
                     break;
             }
             totalRollPercentile += ratingPercentile;
@@ -216,7 +184,7 @@ public static partial class LootGenerationFactory
             var finalAmount = ratingRoll + minRating;
             var ratingPercentile = finalAmount / 7.0;
 
-            var type = ThreadSafeRandom.Next(1, 2); // disabled case 3 until finished development
+            var type = ThreadSafeRandom.Next(1, 2);
             switch (type)
             {
                 case 1:
@@ -224,22 +192,6 @@ public static partial class LootGenerationFactory
                     break;
                 case 2:
                     wo.GearDamageResist = (int)finalAmount;
-                    break;
-                case 3:
-                    if (!isMagical)
-                    {
-                        //Console.WriteLine(wo.NameWithMaterial);
-                        // Apply Spell Proc DID and Proc Rate
-                        var element = ThreadSafeRandom.Next(1, 7);
-                        var spellType = tier < 4 ? 1 : ThreadSafeRandom.Next(1, 4);
-                        //wo.ProcSpell = (uint)GetSpellDID(tier, element, spellType, out var uiEffects);
-                        wo.UiEffects = GetUiEffects(element);
-                        //wo.ProcSpellRate = (GetSpellProcChance(tier, spellType) / 2) * rollPercentile + (GetSpellProcChance(tier, spellType) / 2);
-                        wo.ItemDifficulty = GetSpellProcDifficulty(tier);
-                        wo.LongDesc =
-                            "This item cannot contain additional spells.\n\n(This item's ability is still in development)\n\n"
-                            + wo.LongDesc;
-                    }
                     break;
             }
             totalRollPercentile += ratingPercentile;
@@ -683,26 +635,6 @@ public static partial class LootGenerationFactory
                 break;
         }
         return SpellId.Undef;
-    }
-
-    private static float GetSpellProcChance(int tier, int spellType)
-    {
-        float[,] procChances =
-        {
-            { 0.025f, 0.05f, 0.06f, 0.07f, 0.08f, 0.09f, 0.1f, 0.1f }, // Bolts
-            { 0.025f, 0.05f, 0.09f, 0.0175f, 0.21f, 0.25f, 0.3f, 0.3f }, // Streaks
-            { 0.025f, 0.05f, 0.06f, 0.07f, 0.08f, 0.09f, 0.1f, 0.1f }, // Volleys
-            { 0.025f, 0.05f, 0.06f, 0.07f, 0.08f, 0.09f, 0.1f, 0.1f }, // Blasts
-        };
-
-        return procChances[spellType - 1, tier - 1];
-    }
-
-    private static int GetSpellProcDifficulty(int tier)
-    {
-        int[] diff = { 50, 100, 200, 300, 350, 400, 450, 475 };
-
-        return diff[tier - 1];
     }
 
     private static int GetJewelryWorkmanship(WorldObject wo, double gearRatingPercentile)

--- a/apps/server/Factories/LootGenerationFactory_Spells.cs
+++ b/apps/server/Factories/LootGenerationFactory_Spells.cs
@@ -58,7 +58,8 @@ public partial class LootGenerationFactory
 
         if (itemProc != SpellId.Undef)
         {
-            var procRate = 0.025f + (0.025f * GetDiminishingRoll(profile));
+            var animLength = WeaponAnimationLength.GetWeaponAnimLength(wo) / 100;
+            var procRate = animLength + (animLength * GetDiminishingRoll(profile));
 
             var spell = new Server.Entity.Spell(itemProc);
             wo.ProcSpellRate = procRate;
@@ -76,14 +77,14 @@ public partial class LootGenerationFactory
         wo.WieldDifficulty3 = 2;
 
         var warSpell = ThreadSafeRandom.Next(0, 1) == 0 ? true : false;
-        if (warSpell)
-        {
-            wo.WieldSkillType3 = (int)Skill.WarMagic;
-        }
-        else
-        {
-            wo.WieldSkillType3 = (int)Skill.LifeMagic;
-        }
+        //if (warSpell)
+        //{
+        //    wo.WieldSkillType3 = (int)Skill.WarMagic;
+        //}
+        //else
+        //{
+        //    wo.WieldSkillType3 = (int)Skill.LifeMagic;
+        //}
 
         if (roll.IsMeleeWeapon)
         {

--- a/apps/server/Network/Structure/AppraiseInfo.cs
+++ b/apps/server/Network/Structure/AppraiseInfo.cs
@@ -1682,6 +1682,11 @@ public class AppraiseInfo
             return;
         }
 
+        if (wo.ProcSpell is null)
+        {
+            return;
+        }
+
         var wielder = (Creature)wo.Wielder;
 
         _extraPropertiesText += $"Cast on strike chance: {Math.Round(procSpellRate * 100, 1)}%\n";

--- a/apps/server/WorldObjects/Player_Combat.cs
+++ b/apps/server/WorldObjects/Player_Combat.cs
@@ -869,9 +869,12 @@ partial class Player
         return GetCombatType() == CombatType.Missile ? AccuracyLevel : PowerLevel;
     }
 
+    /// <summary>
+    /// Up to double proc chance based on power/accuracy bar amount
+    /// </summary>
     public float ScaleWithPowerAccuracyBar(float value)
     {
-        return GetPowerAccuracyBar() * value;
+        return 1.0f + GetPowerAccuracyBar();
     }
 
     public Sound GetHitSound(WorldObject source, BodyPart bodyPart)

--- a/apps/server/WorldObjects/SpellTransference.cs
+++ b/apps/server/WorldObjects/SpellTransference.cs
@@ -241,7 +241,8 @@ public class SpellTransference : Stackable
                 if (
                     !player.ConfirmationManager.EnqueueSend(
                         new Confirmation_CraftInteration(player.Guid, source.Guid, target.Guid),
-                        $"Extract {chosenSpell.Name} from {target.NameWithMaterial}, destroying it {consumed} in the process?\n\nIf this item contains more than one spell, selecting 'No' will cycle through the remaining spells.\n\n"
+                        $"Extract {chosenSpell.Name} from {target.NameWithMaterial}, destroying it {consumed} in the process?" +
+                        $"\n\nIf this item contains more than one spell, selecting 'No' will cycle through the remaining spells.\n\n"
                     )
                 )
                 {
@@ -322,7 +323,10 @@ public class SpellTransference : Stackable
                         pearl.Tier = target.Tier;
                         var wieldReq = LootGenerationFactory.GetWieldDifficultyPerTier(pearl.Tier ?? 1);
                         pearl.LongDesc =
-                            $"This pearl contains the spell {spell.Name}.\n\nIt may only be applied to {itemType} with a Wield Requirement of {wieldReq} or greater.\n\nAdding this spell will increase Spellcraft and Arcane Lore of the target item, and will bind it to your character.\n\nIf the spell is an on-hit weapon proc, it will add a Life or War Magic skill wield requirement as well.";
+                            $"This pearl contains the spell {spell.Name}." +
+                            $"\n\nIt may only be applied to {itemType} with a Wield Requirement of {wieldReq} or greater." +
+                            $"\n\nAdding this spell will increase Spellcraft and Arcane Lore of the target item, and will bind it to your character." +
+                            $"\n\nIf the spell is an on-hit weapon proc, it will add a Life or War Magic skill wield requirement as well.";
                         pearl.TinkerLog = $"{target.ItemType}";
                         pearl.UiEffects = ACE.Entity.Enum.UiEffects.BoostMana;
 
@@ -597,21 +601,24 @@ public class SpellTransference : Stackable
 
                         if (isProc)
                         {
-                            target.ProcSpellRate = 0.15f;
+                            var animLength = WeaponAnimationLength.GetWeaponAnimLength(target) / 100;
+                            var procRate = animLength + (animLength * LootGenerationFactory.GetDiminishingRoll());
+
+                            target.ProcSpellRate = procRate;
                             target.ProcSpell = (uint)spellToAddId;
                             target.ProcSpellSelfTargeted = spellToAdd.IsSelfTargeted;
-                            target.WieldRequirements2 = WieldRequirement.Training;
-                            target.WieldDifficulty2 = 2;
+                            //target.WieldRequirements2 = WieldRequirement.Training;
+                            //target.WieldDifficulty2 = 2;
 
-                            if (spellToAdd.School == MagicSchool.LifeMagic)
-                            {
-                                target.WieldSkillType2 = 33;
-                            }
+                            //if (spellToAdd.School == MagicSchool.LifeMagic)
+                            //{
+                            //    target.WieldSkillType2 = 33;
+                            //}
 
-                            if (spellToAdd.School == MagicSchool.WarMagic)
-                            {
-                                target.WieldSkillType2 = 34;
-                            }
+                            //if (spellToAdd.School == MagicSchool.WarMagic)
+                            //{
+                            //    target.WieldSkillType2 = 34;
+                            //}
                         }
                         else
                         {


### PR DESCRIPTION
- Melee/Missile lootgen with proc spells no longer requires trained magic skill.
- Lowered proc spell chance. Now based on weapon animation length.
- Up to doubled chance granted based on player magic skill vs spell difficulty.
- Hide proc spell chance text if weapon doesn't have a proc spell.