### PR TITLE
feat: update stealth mechanics

### DIFF
--- a/apps/server/WorldObjects/Creature_Combat.cs
+++ b/apps/server/WorldObjects/Creature_Combat.cs
@@ -760,6 +760,11 @@ partial class Creature
             playerAttacker.LastAttackTime = Time.GetUnixTime();
         }
 
+        if (this is Player player)
+        {
+            player.LastAttackReceivedTime = Time.GetUnixTime();
+        }
+
         numRecentAttacksReceived++;
     }
 
@@ -1067,6 +1072,11 @@ partial class Creature
             {
                 behind = true;
             }
+        }
+
+        if (this as Player is { IsAttackFromStealth: true})
+        {
+            behind = true;
         }
 
         var multiplier = 1.25f;

--- a/apps/server/WorldObjects/Gem.cs
+++ b/apps/server/WorldObjects/Gem.cs
@@ -304,14 +304,7 @@ public class Gem : Stackable
                     }
                     break;
                 case CombatAbility.Stealth:
-                    if (!player.IsStealthed)
-                    {
-                        player.BeginStealth();
-                    }
-                    else
-                    {
-                        player.EndStealth();
-                    }
+                    player.TryUseStealth();
                     break;
                 case CombatAbility.SlashThrustToggle:
                     if (player.ToggleSlashThrustSetting())

--- a/apps/server/WorldObjects/Player_Ability.cs
+++ b/apps/server/WorldObjects/Player_Ability.cs
@@ -1404,6 +1404,32 @@ partial class Player
         return true;
     }
 
+    public void TryUseStealth()
+    {
+        if (!IsStealthed)
+        {
+            var mostRecentAttackEventTime = LastAttackTime > LastAttackReceivedTime ? LastAttackTime : LastAttackReceivedTime;
+
+            if (Time.GetUnixTime() - mostRecentAttackEventTime < 10.0)
+            {
+                Session.Network.EnqueueSend(
+                    new GameMessageSystemChat(
+                        $"You cannot use Stealth if you have attacked, or received an attack, within the last 10 seconds.",
+                        ChatMessageType.Broadcast
+                    )
+                );
+
+                return;
+            }
+
+            BeginStealth();
+        }
+        else
+        {
+            EndStealth();
+        }
+    }
+
     public void TryUseShroud()
     {
         if (EnchantmentManager.HasSpell(5379))

--- a/apps/server/WorldObjects/Player_Combat.cs
+++ b/apps/server/WorldObjects/Player_Combat.cs
@@ -33,6 +33,8 @@ partial class Player
     public bool Attacking;
     public bool AttackCancelled;
 
+    public double LastAttackReceivedTime;
+
     public DateTime NextRefillTime;
 
     private DamageType LastHitReceivedDamageType;
@@ -2276,5 +2278,22 @@ partial class Player
         var finalDamageMod = 1 + damageMod * 0.01f;
 
         return finalDamageMod;
+    }
+
+    public bool IsBehindTargetCreature(Creature targetCreature)
+    {
+        if (targetCreature is null)
+        {
+            return false;
+        }
+
+        var angle = Math.Abs(targetCreature.GetAngle(this));
+
+        if (angle > 90)
+        {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/apps/server/WorldObjects/Player_Magic.cs
+++ b/apps/server/WorldObjects/Player_Magic.cs
@@ -884,8 +884,6 @@ partial class Player
     {
         //Console.WriteLine("DoCastSpell");
 
-        EndStealth();
-
         if (!MagicState.IsCasting)
         {
             return;
@@ -1162,6 +1160,11 @@ partial class Player
         if (pk_error != null)
         {
             castingPreCheckStatus = CastingPreCheckStatus.InvalidPKStatus;
+        }
+
+        if (IsStealthed)
+        {
+            EndStealth(null, true);
         }
 
         switch (castingPreCheckStatus)

--- a/apps/server/WorldObjects/Player_Melee.cs
+++ b/apps/server/WorldObjects/Player_Melee.cs
@@ -324,15 +324,7 @@ partial class Player
 
         if (IsStealthed)
         {
-            var angle = Math.Abs(creature.GetAngle(this));
-            if (angle < 90 || creature.CombatMode != CombatMode.NonCombat)
-            {
-                EndStealth();
-            }
-            else
-            {
-                EndStealth(null, true);
-            }
+            EndStealth(null, true);
         }
 
         // Disabled to allow use of items/abilities during attack animations

--- a/apps/server/WorldObjects/Player_Missile.cs
+++ b/apps/server/WorldObjects/Player_Missile.cs
@@ -268,6 +268,11 @@ partial class Player
                 var projectile = LaunchProjectile(launcher, ammo, target, origin, orientation, velocity);
                 UpdateAmmoAfterLaunch(ammo);
 
+                if (IsStealthed)
+                {
+                    EndStealth(null, true);
+                }
+
                 // Check for missile cleaves
                 var numCleaves = 0;
 

--- a/apps/server/WorldObjects/SpellProjectile.cs
+++ b/apps/server/WorldObjects/SpellProjectile.cs
@@ -632,6 +632,7 @@ public class SpellProjectile : WorldObject
         var criticalChance = GetWeaponMagicCritFrequency(weapon, sourceCreature, attackSkill, target);
         criticalChance += CheckForWarSpecCriticalChanceBonus(sourcePlayer, weapon);
         criticalChance = CheckForRatingReprisalAutoCrit(target, sourcePlayer, criticalChance);
+        criticalChance = CheckForStealthBackstabAutoCrit(target, sourcePlayer, criticalChance);
 
         if (ThreadSafeRandom.Next(0.0f, 1.0f) < criticalChance)
         {
@@ -1185,6 +1186,25 @@ public class SpellProjectile : WorldObject
         sourcePlayer.QuestManager.Erase($"{target.Guid}/Reprisal");
 
         return 1.0f;
+    }
+
+    /// <summary>
+    /// Backstab: Auto-crit from stealth.
+    /// </summary>
+    private static float CheckForStealthBackstabAutoCrit(Creature target, Player sourcePlayer, float criticalChance)
+    {
+        if (target is null || criticalChance == 1.0f)
+        {
+            return criticalChance;
+        }
+
+        if (sourcePlayer is { IsAttackFromStealth: true, BackstabIsActive: true} && sourcePlayer.IsBehindTargetCreature(target))
+        {
+            sourcePlayer.IsAttackFromStealth = false;
+            return 1.0f;
+        }
+
+        return criticalChance;
     }
 
     private float GetAbsorbMod(Creature target, WorldObject source)


### PR DESCRIPTION
- End stealth when attacking. (for magic, occurs when spell is released)
- Prevent stealth activation of player attacked or received an attack in the last 10 seconds.
- Tweak stealth backstab auto crit logic and add it to spell projectiles.