### PR TITLE
feat: vanish balancing

### DIFF
--- a/apps/server/WorldObjects/Creature_ArchetypeSystem.cs
+++ b/apps/server/WorldObjects/Creature_ArchetypeSystem.cs
@@ -20,7 +20,7 @@ partial class Creature
     private static readonly int[] enemyArmorWard = { 10, 20, 45, 68, 101, 152, 228, 342, 513 };
     private static readonly int[] enemyAttack = { 10, 60, 100, 150, 175, 200, 250, 350, 500 };
     private static readonly int[] enemyDefense = { 10, 60, 100, 150, 175, 200, 250, 350, 500 };
-    private static readonly int[] enemyAssessDeception = { 10, 40, 80, 120, 160, 200, 250, 300, 400 };
+    private static readonly int[] enemyAssessDeception = { 10, 60, 100, 150, 175, 200, 250, 350, 500 };
     private static readonly int[] enemyRun = { 10, 100, 150, 200, 250, 300, 400, 500, 600 };
 
     private static readonly float[] enemyDamage = { 1.0f, 2.0f, 3.0f, 4.5f, 6.0f, 7.0f, 8.0f, 9.0f, 10.0f }; // percentage of player health to be taken per second after all stats (of player and enemy) are considered

--- a/apps/server/WorldObjects/Monster_Awareness.cs
+++ b/apps/server/WorldObjects/Monster_Awareness.cs
@@ -672,7 +672,7 @@ partial class Creature
     /// <summary>
     /// Returns a list of attackable targets currently visible to this monster
     /// </summary>
-    private List<Creature> GetAttackTargets()
+    public List<Creature> GetAttackTargets()
     {
         var visibleTargets = new List<Creature>();
 
@@ -680,6 +680,12 @@ partial class Creature
         {
             // ensure attackable
             if (!creature.Attackable && creature.TargetingTactic == TargetingTactic.None || creature.Teleporting)
+            {
+                continue;
+            }
+
+            // check if player fooled this monster with vanish
+            if (creature is Player player && IsPlayerVanished(player))
             {
                 continue;
             }
@@ -692,7 +698,7 @@ partial class Creature
 
             var distSq = PhysicsObj.get_distance_sq_to_object(creature.PhysicsObj, true);
 
-            if (creature is Player player && player.TestStealth(this, distSq, $"{Name} sees you! You lose stealth."))
+            if (creature is Player targetPlayer && targetPlayer.TestStealth(this, distSq, $"{Name} sees you! You lose stealth."))
             {
                 continue;
             }
@@ -1108,5 +1114,55 @@ partial class Creature
         }
 
         return playerCombatAbility;
+    }
+
+    /// <summary>
+    /// Tracks players who have vanished from this monster's sight
+    /// Key: Player GUID, Value: Expiration time (unix timestamp)
+    /// </summary>
+    private Dictionary<uint, double> VanishedPlayers;
+
+    /// <summary>
+    /// Tracks player GUIDs who successfully fooled this monster with Vanish
+    /// These players cannot be targeted while their VanishIsActive is true
+    /// </summary>
+    private HashSet<uint> FooledByVanishPlayers;
+
+    /// <summary>
+    /// Marks a player as having successfully fooled this monster with Vanish
+    /// </summary>
+    /// <param name="player">The player who fooled the monster</param>
+    public void AddVanishedPlayer(Player player)
+    {
+        if (FooledByVanishPlayers == null)
+        {
+            FooledByVanishPlayers = new HashSet<uint>();
+        }
+
+        FooledByVanishPlayers.Add(player.Guid.Full);
+        _log.Information($"{Name} ({Guid}) - Player {player.Name} ({player.Guid}) successfully vanished from sight");
+    }
+
+    /// <summary>
+    /// Checks if a player is currently vanished from this monster's perspective
+    /// </summary>
+    /// <param name="player">The player to check</param>
+    /// <returns>True if the player fooled this monster and their vanish is still active</returns>
+    public bool IsPlayerVanished(Player player)
+    {
+        if (FooledByVanishPlayers == null || !FooledByVanishPlayers.Contains(player.Guid.Full))
+        {
+            return false;
+        }
+
+        // Check if the player's vanish is still active
+        if (!player.VanishIsActive)
+        {
+            // Vanish expired, remove from tracking
+            FooledByVanishPlayers.Remove(player.Guid.Full);
+            return false;
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
This pull request implements balancing changes to the Vanish ability in the game's combat system. The changes make the ability more strategic by introducing stamina costs based on enemy levels, allowing partial success scenarios, and adjusting monster perception values.

Changes:
- Modified Vanish ability to use a level-based stamina cost formula and support partial success outcomes
- Implemented per-monster vanish tracking so individual monsters can be fooled independently
- Increased monster perception difficulty by aligning enemyAssessDeception values with attack/defense progressions