### PR TITLE
fix: contracts not advancing to Done when received after completion flags already set

### DIFF
--- a/apps/server/WorldObjects/Managers/ContractManager.cs
+++ b/apps/server/WorldObjects/Managers/ContractManager.cs
@@ -201,6 +201,13 @@ public class ContractManager
             );
 
             RefreshMonitoredQuestFlags();
+
+            // If the player already has the completion flag, advance to Done immediately.
+            if (!string.IsNullOrWhiteSpace(datContract.QuestflagFinished) &&
+                Player.QuestManager.HasQuest(datContract.QuestflagFinished))
+            {
+                Update(contractId, datContract.QuestflagFinished);
+            }
         }
         else
         {
@@ -285,6 +292,26 @@ public class ContractManager
         }
 
         RefreshMonitoredQuestFlags();
+    }
+
+    public void HandleContractsOnLogin()
+    {
+        var contracts = Player.Character.GetContracts(Player.CharacterDatabaseLock);
+
+        foreach (var contract in contracts)
+        {
+            var datContract = GetContractFromDat(contract.ContractId);
+            if (datContract == null)
+            {
+                continue;
+            }
+
+            if (!string.IsNullOrWhiteSpace(datContract.QuestflagFinished) &&
+                Player.QuestManager.HasQuest(datContract.QuestflagFinished))
+            {
+                Update(contract.ContractId);
+            }
+        }
     }
 
     public void NotifyOfQuestUpdate(string questName)

--- a/apps/server/WorldObjects/Player_Networking.cs
+++ b/apps/server/WorldObjects/Player_Networking.cs
@@ -143,6 +143,7 @@ partial class Player
         // check if vassals earned XP while offline
         HandleAllegianceOnLogin();
         HandleHouseOnLogin();
+        ContractManager.HandleContractsOnLogin();
 
         // retail appeared to send the squelch list very early,
         // even before the CreatePlayer, but doing it here


### PR DESCRIPTION
 When a player received a contract after already completing the required quest flags, the contract would stay stuck in its initial state. This happened because NotifyOfQuestUpdate only fires when a quest flag changes — contracts added after the fact never got the update event.

Fix:
  - In ContractManager.Add(), after registering the new contract, immediately check if QuestflagFinished is already present on the player and call Update() to push the DoneOrPendingRepeat stage to the client.
  - Add HandleContractsOnLogin() to repair existing stuck contracts for players who already experienced the bug. Called from PlayerEnterWorld() alongside allegiance/house login handlers. Silently resyncs the contract tracker state (no chat message) for any contract where the finished flag is already set.