### PR TITLE
feat: frigid system, endgame, frore

### DIFF
--- a/apps/server/Entity/CreateListSetModifier.cs
+++ b/apps/server/Entity/CreateListSetModifier.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace ACE.Server.Entity;
 
 public class CreateListSetModifier
@@ -6,8 +8,15 @@ public class CreateListSetModifier
     public float Modifier;
 
     /// <summary>
-    /// Usually Modifier, unless Set.TrophyProbability * Modifier > 1.0
-    /// In which case, TrophyMod is capped so Set.TrophyProbability * TrophyMod = 1.0
+    /// Number of guaranteed draws from the set's trophy pool when
+    /// Set.TrophyProbability * Modifier exceeds 1.0 (i.e. floor of the effective probability).
+    /// </summary>
+    public int GuaranteedDrops;
+
+    /// <summary>
+    /// The fractional trophy modifier used for the final probabilistic draw.
+    /// When effective probability <= 1.0 this equals Modifier (normal behaviour).
+    /// When effective probability > 1.0 this represents only the leftover fraction.
     /// </summary>
     public float TrophyMod;
 
@@ -27,12 +36,14 @@ public class CreateListSetModifier
         Set = set;
         Modifier = modifier;
 
-        // calculate TrophyMod
         var trophyProbability = Set.TrophyProbability;
+        var effectiveProb = trophyProbability * modifier;
 
-        if (trophyProbability * modifier > 1.0f)
+        if (effectiveProb > 1.0f)
         {
-            TrophyMod = 1.0f / trophyProbability;
+            GuaranteedDrops = (int)Math.Floor(effectiveProb);
+            var fractionalProb = effectiveProb - GuaranteedDrops;
+            TrophyMod = fractionalProb > 0f ? fractionalProb / trophyProbability : 0.0f;
         }
         else
         {

--- a/apps/server/Entity/EsperMountainsZone.cs
+++ b/apps/server/Entity/EsperMountainsZone.cs
@@ -1,0 +1,101 @@
+using ACE.Entity;
+
+namespace ACE.Server.Entity;
+
+/// <summary>
+/// Defines the Northern Esper Mountains polygon zone used to gate full-strength Frigid damage.
+/// Outside this zone, Frigid environmental damage is scaled to 10% of its normal value.
+/// </summary>
+public static class EsperMountainsZone
+{
+    /// <summary>
+    /// Polygon vertices bounding the Northern Esper Mountains in AC map coordinates.
+    ///
+    /// Format: (northSouth, eastWest)
+    ///   northSouth — positive = North, negative = South  (e.g.  78.7 = 78.7N,  -5.0 = 5.0S)
+    ///   eastWest   — positive = East,  negative = West   (e.g.  3.2  = 3.2E,  -8.0  = 8.0W)
+    ///
+    /// How to read these from the game:
+    ///   The in-game "@loc" or map tooltip shows coordinates like "78.7N, 8.0W".
+    ///   Enter them here as  (78.7f, -8.0f).
+    ///
+    /// Vertices may be listed clockwise or counter-clockwise; the ray-cast algorithm handles both.
+    /// Add as many vertices as needed for an accurate boundary fit.
+    ///
+    /// TODO: Replace these placeholder vertices with the real Northern Esper Mountains boundary.
+    /// </summary>
+    private static readonly (float NS, float EW)[] NsEwVertices =
+    [
+        // (northSouth, eastWest) — e.g. 78.7N 8.0W → (78.7f, -8.0f)
+        (98.0f, 3.0f), // 12:00
+        (86.0f, 32.0f), // 2:00
+        (64.0f, 36.0f), // 3:00
+        (41.0f, -12.0f), // 6:00
+        (55.0f, -52.0f), // 8:00
+        (83.0f, -46.0f), // 10:00
+    ];
+
+    // World-space vertices pre-computed once from NsEwVertices.
+    // worldX = (EW + 102) * 240
+    // worldY = (NS + 102) * 240
+    private static readonly (float X, float Y)[] Vertices = BuildWorldVertices();
+
+    private static (float X, float Y)[] BuildWorldVertices()
+    {
+        var result = new (float X, float Y)[NsEwVertices.Length];
+        for (var i = 0; i < NsEwVertices.Length; i++)
+        {
+            result[i] = NsEwToWorld(NsEwVertices[i].NS, NsEwVertices[i].EW);
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Converts an AC map coordinate pair to world-space (X, Y).
+    /// Inverse of <c>PositionExtensions.GetMapCoords()</c>:
+    ///   worldX = (eastWest  + 102) * 240
+    ///   worldY = (northSouth + 102) * 240
+    /// </summary>
+    public static (float X, float Y) NsEwToWorld(float northSouth, float eastWest) =>
+        ((eastWest + 102f) * 240f, (northSouth + 102f) * 240f);
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the given world-space point lies inside
+    /// the Northern Esper Mountains polygon, using the ray-casting even-odd rule.
+    /// Cost is O(n) where n = number of vertices — negligible for any reasonable polygon size.
+    /// </summary>
+    public static bool Contains(float worldX, float worldY)
+    {
+        var inside = false;
+        var n = Vertices.Length;
+
+        for (int i = 0, j = n - 1; i < n; j = i++)
+        {
+            var (xi, yi) = Vertices[i];
+            var (xj, yj) = Vertices[j];
+
+            if ((yi > worldY) != (yj > worldY) &&
+                worldX < (xj - xi) * (worldY - yi) / (yj - yi) + xi)
+            {
+                inside = !inside;
+            }
+        }
+
+        return inside;
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the given <see cref="Position"/> lies inside
+    /// the Northern Esper Mountains polygon.
+    /// </summary>
+    public static bool Contains(Position position)
+    {
+        if (position is null)
+        {
+            return false;
+        }
+
+        var global = position.ToGlobal();
+        return Contains(global.X, global.Y);
+    }
+}

--- a/apps/server/Entity/EsperMountainsZone.cs
+++ b/apps/server/Entity/EsperMountainsZone.cs
@@ -22,8 +22,6 @@ public static class EsperMountainsZone
     /// Vertices may be listed clockwise or counter-clockwise; the ray-cast algorithm handles both.
     /// Add as many vertices as needed for an accurate boundary fit.
     ///
-    /// TODO: Replace these placeholder vertices with the real Northern Esper Mountains boundary.
-    /// </summary>
     private static readonly (float NS, float EW)[] NsEwVertices =
     [
         // (northSouth, eastWest) — e.g. 78.7N 8.0W → (78.7f, -8.0f)

--- a/apps/server/Factories/LootGenerationFactory.cs
+++ b/apps/server/Factories/LootGenerationFactory.cs
@@ -2965,7 +2965,7 @@ public static partial class LootGenerationFactory
         };
     }
 
-    public static void MutateTrophy(WorldObject wo, int tier)
+    public static void MutateTrophy(WorldObject wo, int tier, float frigidBonus = 1.0f)
     {
         if (wo.TrophyQuality == null)
         {
@@ -2973,6 +2973,12 @@ public static partial class LootGenerationFactory
         }
 
         var trophyQuality = WorkmanshipChance.Roll(tier);
+
+        // bonus trophy quality from monsters with frigid bonuses
+        var frigidBonusRoll = ThreadSafeRandom.Next(0.0f, frigidBonus - 1.0f);
+        var frigidBonusRounded = (int)Math.Round(trophyQuality + frigidBonusRoll, MidpointRounding.AwayFromZero);
+        trophyQuality = Math.Clamp(frigidBonusRounded, 1, 10);
+
         wo.SetProperty(PropertyInt.TrophyQuality, trophyQuality);
 
         var name = GetTrophyQualityName(trophyQuality);

--- a/apps/server/Factories/WorldObjectFactory.cs
+++ b/apps/server/Factories/WorldObjectFactory.cs
@@ -492,7 +492,7 @@ public static class WorldObjectFactory
     /// <summary>
     /// Creates a new WorldObject from a CreateList item
     /// </summary>
-    public static WorldObject CreateNewWorldObject(PropertiesCreateList item, int tier = 1)
+    public static WorldObject CreateNewWorldObject(PropertiesCreateList item, int tier = 1, float frigidBonus = 1.0f)
     {
         var isTreasure = (item.DestinationType & DestinationType.Treasure) != 0;
 
@@ -523,7 +523,7 @@ public static class WorldObjectFactory
 
         if (wo.TrophyQuality != null)
         {
-            LootGenerationFactory.MutateTrophy(wo, tier);
+            LootGenerationFactory.MutateTrophy(wo, tier, frigidBonus);
         }
 
         return wo;

--- a/apps/server/Managers/PropertyManager.cs
+++ b/apps/server/Managers/PropertyManager.cs
@@ -804,7 +804,7 @@ public static class DefaultPropertyManager
 
         ("road_speed_buff", new Property<bool>(true, "if TRUE, players receive a run speed buff while travelling on wilderness roads")),
 
-        ("frigid_damage", new Property<bool>(true, "if TRUE, players standing on snow terrain above elevation 100 take Frigid damage each heartbeat")),
+        ("frigid_damage", new Property<bool>(true, "if TRUE, players standing on snow terrain above elevation 200 take Frigid damage each heartbeat")),
 
         ("debug_threat_system", new Property<bool>(false, "enable this to see threat system console logging")),
         ("debug_crafting_system", new Property<bool>(false, "enable this to see crafting system console logging")),

--- a/apps/server/Managers/PropertyManager.cs
+++ b/apps/server/Managers/PropertyManager.cs
@@ -804,6 +804,8 @@ public static class DefaultPropertyManager
 
         ("road_speed_buff", new Property<bool>(true, "if TRUE, players receive a run speed buff while travelling on wilderness roads")),
 
+        ("frigid_damage", new Property<bool>(true, "if TRUE, players standing on snow terrain above elevation 100 take Frigid damage each heartbeat")),
+
         ("debug_threat_system", new Property<bool>(false, "enable this to see threat system console logging")),
         ("debug_crafting_system", new Property<bool>(false, "enable this to see crafting system console logging")),
         ("debug_loot_quality_system", new Property<bool>(false, "enable this to see loot quality system console logging")),

--- a/apps/server/Managers/RecipeManager.cs
+++ b/apps/server/Managers/RecipeManager.cs
@@ -861,6 +861,10 @@ public partial class RecipeManager
                 Ammunition.HandleAmmoSharpening(player, source, target);
                 break;
 
+            case 0x39000005: // Frigid Shard - GearFrigidProtection
+                target.SetProperty(PropertyInt.GearFrigidProtection, (target.GetProperty(PropertyInt.GearFrigidProtection) ?? 0) + 1);
+                break;
+
             default:
                 _log.Error(
                     $"{player.Name}.RecipeManager.Tinkering_ModifyItem({source.Name} ({source.Guid}), {target.Name} ({target.Guid})) - unknown mutation id: {dataId:X8}"
@@ -987,6 +991,11 @@ public partial class RecipeManager
             return false;
         }
 
+        if (!VerifyCustomRequirements(recipe, player, source, target))
+        {
+            return false;
+        }
+
         if (!VerifyRequirements(recipe, player, target, RequirementType.Target))
         {
             return false;
@@ -1003,6 +1012,30 @@ public partial class RecipeManager
         }
 
         // if (!RequiresEqualOrGreaterWork(player, source, target)) return false;
+
+        return true;
+    }
+
+    /// <summary>
+    /// Handles dynamic recipe requirements that cannot be expressed as static
+    /// <c>recipe_requirements_int</c> entries because they compare two per-item properties.
+    /// Add a new <c>case</c> here for each recipe that needs such a check.
+    /// </summary>
+    private static bool VerifyCustomRequirements(Recipe recipe, Player player, WorldObject source, WorldObject target)
+    {
+        switch (recipe.Id)
+        {
+            case 10011: // Frigid Shard - GearFrigidProtection must be < ArmorSlots
+                var currentFrigid = target.GetProperty(PropertyInt.GearFrigidProtection) ?? 0;
+                var armorSlots = target.GetProperty(PropertyInt.ArmorSlots) ?? 1;
+                if (currentFrigid >= armorSlots)
+                {
+                    player.Session.Network.EnqueueSend(new GameMessageSystemChat(
+                        "The armor has already reached its maximum Frigid Resistance capacity.", ChatMessageType.Craft));
+                    return false;
+                }
+                break;
+        }
 
         return true;
     }

--- a/apps/server/Network/Structure/AppraiseInfo.cs
+++ b/apps/server/Network/Structure/AppraiseInfo.cs
@@ -864,6 +864,7 @@ public class AppraiseInfo
         SetWardCleavingUseLongText(wo);
 
         SetStaminaReductionUseLongText(wo);
+        SetFrigidResistanceUseLongText(wo);
         SetNoCompsRequiredSchoolUseLongText(wo);
 
         SetGearRatingText(wo, PropertyInt.GearStrength, "Mighty Thews", "Grants +10 to current Strength, plus an additional +1 per equipped rating ((ONE) total).", 1.0f, 1.0f, 10);
@@ -1767,6 +1768,27 @@ public class AppraiseInfo
         _additionalPropertiesLongDescriptionsText +=
             $"~ Stamina Cost Reduction: Reduces stamina cost of attack by {ratingAmount}%. " +
             $"Roll range is based on item tier ({rangeMinAtTier}% to {rangeMinAtTier + 10}%).\n";
+    }
+
+    private void SetFrigidResistanceUseLongText(WorldObject wo)
+    {
+        //var hasFloat = PropertiesFloat.TryGetValue(PropertyFloat.GearFrigidProtectionMod, out var frigidProtectionMod) && frigidProtectionMod > 0.001f;
+        var hasInt = PropertiesInt.TryGetValue(PropertyInt.GearFrigidProtection, out var frigidProtection) && frigidProtection > 0;
+
+        if (!hasInt)
+        {
+            return;
+        }
+        
+        //var ratingAmount = Math.Round((frigidProtectionMod * 100), 0);
+
+        _additionalPropertiesList.Add($"Frigid Resistance {ToRoman(frigidProtection)}");
+
+        _hasExtraPropertiesText = true;
+
+        _additionalPropertiesLongDescriptionsText +=
+            $"~ Frigid Resistance {ToRoman(frigidProtection)}: Reduces damage taken from frigid temperatures by {frigidProtection}. " +
+            $"This effect stacks with other sources of Frigid Resistance.\n";
     }
 
     private void SetBitingStrikeUseLongText(WorldObject wo)

--- a/apps/server/Network/Structure/AppraiseInfo.cs
+++ b/apps/server/Network/Structure/AppraiseInfo.cs
@@ -912,13 +912,13 @@ public class AppraiseInfo
         SetGearRatingText(wo, PropertyInt.GearElementalist, "Elementalist", $"Grants up to a 20% damage bonus to war spells, plus an additional 1% per equipped rating ((ONE) total). The amount builds up from 0%, based on how often you have hit your target.", 1.0f, 1.0f, 20, 0, true);
         SetGearRatingText(wo, PropertyInt.GearToughness, "Toughness", $"Grants +20 physical defense, plus an additional 1 per equipped rating ((ONE) total).", 1.0f, 1.0f, 20);
         SetGearRatingText(wo, PropertyInt.GearResistance, "Resistance", $"Grants +20 magic defense, plus an additional 1 per equipped rating ((ONE) total).", 1.0f, 1.0f, 20);
-        SetGearRatingText(wo, PropertyInt.GearSlashBane, "Swordsman's Bane", $"Grants +0.2 slashing protection to all equipped armor, plus an additional 0.01 per equipped rating ((ONE) total). The protection level cannot be increased beyond 1.0 (average), from this effect.", 0.01f, 1.0f, 0.2f);
-        SetGearRatingText(wo, PropertyInt.GearBludgeonBane, "Tusker's Bane", $"Grants +0.2 bludgeoning protection to all equipped armor, plus an additional 0.01 per equipped rating ((ONE) total). The protection level cannot be increased beyond 1.0 (average), from this effect.", 0.01f, 1.0f, 0.2f);
-        SetGearRatingText(wo, PropertyInt.GearPierceBane, "Archer's Bane", $"Grants +0.2 piercing protection to all equipped armor, plus an additional 0.01 per equipped rating ((ONE) total). The protection level cannot be increased beyond 1.0 (average), from this effect.", 0.01f, 1.0f, 0.2f);
-        SetGearRatingText(wo, PropertyInt.GearAcidBane, "Olthoi's Bane", $"Grants +0.2 acid protection to all equipped armor, plus an additional 0.01 per equipped rating ((ONE) total). The protection level cannot be increased beyond 1.0 (average), from this effect.", 0.01f, 1.0f, 0.2f);
-        SetGearRatingText(wo, PropertyInt.GearFireBane, "Inferno's Bane", $"Grants +0.2 fire protection to all equipped armor, plus an additional 0.01 per equipped rating ((ONE) total). The protection level cannot be increased beyond 1.0 (average), from this effect.", 0.01f, 1.0f, 0.2f);
-        SetGearRatingText(wo, PropertyInt.GearFrostBane, "Gelidite's Bane", $"Grants +0.2 cold protection to all equipped armor, plus an additional 0.01 per equipped rating ((ONE) total). The protection level cannot be increased beyond 1.0 (average), from this effect.", 0.01f, 1.0f, 0.2f);
-        SetGearRatingText(wo, PropertyInt.GearLightningBane, "Astyrrian's Bane", $"Grants +0.2 electric protection to all equipped armor, plus an additional 0.01 per equipped rating ((ONE) total) The protection level cannot be increased beyond 1.0 (average), from this effect..", 0.01f, 1.0f, 0.2f);
+        SetGearRatingText(wo, PropertyInt.GearSlashBane, "Swordsman's Bane", $"Grants +0.2 slashing protection to all equipped armor, plus an additional 0.01 per equipped rating ((ONE) total). Increases beyond 1.0 have steep diminishing returns.", 0.01f, 1.0f, 0.2f);
+        SetGearRatingText(wo, PropertyInt.GearBludgeonBane, "Tusker's Bane", $"Grants +0.2 bludgeoning protection to all equipped armor, plus an additional 0.01 per equipped rating ((ONE) total). Increases beyond 1.0 have steep diminishing returns.", 0.01f, 1.0f, 0.2f);
+        SetGearRatingText(wo, PropertyInt.GearPierceBane, "Archer's Bane", $"Grants +0.2 piercing protection to all equipped armor, plus an additional 0.01 per equipped rating ((ONE) total). Increases beyond 1.0 have steep diminishing returns.", 0.01f, 1.0f, 0.2f);
+        SetGearRatingText(wo, PropertyInt.GearAcidBane, "Olthoi's Bane", $"Grants +0.2 acid protection to all equipped armor, plus an additional 0.01 per equipped rating ((ONE) total). Increases beyond 1.0 have steep diminishing returns.", 0.01f, 1.0f, 0.2f);
+        SetGearRatingText(wo, PropertyInt.GearFireBane, "Inferno's Bane", $"Grants +0.2 fire protection to all equipped armor, plus an additional 0.01 per equipped rating ((ONE) total). Increases beyond 1.0 have steep diminishing returns.", 0.01f, 1.0f, 0.2f);
+        SetGearRatingText(wo, PropertyInt.GearFrostBane, "Gelidite's Bane", $"Grants +0.2 cold protection to all equipped armor, plus an additional 0.01 per equipped rating ((ONE) total). Increases beyond 1.0 have steep diminishing returns.", 0.01f, 1.0f, 0.2f);
+        SetGearRatingText(wo, PropertyInt.GearLightningBane, "Astyrrian's Bane", $"Grants +0.2 electric protection to all equipped armor, plus an additional 0.01 per equipped rating ((ONE) total). Increases beyond 1.0 have steep diminishing returns.", 0.01f, 1.0f, 0.2f);
 
         SetAdditionalPropertiesUseText(wo);
 
@@ -1779,8 +1779,17 @@ public class AppraiseInfo
         {
             return;
         }
-        
+
         //var ratingAmount = Math.Round((frigidProtectionMod * 100), 0);
+        var totalRating = 0;
+        var totalRatingString = "";
+        var creatureWielder = wo.Wielder as Creature;
+
+        if (creatureWielder != null)
+        {
+            totalRating = creatureWielder.GetEquippedAndActivatedItemRatingSum(PropertyInt.GearFrigidProtection);
+            totalRatingString = $" ({totalRating} total)";
+        }
 
         _additionalPropertiesList.Add($"Frigid Resistance {ToRoman(frigidProtection)}");
 
@@ -1788,7 +1797,7 @@ public class AppraiseInfo
 
         _additionalPropertiesLongDescriptionsText +=
             $"~ Frigid Resistance {ToRoman(frigidProtection)}: Reduces damage taken from frigid temperatures by {frigidProtection}. " +
-            $"This effect stacks with other sources of Frigid Resistance.\n";
+            $"This effect stacks with other sources of Frigid Resistance.{totalRatingString}\n";
     }
 
     private void SetBitingStrikeUseLongText(WorldObject wo)

--- a/apps/server/Network/Structure/AppraiseInfo.cs
+++ b/apps/server/Network/Structure/AppraiseInfo.cs
@@ -1741,9 +1741,9 @@ public class AppraiseInfo
         additionaPropertiesString = additionaPropertiesString.TrimEnd();
         additionaPropertiesString = additionaPropertiesString.TrimEnd(',');
 
-        var oomText = wo.Workmanship != null ? "" : "This item's properties will not activate if it is out of mana";
+        var oomText = wo.Workmanship != null ? "" : "\n\nThis item's properties will not activate if it is out of mana.\n";
 
-        _extraPropertiesText += $"Additional Properties: {additionaPropertiesString}.\n\n{oomText}\n\n";
+        _extraPropertiesText += $"Additional Properties: {additionaPropertiesString}.{oomText}\n";
 
         _hasExtraPropertiesText = true;
     }
@@ -1763,7 +1763,7 @@ public class AppraiseInfo
         var itemTier = LootGenerationFactory.GetTierFromWieldDifficulty(wo.WieldDifficulty ?? 1);
         var rangeMinAtTier = Math.Round(LootTables.StaminaCostReductionPerTier[itemTier - 1] * 100, 0);
 
-        _hasExtraPropertiesText = true;
+        _hasAdditionalProperties = true;
 
         _additionalPropertiesLongDescriptionsText +=
             $"~ Stamina Cost Reduction: Reduces stamina cost of attack by {ratingAmount}%. " +
@@ -1784,7 +1784,7 @@ public class AppraiseInfo
 
         _additionalPropertiesList.Add($"Frigid Resistance {ToRoman(frigidProtection)}");
 
-        _hasExtraPropertiesText = true;
+        _hasAdditionalProperties = true;
 
         _additionalPropertiesLongDescriptionsText +=
             $"~ Frigid Resistance {ToRoman(frigidProtection)}: Reduces damage taken from frigid temperatures by {frigidProtection}. " +

--- a/apps/server/Network/Structure/ArmorProfile.cs
+++ b/apps/server/Network/Structure/ArmorProfile.cs
@@ -46,17 +46,13 @@ public class ArmorProfile
         var resistanceMod = armor.EnchantmentManager.GetArmorModVsType(damageType);
         var effectiveRL = (float)(baseResistance + resistanceMod);
 
-        if (effectiveRL < 1.0f)
-        {
-            var jewelBaneRating = GetJewelBaneRating(armor, damageType);
-            effectiveRL += jewelBaneRating;
-
-            if (effectiveRL > 1.0f)
-            {
-                effectiveRL = 1.0f;
-            }
-        }
-
+        // jewelrating: direct below 1.0, diminishing returns above 1.0, hard cap at 1.5
+        var jewelBaneRating = GetJewelBaneRating(armor, damageType);
+        var directPortion = Math.Clamp(1.0f - effectiveRL, 0.0f, jewelBaneRating);
+        var excessPortion = jewelBaneRating - directPortion;
+        var postDirect = effectiveRL + directPortion;
+        effectiveRL = Math.Min(postDirect + excessPortion * (1.5f - postDirect), 1.5f);
+        
         // resistance clamp
         // TODO: this would be a good place to test with client values
         //if (effectiveRL > 2.0f)

--- a/apps/server/Physics/Common/Landblock.cs
+++ b/apps/server/Physics/Common/Landblock.cs
@@ -506,6 +506,69 @@ public class Landblock : LandblockStruct
         return t0;
     }
 
+    /// <summary>
+    /// Returns TRUE if the position is on a snow or ice terrain tile.
+    /// </summary>
+    public bool OnSnow(Vector3 obj)
+    {
+        var cellX = (int)Math.Floor(obj.X / LandDefs.CellLength);
+        var cellY = (int)Math.Floor(obj.Y / LandDefs.CellLength);
+
+        if (cellX < 0 || cellX >= LandDefs.BlockSide || cellY < 0 || cellY >= LandDefs.BlockSide)
+        {
+            return false;
+        }
+
+        var terrain = Terrain[cellX * (LandDefs.BlockSide + 1) + cellY];
+        var terrainType = (LandDefs.TerrainType)((terrain >> 2) & 0x1F);
+        return terrainType == LandDefs.TerrainType.Snow || terrainType == LandDefs.TerrainType.Ice;
+    }
+
+    /// <summary>
+    /// Returns TRUE if any snow or ice terrain tile has any part within <paramref name="radius"/> units of <paramref name="obj"/>.
+    /// Uses AABB closest-point distance so partial cell overlaps are handled correctly.
+    /// Only searches within the current landblock.
+    /// </summary>
+    public bool NearSnow(Vector3 obj, float radius)
+    {
+        var cellLen = (float)LandDefs.CellLength;
+
+        var minCellX = Math.Max(0,                    (int)Math.Floor((obj.X - radius) / cellLen));
+        var maxCellX = Math.Min(LandDefs.BlockSide - 1, (int)Math.Floor((obj.X + radius) / cellLen));
+        var minCellY = Math.Max(0,                    (int)Math.Floor((obj.Y - radius) / cellLen));
+        var maxCellY = Math.Min(LandDefs.BlockSide - 1, (int)Math.Floor((obj.Y + radius) / cellLen));
+
+        var radiusSq = radius * radius;
+
+        for (var cx = minCellX; cx <= maxCellX; cx++)
+        {
+            for (var cy = minCellY; cy <= maxCellY; cy++)
+            {
+                // Closest point on the cell AABB to the player position (ignores Z)
+                var closestX = Math.Clamp(obj.X, cx * cellLen, (cx + 1) * cellLen);
+                var closestY = Math.Clamp(obj.Y, cy * cellLen, (cy + 1) * cellLen);
+
+                var dx = obj.X - closestX;
+                var dy = obj.Y - closestY;
+
+                if (dx * dx + dy * dy > radiusSq)
+                {
+                    continue;
+                }
+
+                var terrain = Terrain[cx * (LandDefs.BlockSide + 1) + cy];
+                var terrainType = (LandDefs.TerrainType)((terrain >> 2) & 0x1F);
+
+                if (terrainType == LandDefs.TerrainType.Snow || terrainType == LandDefs.TerrainType.Ice)
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
     public LandCell get_landcell(uint cellID)
     {
         var lcoord = LandDefs.gid_to_lcoord(cellID).Value;

--- a/apps/server/WorldObjects/Creature.cs
+++ b/apps/server/WorldObjects/Creature.cs
@@ -278,19 +278,21 @@ public partial class Creature : Container
             
             if (IsInFrigidZone())
             {
-                var frigidMod = 1.0 + (Location.PositionZ - 200.0) * 0.01;
+                var esperMountainsMultiplier = EsperMountainsZone.Contains(Location) ? 10 : 1;
+
+                var frigidMod = 1.0 + (Location.PositionZ - 200.0) * 0.001 * esperMountainsMultiplier;
                 toughness *= frigidMod;
                 lethality *= frigidMod;
 
                 // double the bonus for creature trophy drops
                 FrigidBonus = (float)(1.0f + (frigidMod - 1) * 2.0f);
 
-                _log.Information(
-                    "[FRIGID ZONE] {Name} spawning on snow/ice at elevation {Elevation:F1} - toughness and lethality boosted by {Mod:P1}",
-                    Name,
-                    Location.PositionZ,
-                    frigidMod - 1.0
-                );
+                //_log.Information(
+                //    "[FRIGID ZONE] {Name} spawning on snow/ice at elevation {Elevation:F1} - toughness and lethality boosted by {Mod:P1}",
+                //    Name,
+                //    Location.PositionZ,
+                //    frigidMod - 1.0
+                //);
             }
 
             SetSkills(tier, statWeight, toughness, physicality, dexterity, magic, intelligence, 1.0);

--- a/apps/server/WorldObjects/Creature.cs
+++ b/apps/server/WorldObjects/Creature.cs
@@ -275,12 +275,15 @@ public partial class Creature : Container
 
             // Boost toughness and lethality for creatures that spawn on snow/ice above elevation 200.
             // Multiplier scales at 1% per unit of elevation above 200.
-            
+
             if (IsInFrigidZone())
             {
                 var esperMountainsMultiplier = EsperMountainsZone.Contains(Location) ? 10 : 1;
 
-                FrigidBonus = 1.0 + (Location.PositionZ - 200.0) * 0.001 * esperMountainsMultiplier;
+                const double frigidElevationBase = 200.0;
+                const double frigidScalingFactor = 0.001;
+
+                FrigidBonus = 1.0 + (Location.PositionZ - frigidElevationBase) * frigidScalingFactor * esperMountainsMultiplier;
                 toughness *= FrigidBonus;
                 lethality *= FrigidBonus;
 

--- a/apps/server/WorldObjects/Creature.cs
+++ b/apps/server/WorldObjects/Creature.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Numerics;
 using ACE.Common;
 using ACE.DatLoader;
 using ACE.DatLoader.FileTypes;
@@ -10,6 +11,7 @@ using ACE.Entity.Models;
 using ACE.Server.Entity;
 using ACE.Server.Managers;
 using ACE.Server.WorldObjects.Entity;
+using LScape = ACE.Server.Physics.Common.LScape;
 
 namespace ACE.Server.WorldObjects;
 
@@ -199,65 +201,6 @@ public partial class Creature : Container
                 }
             }
 
-            // Archetype System
-            var useArchetypeSystem = UseArchetypeSystem ?? false;
-            if (useArchetypeSystem && WeenieClassId != 1020001)
-            {
-                var statWeight = 0.0f;
-                var level = (float)(Level ?? 1);
-                var tier = (Tier ?? 1) - 1;
-
-                switch (tier)
-                {
-                    case 0:
-                        statWeight = level / 9;
-                        break;
-                    case 1:
-                        statWeight = (level - 10) / 10;
-                        break;
-                    case 2:
-                        statWeight = (level - 20) / 10;
-                        break;
-                    case 3:
-                        statWeight = (level - 30) / 10;
-                        break;
-                    case 4:
-                        statWeight = (level - 40) / 10;
-                        break;
-                    case 5:
-                        statWeight = (level - 50) / 25;
-                        break;
-                    case 6:
-                        statWeight = (level - 75) / 25;
-                        break;
-                    case 7:
-                        statWeight = (level - 100) / 25;
-                        break;
-                }
-
-                var toughness = ArchetypeToughness ?? 1.0;
-                var physicality = ArchetypePhysicality ?? 1.0;
-                var dexterity = ArchetypeDexterity ?? 1.0;
-                var magic = ArchetypeMagic ?? 1.0;
-                var intelligence = ArchetypeIntelligence ?? 1.0;
-                var lethality = ArchetypeLethality ?? 1.0;
-
-                
-                SetSkills(tier, statWeight, toughness, physicality, dexterity, magic, intelligence, 1.0);
-
-                SetVitals(tier, statWeight, toughness, physicality, dexterity, magic);
-
-                SetDamageArmorWard(tier, statWeight, toughness, physicality, magic, lethality);
-
-                var difficultyMod =
-                    (toughness * 3 + physicality + dexterity + magic + intelligence + lethality * 3) / 10.0;
-
-                //Console.WriteLine($"\nDIFFICULTY MOD: {difficultyMod}\n" +
-                //    $"Tough: {toughness}, Phys: {physicality}, Dex: {dexterity}, Magic: {magic}, Int: {intelligence}, Lethal: {lethality}");
-
-                SetXp(difficultyMod);
-            }
-
             // TODO: fix tod data
             Health.Current = Health.MaxValue;
             Stamina.Current = Stamina.MaxValue;
@@ -273,6 +216,122 @@ public partial class Creature : Container
 
     // verify logic
     public bool IsNPC => !(this is Player) && !Attackable && TargetingTactic == TargetingTactic.None;
+
+    public override bool EnterWorld()
+    {
+        var result = base.EnterWorld();
+
+        if (result && !(this is Player))
+        {
+            ApplyArchetypeSystem();
+        }
+
+        return result;
+    }
+
+    private void ApplyArchetypeSystem()
+    {
+        var useArchetypeSystem = UseArchetypeSystem ?? false;
+        if (useArchetypeSystem && WeenieClassId != 1020001)
+        {
+            var statWeight = 0.0f;
+            var level = (float)(Level ?? 1);
+            var tier = (Tier ?? 1) - 1;
+
+            switch (tier)
+            {
+                case 0:
+                    statWeight = level / 9;
+                    break;
+                case 1:
+                    statWeight = (level - 10) / 10;
+                    break;
+                case 2:
+                    statWeight = (level - 20) / 10;
+                    break;
+                case 3:
+                    statWeight = (level - 30) / 10;
+                    break;
+                case 4:
+                    statWeight = (level - 40) / 10;
+                    break;
+                case 5:
+                    statWeight = (level - 50) / 25;
+                    break;
+                case 6:
+                    statWeight = (level - 75) / 25;
+                    break;
+                case 7:
+                    statWeight = (level - 100) / 25;
+                    break;
+            }
+
+            var toughness = ArchetypeToughness ?? 1.0;
+            var physicality = ArchetypePhysicality ?? 1.0;
+            var dexterity = ArchetypeDexterity ?? 1.0;
+            var magic = ArchetypeMagic ?? 1.0;
+            var intelligence = ArchetypeIntelligence ?? 1.0;
+            var lethality = ArchetypeLethality ?? 1.0;
+
+            // Boost toughness and lethality for creatures that spawn on snow/ice above elevation 200.
+            // Multiplier scales at 1% per unit of elevation above 200.
+            Console.WriteLine(IsInFrigidZone());
+            if (IsInFrigidZone())
+            {
+                var frigidMod = 1.0 + (Location.PositionZ - 200.0) * 0.01;
+                toughness *= frigidMod;
+                lethality *= frigidMod;
+
+                // double the bonus for creature trophy drops
+                FrigidBonus = (float)(1.0f + (frigidMod - 1) * 2.0f);
+
+                _log.Information(
+                    "[FRIGID ZONE] {Name} spawning on snow/ice at elevation {Elevation:F1} - toughness and lethality boosted by {Mod:P1}",
+                    Name,
+                    Location.PositionZ,
+                    frigidMod - 1.0
+                );
+            }
+
+            SetSkills(tier, statWeight, toughness, physicality, dexterity, magic, intelligence, 1.0);
+
+            SetVitals(tier, statWeight, toughness, physicality, dexterity, magic);
+
+            SetDamageArmorWard(tier, statWeight, toughness, physicality, magic, lethality);
+
+            var difficultyMod =
+                (toughness * 3 + physicality + dexterity + magic + intelligence + lethality * 3) / 10.0;
+
+            SetXp(difficultyMod);
+
+            // Reset vitals to the new max values set by the archetype system
+            Health.Current = Health.MaxValue;
+            Stamina.Current = Stamina.MaxValue;
+            Mana.Current = Mana.MaxValue;
+        }
+    }
+
+    /// <summary>
+    /// Returns true if this creature's spawn location is on snow or ice terrain above elevation 200.
+    /// Used to determine whether to apply frigid zone archetype stat boosts.
+    /// </summary>
+    private bool IsInFrigidZone()
+    {
+        if (Location == null || Location.PositionZ <= 200f)
+        {
+            return false;
+        }
+
+        // Snow and ice terrain only exist on outdoor landcells (lower 16 bits of cell ID < 0x100)
+        if ((Location.Cell & 0xFFFF) >= 0x100)
+        {
+            return false;
+        }
+
+        var frigidLandblock = LScape.get_landblock(Location.Cell);
+        return frigidLandblock != null && frigidLandblock.NearSnow(
+            new Vector3(Location.PositionX, Location.PositionY, Location.PositionZ), 50f);
+    }
 
     public void GenerateNewFace()
     {

--- a/apps/server/WorldObjects/Creature.cs
+++ b/apps/server/WorldObjects/Creature.cs
@@ -280,12 +280,9 @@ public partial class Creature : Container
             {
                 var esperMountainsMultiplier = EsperMountainsZone.Contains(Location) ? 10 : 1;
 
-                var frigidMod = 1.0 + (Location.PositionZ - 200.0) * 0.001 * esperMountainsMultiplier;
-                toughness *= frigidMod;
-                lethality *= frigidMod;
-
-                // double the bonus for creature trophy drops
-                FrigidBonus = (float)(1.0f + (frigidMod - 1) * 2.0f);
+                FrigidBonus = 1.0 + (Location.PositionZ - 200.0) * 0.001 * esperMountainsMultiplier;
+                toughness *= FrigidBonus;
+                lethality *= FrigidBonus;
 
                 //_log.Information(
                 //    "[FRIGID ZONE] {Name} spawning on snow/ice at elevation {Elevation:F1} - toughness and lethality boosted by {Mod:P1}",

--- a/apps/server/WorldObjects/Creature.cs
+++ b/apps/server/WorldObjects/Creature.cs
@@ -275,7 +275,7 @@ public partial class Creature : Container
 
             // Boost toughness and lethality for creatures that spawn on snow/ice above elevation 200.
             // Multiplier scales at 1% per unit of elevation above 200.
-            Console.WriteLine(IsInFrigidZone());
+            
             if (IsInFrigidZone())
             {
                 var frigidMod = 1.0 + (Location.PositionZ - 200.0) * 0.01;

--- a/apps/server/WorldObjects/Creature_BodyPart.cs
+++ b/apps/server/WorldObjects/Creature_BodyPart.cs
@@ -5,6 +5,7 @@ using ACE.Entity.Enum;
 using ACE.Entity.Enum.Properties;
 using ACE.Entity.Models;
 using ACE.Server.Entity;
+using ACE.Server.Network.Structure;
 using ACE.Server.WorldObjects.Managers;
 
 namespace ACE.Server.WorldObjects;
@@ -118,6 +119,14 @@ public class Creature_BodyPart
         var armorBane = ignoreMagicArmor ? 0 : armor.EnchantmentManager.GetArmorModVsType(damageType);
         // Console.WriteLine("Bane: " + armorBane);
         var effectiveRL = (float)(resistance + armorBane);
+
+
+        // jewelrating: direct below 1.0, diminishing returns above 1.0, hard cap at 1.5
+        var jewelBaneRating = ArmorProfile.GetJewelBaneRating(armor, damageType);
+        var directPortion = Math.Clamp(1.0f - effectiveRL, 0.0f, jewelBaneRating);
+        var excessPortion = jewelBaneRating - directPortion;
+        var postDirect = effectiveRL + directPortion;
+        effectiveRL = Math.Min(postDirect + excessPortion * (1.5f - postDirect), 1.5f);
 
         // resistance clamp
         effectiveRL = Math.Clamp(effectiveRL, -2.0f, 2.0f);

--- a/apps/server/WorldObjects/Creature_Combat.cs
+++ b/apps/server/WorldObjects/Creature_Combat.cs
@@ -1035,6 +1035,13 @@ partial class Creature
 
         var effectiveRL = (float)(baseRL + modRL);
 
+        // jewelrating: direct below 1.0, diminishing returns above 1.0, hard cap at 1.5
+        var jewelBaneRating = ArmorProfile.GetJewelBaneRating(shield, damageType);
+        var directPortion = Math.Clamp(1.0f - effectiveRL, 0.0f, jewelBaneRating);
+        var excessPortion = jewelBaneRating - directPortion;
+        var postDirect = effectiveRL + directPortion;
+        effectiveRL = Math.Min(postDirect + excessPortion * (1.5f - postDirect), 1.5f);
+
         // resistance clamp
         effectiveRL = Math.Clamp(effectiveRL, -2.0f, 2.0f);
 

--- a/apps/server/WorldObjects/Creature_Death.cs
+++ b/apps/server/WorldObjects/Creature_Death.cs
@@ -1128,9 +1128,11 @@ partial class Creature
                 var createdObjects = new List<WorldObject>();
                 foreach (var item in selected)
                 {
-                    var wo = WorldObjectFactory.CreateNewWorldObject(item, Tier ?? 1);
+                    var wo = WorldObjectFactory.CreateNewWorldObject(item, Tier ?? 1, FrigidBonus);
                     if (wo != null)
+                    {
                         createdObjects.Add(wo);
+                    }
                 }
 
                 // Merge identical stackable items — can produce duplicates when overflow

--- a/apps/server/WorldObjects/Creature_Death.cs
+++ b/apps/server/WorldObjects/Creature_Death.cs
@@ -1022,7 +1022,18 @@ partial class Creature
                 _deathTreasureTier = Tier.Value;
             }
 
-            var items = LootGenerationFactory.CreateRandomLootObjects(DeathTreasure);
+            var deathTreasure = DeathTreasure;
+
+            // FrigidBonus increases lootqualitymod.
+            // Strong diminishing returns, cap of 0.5 at FrigidBonus = 10.0 (realistic FB range: 1-5)
+            if (FrigidBonus > 1.0f)
+            {
+                var fullFrigidBonus = (float)Math.Sqrt((FrigidBonus - 1.0f) / 9.0f) * 0.5f;
+                var frigidQualityBonus = (1.0f - deathTreasure.LootQualityMod) * fullFrigidBonus;
+                deathTreasure.LootQualityMod = Math.Min(1.0f, deathTreasure.LootQualityMod + frigidQualityBonus);
+            }
+
+            var items = LootGenerationFactory.CreateRandomLootObjects(deathTreasure);
 
             for (var i = items.Count - 1; i >= 0; i--)
             {
@@ -1117,10 +1128,6 @@ partial class Creature
             var dropRateBonus = 1.0f + (SpellStackBonus - 1.0f) + (FrigidBonus - 1.0f);
 
             var selected = new List<PropertiesCreateList>();
-            foreach(var item in createList)
-            {
-                Console.WriteLine($"{item.WeenieClassId} {dropRateBonus}");
-            }
             selected = CreateListSelect(createList, dropRateBonus);
             
             if (selected.Count > 0)

--- a/apps/server/WorldObjects/Creature_Death.cs
+++ b/apps/server/WorldObjects/Creature_Death.cs
@@ -42,7 +42,7 @@ partial class Creature
     private bool onDeathEntered = false;
 
     private float SpellStackBonus = 1.0f;
-    private float FrigidBonus = 1.0f;
+    private double FrigidBonus = 1.0;
 
     /// <summary>
     /// Called when a monster or player dies, in conjunction with Die()
@@ -1025,12 +1025,13 @@ partial class Creature
             var deathTreasure = DeathTreasure;
 
             // FrigidBonus increases lootqualitymod.
-            // Strong diminishing returns, cap of 0.5 at FrigidBonus = 10.0 (realistic FB range: 1-5)
+            // Strong diminishing returns, cap of 0.5 at FrigidBonus = 5.0
             if (FrigidBonus > 1.0f)
             {
-                var fullFrigidBonus = (float)Math.Sqrt((FrigidBonus - 1.0f) / 9.0f) * 0.5f;
+                var fullFrigidBonus = (float)Math.Sqrt((FrigidBonus - 1.0f) / 4.0f) * 0.5f;
                 var frigidQualityBonus = (1.0f - deathTreasure.LootQualityMod) * fullFrigidBonus;
                 deathTreasure.LootQualityMod = Math.Min(1.0f, deathTreasure.LootQualityMod + frigidQualityBonus);
+                Console.WriteLine($"FB: {FrigidBonus}, fullFB: {fullFrigidBonus}, LQM: {deathTreasure.LootQualityMod}");
             }
 
             var items = LootGenerationFactory.CreateRandomLootObjects(deathTreasure);
@@ -1125,7 +1126,9 @@ partial class Creature
                 SpellStackBonus = GetSpellStackBonus(killer);
             }
 
-            var dropRateBonus = 1.0f + (SpellStackBonus - 1.0f) + (FrigidBonus - 1.0f);
+            var frigidDropBonus =  (float)(1.0f + (FrigidBonus - 1) * 2.0f);
+
+            var dropRateBonus = 1.0f + (SpellStackBonus - 1.0f) + (frigidDropBonus - 1.0f);
 
             var selected = new List<PropertiesCreateList>();
             selected = CreateListSelect(createList, dropRateBonus);
@@ -1135,7 +1138,7 @@ partial class Creature
                 var createdObjects = new List<WorldObject>();
                 foreach (var item in selected)
                 {
-                    var wo = WorldObjectFactory.CreateNewWorldObject(item, Tier ?? 1, FrigidBonus);
+                    var wo = WorldObjectFactory.CreateNewWorldObject(item, Tier ?? 1, frigidDropBonus);
                     if (wo != null)
                     {
                         createdObjects.Add(wo);

--- a/apps/server/WorldObjects/Creature_Death.cs
+++ b/apps/server/WorldObjects/Creature_Death.cs
@@ -42,6 +42,7 @@ partial class Creature
     private bool onDeathEntered = false;
 
     private float SpellStackBonus = 1.0f;
+    private float FrigidBonus = 1.0f;
 
     /// <summary>
     /// Called when a monster or player dies, in conjunction with Die()
@@ -1108,25 +1109,50 @@ partial class Creature
                 )
                 .ToList();
 
-            SpellStackBonus = GetSpellStackBonus(killer);
+            if (StackableSpellType > StackableSpellTables.StackableSpellType.None)
+            {
+                SpellStackBonus = GetSpellStackBonus(killer);
+            }
+
+            var dropRateBonus = 1.0f + (SpellStackBonus - 1.0f) + (FrigidBonus - 1.0f);
 
             var selected = new List<PropertiesCreateList>();
-
-            if (SpellStackBonus != 1.0f && StackableSpellType > StackableSpellTables.StackableSpellType.None)
+            foreach(var item in createList)
             {
-                selected = CreateListSelect(createList, SpellStackBonus);
+                Console.WriteLine($"{item.WeenieClassId} {dropRateBonus}");
             }
-            else
-            {
-                selected = CreateListSelect(createList);
-            }
-
+            selected = CreateListSelect(createList, dropRateBonus);
+            
             if (selected.Count > 0)
             {
+                var createdObjects = new List<WorldObject>();
                 foreach (var item in selected)
                 {
                     var wo = WorldObjectFactory.CreateNewWorldObject(item, Tier ?? 1);
+                    if (wo != null)
+                        createdObjects.Add(wo);
+                }
 
+                // Merge identical stackable items — can produce duplicates when overflow
+                // guaranteed draws select the same entry more than once.
+                for (var i = createdObjects.Count - 1; i >= 0; i--)
+                {
+                    if ((createdObjects[i].MaxStackSize ?? 1) > 1)
+                    {
+                        for (var j = 0; j < i; j++)
+                        {
+                            if (createdObjects[j].WeenieClassId == createdObjects[i].WeenieClassId)
+                            {
+                                createdObjects[j].SetStackSize((createdObjects[j].StackSize ?? 1) + (createdObjects[i].StackSize ?? 1));
+                                createdObjects.RemoveAt(i);
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                foreach (var wo in createdObjects)
+                {
                     if (corpse != null)
                     {
                         corpse.TryAddToInventory(wo);

--- a/apps/server/WorldObjects/Creature_Equipment.cs
+++ b/apps/server/WorldObjects/Creature_Equipment.cs
@@ -408,6 +408,7 @@ partial class Creature
             && (wo.GearFireBane ?? 0) == 0
             && (wo.GearFrostBane ?? 0) == 0
             && (wo.GearLightningBane ?? 0) == 0
+            && (wo.GearFrigidProtection ?? 0) == 0
         )
         {
             return;
@@ -482,7 +483,8 @@ partial class Creature
                 { PropertyInt.GearAcidBane, 0 },
                 { PropertyInt.GearFireBane, 0 },
                 { PropertyInt.GearFrostBane, 0 },
-                { PropertyInt.GearLightningBane, 0 }
+                { PropertyInt.GearLightningBane, 0 },
+                { PropertyInt.GearFrigidProtection, 0 },
             };
         }
 
@@ -550,6 +552,7 @@ partial class Creature
         equippedItemsRatingCache[PropertyInt.GearFireBane] -= (wo.GearFireBane ?? 0);
         equippedItemsRatingCache[PropertyInt.GearFrostBane] -= (wo.GearFrostBane ?? 0);
         equippedItemsRatingCache[PropertyInt.GearLightningBane] -= (wo.GearLightningBane ?? 0);
+        equippedItemsRatingCache[PropertyInt.GearFrigidProtection] += (wo.GearFrigidProtection ?? 0);
     }
 
     private void RemoveItemFromEquippedItemsRatingCache(WorldObject wo)
@@ -622,6 +625,7 @@ partial class Creature
         equippedItemsRatingCache[PropertyInt.GearFireBane] -= (wo.GearFireBane ?? 0);
         equippedItemsRatingCache[PropertyInt.GearFrostBane] -= (wo.GearFrostBane ?? 0);
         equippedItemsRatingCache[PropertyInt.GearLightningBane] -= (wo.GearLightningBane ?? 0);
+        equippedItemsRatingCache[PropertyInt.GearFrigidProtection] -= (wo.GearFrigidProtection ?? 0);
     }
 
     public int GetEquippedItemsRatingSum(PropertyInt rating)
@@ -779,6 +783,7 @@ partial class Creature
             && (wo.ArmorStaminaMod ?? 0) == 0
             && (wo.ArmorManaMod ?? 0) == 0
             && (wo.ArmorResourcePenalty ?? 0) == 0
+            && (wo.GearFrigidProtectionMod ?? 0) == 0
         )
         {
             return;
@@ -811,6 +816,7 @@ partial class Creature
                 { PropertyFloat.ArmorStaminaMod, 0 },
                 { PropertyFloat.ArmorManaMod, 0 },
                 { PropertyFloat.ArmorResourcePenalty, 0 },
+                { PropertyFloat.GearFrigidProtectionMod, 0 },
             };
         }
 
@@ -837,6 +843,7 @@ partial class Creature
         equippedItemsSkillModCache[PropertyFloat.ArmorStaminaMod] += (wo.ArmorStaminaMod ?? 0);
         equippedItemsSkillModCache[PropertyFloat.ArmorManaMod] += (wo.ArmorManaMod ?? 0);
         equippedItemsSkillModCache[PropertyFloat.ArmorResourcePenalty] += (wo.ArmorResourcePenalty ?? 0);
+        equippedItemsSkillModCache[PropertyFloat.GearFrigidProtectionMod] += (wo.GearFrigidProtectionMod ?? 0);
     }
 
     private void RemoveItemFromEquippedItemsSkillModCache(WorldObject wo)
@@ -869,6 +876,7 @@ partial class Creature
         equippedItemsSkillModCache[PropertyFloat.ArmorStaminaMod] -= (wo.ArmorStaminaMod ?? 0);
         equippedItemsSkillModCache[PropertyFloat.ArmorManaMod] -= (wo.ArmorManaMod ?? 0);
         equippedItemsSkillModCache[PropertyFloat.ArmorResourcePenalty] -= (wo.ArmorResourcePenalty ?? 0);
+        equippedItemsSkillModCache[PropertyFloat.GearFrigidProtectionMod] -= (wo.GearFrigidProtectionMod ?? 0);
     }
 
     public double GetEquippedItemsSkillModSum(PropertyFloat skillMod)
@@ -1497,6 +1505,42 @@ partial class Creature
                     rngSelected = false;
 
                     modifier = createList.GetSetModifier(i, dropRateMod);
+
+                    // When effective drop probability exceeds 100%, fire guaranteed draws for each
+                    // whole multiple and leave TrophyMod as the fractional remainder for the normal pass.
+                    if (modifier.GuaranteedDrops > 0)
+                    {
+                        var effectiveProb = modifier.Set.TrophyProbability * dropRateMod;
+                        var fractionalChance = modifier.Set.TrophyProbability * modifier.TrophyMod;
+                        _log.Information(
+                            "[LOOT][OVERFLOW] dropRateMod {DropRateMod:F4} -> effectiveProb {EffectiveProb:F4}: {GuaranteedDrops} guaranteed draw(s) + {FractionalChance:P1} fractional chance",
+                            dropRateMod,
+                            effectiveProb,
+                            modifier.GuaranteedDrops,
+                            fractionalChance
+                        );
+                    }
+
+                    for (var g = 0; g < modifier.GuaranteedDrops; g++)
+                    {
+                        var guaranteed = DrawFromSetGuaranteed(modifier.Set);
+                        if (guaranteed != null)
+                        {
+                            results.Add(guaranteed);
+                            _log.Information(
+                                "[LOOT][OVERFLOW] Guaranteed draw {DrawNumber}/{TotalDraws}: WeenieClassId {WeenieClassId}",
+                                g + 1,
+                                modifier.GuaranteedDrops,
+                                guaranteed.WeenieClassId
+                            );
+                        }
+                    }
+
+                    // No fractional probability left — skip the probabilistic pass entirely.
+                    if (modifier.TrophyMod <= 0.0f)
+                    {
+                        rngSelected = true;
+                    }
                 }
 
                 if (modifier != null)
@@ -1507,7 +1551,7 @@ partial class Creature
                     totalProbability += probability;
                 }
 
-                //Console.WriteLine($"Modifier: {modifier}, Prob: {probability}, TotalProb: {totalProbability}");
+                Console.WriteLine($"Modifier: {modifier}, TotalProb: {totalProbability}");
                 if (rngSelected || rng >= totalProbability)
                 {
                     continue;
@@ -1520,6 +1564,33 @@ partial class Creature
         }
 
         return results;
+    }
+
+    /// <summary>
+    /// Selects one item from <paramref name="set"/> proportionally to the trophy probabilities,
+    /// with no chance of a "none" result. Used when a drop is guaranteed due to overflow.
+    /// </summary>
+    private static PropertiesCreateList DrawFromSetGuaranteed(CreateListSet set)
+    {
+        var trophies = set.Trophies;
+        if (trophies.Count == 0)
+        {
+            return null;
+        }
+
+        var rng = ThreadSafeRandom.Next(0.0f, set.TrophyProbability);
+        var cumulative = 0.0f;
+
+        foreach (var trophy in trophies)
+        {
+            cumulative += trophy.Shade;
+            if (rng < cumulative)
+            {
+                return trophy;
+            }
+        }
+
+        return trophies[trophies.Count - 1];
     }
 
     public uint? WieldedTreasureType

--- a/apps/server/WorldObjects/Creature_Equipment.cs
+++ b/apps/server/WorldObjects/Creature_Equipment.cs
@@ -1512,13 +1512,13 @@ partial class Creature
                     {
                         var effectiveProb = modifier.Set.TrophyProbability * dropRateMod;
                         var fractionalChance = modifier.Set.TrophyProbability * modifier.TrophyMod;
-                        _log.Information(
-                            "[LOOT][OVERFLOW] dropRateMod {DropRateMod:F4} -> effectiveProb {EffectiveProb:F4}: {GuaranteedDrops} guaranteed draw(s) + {FractionalChance:P1} fractional chance",
-                            dropRateMod,
-                            effectiveProb,
-                            modifier.GuaranteedDrops,
-                            fractionalChance
-                        );
+                        //_log.Information(
+                        //    "[LOOT][OVERFLOW] dropRateMod {DropRateMod:F4} -> effectiveProb {EffectiveProb:F4}: {GuaranteedDrops} guaranteed draw(s) + {FractionalChance:P1} fractional chance",
+                        //    dropRateMod,
+                        //    effectiveProb,
+                        //    modifier.GuaranteedDrops,
+                        //    fractionalChance
+                        //);
                     }
 
                     for (var g = 0; g < modifier.GuaranteedDrops; g++)
@@ -1527,12 +1527,12 @@ partial class Creature
                         if (guaranteed != null)
                         {
                             results.Add(guaranteed);
-                            _log.Information(
-                                "[LOOT][OVERFLOW] Guaranteed draw {DrawNumber}/{TotalDraws}: WeenieClassId {WeenieClassId}",
-                                g + 1,
-                                modifier.GuaranteedDrops,
-                                guaranteed.WeenieClassId
-                            );
+                            //_log.Information(
+                            //    "[LOOT][OVERFLOW] Guaranteed draw {DrawNumber}/{TotalDraws}: WeenieClassId {WeenieClassId}",
+                            //    g + 1,
+                            //    modifier.GuaranteedDrops,
+                            //    guaranteed.WeenieClassId
+                            //);
                         }
                     }
 
@@ -1551,7 +1551,6 @@ partial class Creature
                     totalProbability += probability;
                 }
 
-                Console.WriteLine($"Modifier: {modifier}, TotalProb: {totalProbability}");
                 if (rngSelected || rng >= totalProbability)
                 {
                     continue;

--- a/apps/server/WorldObjects/Managers/EmoteManager.cs
+++ b/apps/server/WorldObjects/Managers/EmoteManager.cs
@@ -676,6 +676,7 @@ public class EmoteManager
                         var trophyQualityIteration = 0u;
                         if (creatureObject is { WeenieClassId: 3932 })
                         {
+                            stackSize = 1;
                             trophyQualityIteration = (uint)((creatureObject.RefusalItem.Item1.TrophyQuality - 1) ?? 0);
                             weenieClassId += trophyQualityIteration;
                         }

--- a/apps/server/WorldObjects/Monster_Melee.cs
+++ b/apps/server/WorldObjects/Monster_Melee.cs
@@ -706,20 +706,16 @@ partial class Creature
         {
             armorBane = IgnoreMagicArmorScaled(armorBane);
         }
-
-        if (resistance < 1.0f)
-        {
-            var jewelBaneRating = ArmorProfile.GetJewelBaneRating(armor, damageType);
-            resistance += jewelBaneRating;
-
-            if (resistance > 1.0f)
-            {
-                resistance = 1.0f;
-            }
-        }
-
+        
         // Console.WriteLine("Bane: " + armorBane);
         var effectiveRL = (float)(resistance + armorBane);
+
+        // jewelrating: direct below 1.0, diminishing returns above 1.0, hard cap at 1.5
+        var jewelBaneRating = ArmorProfile.GetJewelBaneRating(armor, damageType);
+        var directPortion = Math.Clamp(1.0f - effectiveRL, 0.0f, jewelBaneRating);
+        var excessPortion = jewelBaneRating - directPortion;
+        var postDirect = effectiveRL + directPortion;
+        effectiveRL = Math.Min(postDirect + excessPortion * (1.5f - postDirect), 1.5f);
 
         // resistance clamp
         effectiveRL = Math.Clamp(effectiveRL, -2.0f, 2.0f);

--- a/apps/server/WorldObjects/Player_Tick.cs
+++ b/apps/server/WorldObjects/Player_Tick.cs
@@ -249,6 +249,31 @@ partial class Player
 
         var rawDamage = (float)Location.PositionZ - 200f;
 
+        // Outside the Northern Esper Mountains, Frigid damage is only 1/10th strength.
+        var inEsperMountains = EsperMountainsZone.Contains(Location);
+        var worldX = Location.LandblockX * 192f + Location.PositionX;
+        var worldY = Location.LandblockY * 192f + Location.PositionY;
+
+        //_log.Information(
+        //    "[FRIGID ZONE] {Name} zone check — inEsperMountains: {InZone}, mapCoords: {MapCoords}, worldX: {WorldX:F1}, worldY: {WorldY:F1}, rawDamage before modifier: {RawDamage:F1}",
+        //    Name,
+        //    inEsperMountains,
+        //    Location.GetMapCoordStr() ?? "unknown",
+        //    worldX,
+        //    worldY,
+        //    rawDamage
+        //);
+
+        if (!inEsperMountains)
+        {
+            rawDamage *= 0.1f;
+            //_log.Information(
+            //    "[FRIGID ZONE] {Name} is outside Esper Mountains — rawDamage reduced to {RawDamage:F1}",
+            //    Name,
+            //    rawDamage
+            //);
+        }
+
         // Apply percentage reduction from equipped gear
         var modReduction = GetEquippedItemsSkillModSum(PropertyFloat.GearFrigidProtectionMod);
         rawDamage *= (float)Math.Max(0.0, 1.0 - modReduction);
@@ -268,21 +293,21 @@ partial class Player
 
         var damage = (int)Math.Ceiling(rawDamage);
 
-        _log.Information(
-            "[FRIGID] {Name} took {Damage} Frigid damage at elevation {Elevation:F1} (modReduction: {ModReduction:P1}, flatReduction: {FlatReduction})",
-            Name,
-            damage,
-            Location.PositionZ,
-            modReduction,
-            flatReduction
-        );
+        //_log.Information(
+        //    "[FRIGID] {Name} took {Damage} Frigid damage at elevation {Elevation:F1} (modReduction: {ModReduction:P1}, flatReduction: {FlatReduction})",
+        //    Name,
+        //    damage,
+        //    Location.PositionZ,
+        //    modReduction,
+        //    flatReduction
+        //);
 
         DamageHistory.Add(this, DamageType.Cold, (uint)damage);
         UpdateVitalDelta(Health, -damage);
 
         Session.Network.EnqueueSend(
             new GameMessageSystemChat(
-                $"The frigid cold bites at you for {damage} points of cold damage!",
+                $"The frigid air bites at you for {damage} points of cold damage!",
                 ChatMessageType.Broadcast
             )
         );

--- a/apps/server/WorldObjects/Player_Tick.cs
+++ b/apps/server/WorldObjects/Player_Tick.cs
@@ -206,6 +206,94 @@ partial class Player
         }
     }
 
+    /// <summary>
+    /// Checks whether the player is on a snow terrain tile above elevation 100 and applies Frigid damage.
+    /// Damage = (PositionZ - 100), reduced by GearFrigidProtectionMod (% reduction) then GearFrigidProtection (flat reduction).
+    /// Called every heartbeat (~5 seconds).
+    /// </summary>
+    private void CheckFrigidDamage()
+    {
+        if (!PropertyManager.GetBool("frigid_damage").Item)
+        {
+            return;
+        }
+
+        if (IsDead || Teleporting)
+        {
+            return;
+        }
+
+        if (Location.PositionZ <= 200f)
+        {
+            return;
+        }
+
+        // Snow textures only exist on outdoor landcells (cell ID lower 16 bits < 0x100)
+        if ((PhysicsObj?.Position.ObjCellID & 0xFFFF) >= 0x100)
+        {
+            return;
+        }
+
+        var physLandblock = LScape.get_landblock(PhysicsObj.Position.ObjCellID);
+        if (physLandblock == null || !physLandblock.NearSnow(PhysicsObj.Position.Frame.Origin, 50f))
+        {
+            return;
+        }
+
+        _log.Information(
+            "[FRIGID] {Name} is near snow/ice terrain (within 50 units) at cell {CellID:X8}, elevation {Elevation:F1}",
+            Name,
+            PhysicsObj.Position.ObjCellID,
+            Location.PositionZ
+        );
+
+        var rawDamage = (float)Location.PositionZ - 200f;
+
+        // Apply percentage reduction from equipped gear
+        var modReduction = GetEquippedItemsSkillModSum(PropertyFloat.GearFrigidProtectionMod);
+        rawDamage *= (float)Math.Max(0.0, 1.0 - modReduction);
+
+        // Apply cold resistance from active spells, natural resistance, and augmentations
+        var coldResistMod = GetResistanceMod(DamageType.Cold, null, null);
+        rawDamage *= coldResistMod;
+
+        // Apply flat reduction from equipped gear (after % reduction)
+        var flatReduction = GetEquippedItemsRatingSum(PropertyInt.GearFrigidProtection);
+        rawDamage -= flatReduction;
+
+        if (rawDamage <= 0)
+        {
+            return;
+        }
+
+        var damage = (int)Math.Ceiling(rawDamage);
+
+        _log.Information(
+            "[FRIGID] {Name} took {Damage} Frigid damage at elevation {Elevation:F1} (modReduction: {ModReduction:P1}, flatReduction: {FlatReduction})",
+            Name,
+            damage,
+            Location.PositionZ,
+            modReduction,
+            flatReduction
+        );
+
+        DamageHistory.Add(this, DamageType.Cold, (uint)damage);
+        UpdateVitalDelta(Health, -damage);
+
+        Session.Network.EnqueueSend(
+            new GameMessageSystemChat(
+                $"The frigid cold bites at you for {damage} points of cold damage!",
+                ChatMessageType.Broadcast
+            )
+        );
+
+        if (Health.Current == 0)
+        {
+            OnDeath(DamageHistory.LastDamager, DamageType.Cold);
+            Die();
+        }
+    }
+
     private void RemoveRoadSpeedBuff()
     {
         var roadBuff = EnchantmentManager.GetEnchantment(RoadSpeedBuffSpellId);
@@ -232,6 +320,8 @@ partial class Player
         HandleTargetVitals();
 
         HandleBuildUpEffects();
+
+        CheckFrigidDamage();
 
         LifestoneProtectionTick();
 

--- a/apps/server/WorldObjects/Vendor.cs
+++ b/apps/server/WorldObjects/Vendor.cs
@@ -1039,7 +1039,12 @@ public class Vendor : Creature
     {
         foreach (var kvp in DefaultItemsForSale)
         {
-            if (UseAltCurrencValue(kvp.Value.AltCurrencyValue))
+            if (AlternateCurrency != null && kvp.Value.ItemType == ItemType.PromissoryNote)
+            {
+                var cost = GetSellCost(kvp.Value);
+                kvp.Value.Value = (int)Math.Floor((cost + 0.1) / 1.15);
+            }
+            else if (UseAltCurrencValue(kvp.Value.AltCurrencyValue))
             {
                 kvp.Value.Value = kvp.Value.AltCurrencyValue;
             }
@@ -1057,7 +1062,12 @@ public class Vendor : Creature
     {
         foreach (var kvp in DefaultItemsForSale)
         {
-            if (UseAltCurrencValue(kvp.Value.AltCurrencyValue))
+            if (AlternateCurrency != null && kvp.Value.ItemType == ItemType.PromissoryNote)
+            {
+                var cost = GetSellCost(kvp.Value);
+                kvp.Value.Value = (int)Math.Floor((cost + 0.1) / 1.15);
+            }
+            else if (UseAltCurrencValue(kvp.Value.AltCurrencyValue))
             {
                 kvp.Value.Value = kvp.Value.AltCurrencyValue;
             }
@@ -1597,7 +1607,7 @@ public class Vendor : Creature
         var sellRate = SellPrice ?? 1.0;
         if (itemType == ItemType.PromissoryNote)
         {
-            sellRate = 1.15;
+            sellRate = AlternateCurrency == null ? 1.15 : 1.0;
         }
 
         if (UseAltCurrencValue(altCurrencyValue))

--- a/apps/server/WorldObjects/WorldObject_Properties.cs
+++ b/apps/server/WorldObjects/WorldObject_Properties.cs
@@ -9633,4 +9633,42 @@ partial class WorldObject
             }
         }
     }
+
+    /// <summary>
+    /// Percentage (0.0–1.0) of Frigid damage reduction granted to the wielder.
+    /// </summary>
+    public double? GearFrigidProtectionMod
+    {
+        get => GetProperty(PropertyFloat.GearFrigidProtectionMod);
+        set
+        {
+            if (!value.HasValue)
+            {
+                RemoveProperty(PropertyFloat.GearFrigidProtectionMod);
+            }
+            else
+            {
+                SetProperty(PropertyFloat.GearFrigidProtectionMod, value.Value);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Flat Frigid damage reduction applied to the wielder after percentage reduction.
+    /// </summary>
+    public int? GearFrigidProtection
+    {
+        get => GetProperty(PropertyInt.GearFrigidProtection);
+        set
+        {
+            if (!value.HasValue)
+            {
+                RemoveProperty(PropertyInt.GearFrigidProtection);
+            }
+            else
+            {
+                SetProperty(PropertyInt.GearFrigidProtection, value.Value);
+            }
+        }
+    }
 }

--- a/libs/entity/Enum/Properties/PropertyFloat.cs
+++ b/libs/entity/Enum/Properties/PropertyFloat.cs
@@ -252,6 +252,8 @@ public enum PropertyFloat : ushort
     [ServerOnly]
     SpecializedPackBurdenMod = 204,
 
+    GearFrigidProtectionMod = 205,
+
     [ServerOnly]
     PCAPRecordedWorkmanship = 8004,
 

--- a/libs/entity/Enum/Properties/PropertyInt.cs
+++ b/libs/entity/Enum/Properties/PropertyInt.cs
@@ -878,6 +878,7 @@ public enum PropertyInt : ushort
     TrophyEssenceSpellId = 516,
     TrophyEssenceSkill = 517,
     TrophyEssenceEffectType = 518,
+    GearFrigidProtection = 519,
 
     [ServerOnly]
     PCAPRecordedAutonomousMovement = 8007,


### PR DESCRIPTION
This PR implements a geographic zone-based environmental hazard ("frigid damage") centered on the Northern Esper Mountains. Players on snow terrain above a certain elevation take periodic cold damage, mitigated by two new gear properties (GearFrigidProtection flat, GearFrigidProtectionMod percentage). Creatures in the zone get stat multipliers tied to elevation, and their trophy drops get quality bonuses. Secondary changes include loot overflow math for guaranteed drops, armor jewel bane diminishing returns above 1.0, and a new Frigid Shard tinkering recipe.