### PR TITLE
BUG-Enhance-TownAttunement

### DIFF
--- a/apps/server/WorldObjects/Creature_Death.cs
+++ b/apps/server/WorldObjects/Creature_Death.cs
@@ -1371,15 +1371,6 @@ partial class Creature
         var nearestTown = Town.GetNearestTown(this);
         var simplifiedTownName = Town.GetSimplifiedTownString(nearestTown);
 
-        var playerTownStamps = player.QuestManager.GetCurrentSolves($"Quest{simplifiedTownName}");
-        var playerArrivedAtTownStamps = player.QuestManager.GetCurrentSolves($"Arrived{simplifiedTownName}");
-        var playerArrivedAtTown = playerArrivedAtTownStamps >= 1;
-
-        if (playerTownStamps >= 1 && !playerArrivedAtTown)
-        {
-            return;
-        }
-
         var townTier = Town.GetTownTier(nearestTown);
         var creatureTier = GetCreatureTier();
 

--- a/apps/server/WorldObjects/Player.cs
+++ b/apps/server/WorldObjects/Player.cs
@@ -41,6 +41,10 @@ public partial class Player : Creature, IPlayer
 
     public bool LastContact = true;
 
+    /// Debounce guard for town attunement overflow messaging (Quest{Town} completions > 5).
+    /// Stored as unix time (seconds) to prevent chat spam when multiple stamps occur in quick succession.
+    public uint LastTownAttunementMsgTime;
+
     public Player P_PetOwner;
 
     public LandblockId? CapstoneDungeon;


### PR DESCRIPTION
Removed gate on killing a Rare not giving town stamp if player has not "Arrived" in town and already has one or more town stamps.
Modified stamp messaging, stamps 1-4 give progress update, stamp 5 gives progress update and a final message, messages 6+ give a single "summary message"  (no spam)

Consecutive messages in short timespan spamming for messages over 6 has been repressed:

example:
Stamps 1-3
Tempered by the portal energies of Hebian-To, a slight resilience has taken shape within you. 
Tempered by the portal energies of Hebian-To, a minor resilience has taken shape within you.
Tempered by the portal energies of Hebian-To, a moderate resilience has taken shape within you.

Stamps 4-6
HebianChestDrudgeNest erased.
Tempered by the portal energies of Hebian-To, a major resilience has taken shape within you.
Tempered by the portal energies of Hebian-To, a significant resilience has taken shape within you. 
As your body steadies under the portal energy of Hebian-To, a final swirl rises and breaks around you.

Stamps 7-9
HebianChestDrudgeNest erased.
A familiar surge of portal energy passes through you, then fades. You sense the elder of Hebian-To expects your presence.

Stamps 10-12
HebianChestDrudgeNest erased.
A familiar surge of portal energy passes through you, then fades. You sense the elder of Hebian-To expects your presence.

Note only a single message is received after fifth attunement.