### PR TITLE
feat: scroll writing system - blank scrolls, scribing table, spell dust

### DIFF
--- a/apps/server/Entity/Confirmation.cs
+++ b/apps/server/Entity/Confirmation.cs
@@ -218,6 +218,9 @@ public class Confirmation_CraftInteration : Confirmation
             case WeenieType.TrophyEssence:
                 TrophyEssence.HandleTrophyEssenceCrafting(player, source, target, !repeatConfirmation);
                 break;
+            case WeenieType.SpellDust:
+                ScrollFinalizer.TryFinalizeScroll(player, source, target, true);
+                break;
             default:
                 RecipeManager.UseObjectOnTarget(player, source, target, true);
                 break;

--- a/apps/server/Entity/SpellFormula.cs
+++ b/apps/server/Entity/SpellFormula.cs
@@ -114,6 +114,16 @@ public class SpellFormula
     }
 
     /// <summary>
+    /// Returns TRUE if this spell component is a taper
+    /// </summary>
+    /// <param name="componentID">The ID from the spell components table</param>
+    public static bool IsTaper(uint componentID)
+    {
+        return SpellComponentsTable.SpellComponents.TryGetValue(componentID, out var component)
+            && component.Type == (uint)SpellComponentsTable.Type.Taper;
+    }
+
+    /// <summary>
     /// The spell for this formula
     /// </summary>
     public Spell Spell;

--- a/apps/server/Factories/Tables/VendorBaseItems.cs
+++ b/apps/server/Factories/Tables/VendorBaseItems.cs
@@ -216,6 +216,7 @@ public static class VendorBaseItems
         (0, false, HeritageAny, 1054005, 0, 0.0, -1), // Pearl of Spell Purging
         (0, false, HeritageAny, 1053979, 0, 0.0, -1), // Bezel (spellcrafting)
         (0, false, HeritageAny, 1053981, 0, 0.0, -1), // Alkahest Salt (cooking/alchemy)
+        (0, false, HeritageAny, 1053988, 0, 0.0, -1), // Blank Scroll (spellcrafting)
     ];
 
     // <(tier, onlyThisTier, heritage, wcid, paletteTemplate, shade, stackSize)>

--- a/apps/server/Factories/WorldObjectFactory.cs
+++ b/apps/server/Factories/WorldObjectFactory.cs
@@ -175,6 +175,12 @@ public static class WorldObjectFactory
                 return new ResonanceForge(weenie, guid);
             case WeenieType.Destabilizer:
                 return new Destabilizer(weenie, guid);
+            case WeenieType.BlankScroll:
+                return new BlankScroll(weenie, guid);
+            case WeenieType.SpellDust:
+                return new SpellDust(weenie, guid);
+            case WeenieType.ScribingTable:
+                return new ScribingTable(weenie, guid);
             default:
                 return new GenericObject(weenie, guid);
         }
@@ -326,6 +332,12 @@ public static class WorldObjectFactory
                 return new ResonanceForge(biota);
             case WeenieType.Destabilizer:
                 return new Destabilizer(biota);
+            case WeenieType.BlankScroll:
+                return new BlankScroll(biota);
+            case WeenieType.SpellDust:
+                return new SpellDust(biota);
+            case WeenieType.ScribingTable:
+                return new ScribingTable(biota);
             default:
                 return new GenericObject(biota);
         }

--- a/apps/server/Managers/PropertyManager.cs
+++ b/apps/server/Managers/PropertyManager.cs
@@ -846,7 +846,8 @@ public static class DefaultPropertyManager
         ("olthoi_north_camp_north_supply_level", new Property<long>(0, "Set the supply level of the Olthoi North Northern Camp.")),
         ("fragment_stability_phase_one", new Property<long>(0, "Phase One resonance stability tracker (0–15000 max)")),
         ("market_listing_max_price", new Property<long>(1_000_000_000, "Max market list price")),
-        ("market_max_active_listings_per_account", new Property<long>(30, "Max listings per account"))
+        ("market_max_active_listings_per_account", new Property<long>(30, "Max listings per account")),
+        ("scroll_writing_max_components", new Property<long>(10, "Maximum number of spell components that can be scribed onto a single Blank Scroll."))
     );
 
     public static readonly ReadOnlyDictionary<string, Property<double>> DefaultDoubleProperties = DictOf(

--- a/apps/server/WorldObjects/BlankScroll.cs
+++ b/apps/server/WorldObjects/BlankScroll.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using ACE.Entity;
+using ACE.Entity.Enum.Properties;
+using ACE.Entity.Models;
+
+namespace ACE.Server.WorldObjects;
+
+/// <summary>
+/// An unfinished spell scroll. Players scribe spell components onto it in order
+/// (Scroll Writing / Spellcrafting), then finalize it with Scroll Dust via <see cref="SpellDust"/>.
+/// </summary>
+public class BlankScroll : WorldObject
+{
+    private const string BaseLongDesc =
+        "A blank scroll. Double-click, then target spell components in your inventory, one at a time and in the correct order, to scribe a spell formula onto it. Use Spell Dust on it once you have finished scribing.";
+
+    /// <summary>
+    /// A new biota be created taking all of its values from weenie.
+    /// </summary>
+    public BlankScroll(Weenie weenie, ObjectGuid guid)
+        : base(weenie, guid)
+    {
+        SetEphemeralValues();
+    }
+
+    /// <summary>
+    /// Restore a WorldObject from the database.
+    /// </summary>
+    public BlankScroll(Biota biota)
+        : base(biota)
+    {
+        SetEphemeralValues();
+    }
+
+    private void SetEphemeralValues()
+    {
+        RefreshLongDesc();
+    }
+
+    /// <summary>
+    /// The ordered list of spell component IDs (SpellComponentsTable IDs) scribed onto this scroll so far.
+    /// Persisted as a comma-separated list in PropertyString.ScrollWritingComponents, same pattern as
+    /// SigilTrinket.AllowedSpecializedSkills, so scribing progress survives relog/trade.
+    /// </summary>
+    public List<uint> ScribedComponents
+    {
+        get
+        {
+            var raw = GetProperty(PropertyString.ScrollWritingComponents);
+            if (string.IsNullOrWhiteSpace(raw))
+            {
+                return new List<uint>();
+            }
+
+            var parts = raw.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            var list = new List<uint>(parts.Length);
+            foreach (var p in parts)
+            {
+                if (uint.TryParse(p, out var v))
+                {
+                    list.Add(v);
+                }
+            }
+
+            return list;
+        }
+        set
+        {
+            if (value == null || value.Count == 0)
+            {
+                RemoveProperty(PropertyString.ScrollWritingComponents);
+            }
+            else
+            {
+                SetProperty(PropertyString.ScrollWritingComponents, string.Join(",", value));
+            }
+
+            RefreshLongDesc();
+        }
+    }
+
+    /// <summary>
+    /// Rebuilds LongDesc from the base description plus the scribed component names, in the order
+    /// they were added, so examining the scroll shows scribing progress.
+    /// </summary>
+    private void RefreshLongDesc()
+    {
+        var scribed = ScribedComponents;
+
+        if (scribed.Count == 0)
+        {
+            LongDesc = BaseLongDesc;
+            return;
+        }
+
+        var comps = SpellComponent.SpellComponentsTable.SpellComponents;
+
+        var sb = new StringBuilder(BaseLongDesc);
+        sb.Append("\n\nScribed components (in order):");
+
+        for (var i = 0; i < scribed.Count; i++)
+        {
+            var name = comps.TryGetValue(scribed[i], out var comp) ? comp.Name : "Unknown Component";
+            sb.Append($"\n{i + 1}. {name}");
+        }
+
+        LongDesc = sb.ToString();
+    }
+
+    public override void HandleActionUseOnTarget(Player player, WorldObject target)
+    {
+        ScrollWritingService.TryScribeComponent(player, this, target);
+    }
+}

--- a/apps/server/WorldObjects/Player_Inventory.cs
+++ b/apps/server/WorldObjects/Player_Inventory.cs
@@ -134,9 +134,80 @@ partial class Player
             UpdateCoinValue();
         }
 
+        SpellTomeService.SyncOnAcquire(this, item);
+
         item.SaveBiotaToDatabase();
 
         return true;
+    }
+
+    /// <summary>
+    /// Adds `amount` of `weenieClassId` to inventory, merging into existing stacks with room before
+    /// creating a new stack for any remainder (e.g. a reward that shouldn't fragment into a separate
+    /// stack when the player already has some). Splits across multiple existing stacks if needed.
+    /// </summary>
+    public bool TryCreateOrMergeStackInInventoryWithNetworking(uint weenieClassId, int amount)
+    {
+        if (amount <= 0)
+        {
+            return true;
+        }
+
+        var existingStacks = GetInventoryItemsOfWCID(weenieClassId)
+            .Where(i => (i.StackSize ?? 1) < (i.MaxStackSize ?? 1))
+            .ToList();
+
+        foreach (var stack in existingStacks)
+        {
+            if (amount <= 0)
+            {
+                break;
+            }
+
+            var room = (stack.MaxStackSize ?? 1) - (stack.StackSize ?? 1);
+
+            if (room <= 0)
+            {
+                continue;
+            }
+
+            if (
+                FindObject(stack.Guid.Full, SearchLocations.MyInventory, out var stackContainer, out var rootOwner, out _)
+                == null
+            )
+            {
+                continue;
+            }
+
+            var mergeAmount = Math.Min(room, amount);
+
+            if (!AdjustStack(stack, mergeAmount, stackContainer, rootOwner))
+            {
+                continue;
+            }
+
+            Session.Network.EnqueueSend(
+                new GameMessageSetStackSize(stack),
+                new GameMessagePrivateUpdatePropertyInt(this, PropertyInt.EncumbranceVal, EncumbranceVal ?? 0)
+            );
+
+            amount -= mergeAmount;
+        }
+
+        if (amount <= 0)
+        {
+            return true;
+        }
+
+        var newStack = WorldObjectFactory.CreateNewWorldObject(weenieClassId);
+        if (newStack == null)
+        {
+            return false;
+        }
+
+        newStack.SetStackSize(amount);
+
+        return TryCreateInInventoryWithNetworking(newStack);
     }
 
     public bool TryConsumeFromInventoryWithNetworking(WorldObject item, int amount = int.MaxValue, uint? guid = null)
@@ -5232,6 +5303,26 @@ partial class Player
             Session.Network.EnqueueSend(new GameEventInventoryServerSaveFailed(Session, item.Guid.Full));
 
             SendUseDoneEvent();
+
+            return;
+        }
+
+        if (target is ScribingTable scribingTable)
+        {
+            // This is a "give object" interaction (see RemoveItemForGive's whole-object branch below,
+            // used by real quest NPCs that accept and consume an item), not a "use item" one. On
+            // success, TryConvertScrollToDust already sends GameEventItemServerSaysContainId, which is
+            // the complete, sufficient acknowledgment for a give transaction on its own. On rejection
+            // (item untouched), send GameEventInventoryServerSaveFailed instead, same as a normal give.
+            // Deliberately no SendUseDoneEvent() here — that belongs to the use-item/use-with-target
+            // action family (GameAction 0x35/0x36), not give-object, and sending it confused the
+            // client's cursor state for a transaction it never considered a "use" to begin with.
+            var consumed = ScribingTableService.TryConvertScrollToDust(this, scribingTable, item);
+
+            if (!consumed)
+            {
+                Session.Network.EnqueueSend(new GameEventInventoryServerSaveFailed(Session, item.Guid.Full));
+            }
 
             return;
         }

--- a/apps/server/WorldObjects/ScribingTable.cs
+++ b/apps/server/WorldObjects/ScribingTable.cs
@@ -1,0 +1,69 @@
+using ACE.Entity;
+using ACE.Entity.Enum;
+using ACE.Entity.Models;
+using ACE.Server.Network.GameEvent.Events;
+
+namespace ACE.Server.WorldObjects;
+
+/// <summary>
+/// A player-summoned crafting station. Give (drag/drop) a scroll from inventory onto it to break
+/// the scroll back down into Spell Dust (amount equal to the scroll's spell level). Handled via
+/// the "give object" pathway (Player_Inventory.GiveObjectToNPC).
+/// </summary>
+public class ScribingTable : Pet
+{
+    /// <summary>
+    /// A new biota be created taking all of its values from weenie.
+    /// </summary>
+    public ScribingTable(Weenie weenie, ObjectGuid guid)
+        : base(weenie, guid)
+    {
+        SetEphemeralValues();
+    }
+
+    /// <summary>
+    /// Restore a WorldObject from the database.
+    /// </summary>
+    public ScribingTable(Biota biota)
+        : base(biota)
+    {
+        SetEphemeralValues();
+    }
+
+    private void SetEphemeralValues()
+    {
+        // Pet.SetEphemeralValues() sets IsPassivePet based on WeenieType == WeenieType.Pet, which is
+        // false for us (we're WeenieType.ScribingTable so the factory constructs this class instead of
+        // the base Pet). Force it back on so Pet.Init() takes the passive-placement / no-rot path.
+        IsPassivePet = true;
+
+        // Pet.SetEphemeralValues() unconditionally sets ItemUseable = Usable.No, which would make
+        // double-clicking the table do nothing. Giving scrolls to the table doesn't go through this
+        // property at all (see Player_Inventory.GiveObjectToNPC) — this is purely for the plain
+        // double-click popup (ActOnUse below), so it must NOT be a SourceXTargetY value (that arms a
+        // use-with-target reticle instead of firing a plain use).
+        ItemUseable = Usable.Remote;
+    }
+
+    /// <summary>
+    /// Double-clicking the table shows usage instructions. Requires PropertyInt.ActivationResponse to
+    /// include the Use flag (0x2) on the weenie, or WorldObject.OnActivate won't call this at all.
+    /// </summary>
+    public override void ActOnUse(WorldObject activator)
+    {
+        if (activator is not Player player)
+        {
+            return;
+        }
+
+        player.Session.Network.EnqueueSend(
+            new GameEventPopupString(
+                player.Session,
+                "Disenchant Scroll: Drag a scroll to the Scribing Table to convert it to Spell Dust, obtaining 1 dust per spell level.\n\n"
+                    + "Scroll Crafting: Use a Blank Scroll, then target each of the spell's components (excluding tapers) in your "
+                    + "inventory, one at a time and in the correct order, to scribe them onto the scroll. Once all components are scribed, use "
+                    + "Spell Dust on the finished scroll to complete it."
+            )
+        );
+    }
+}

--- a/apps/server/WorldObjects/ScribingTableService.cs
+++ b/apps/server/WorldObjects/ScribingTableService.cs
@@ -1,0 +1,133 @@
+using ACE.Database;
+using ACE.Entity.Enum;
+using ACE.Server.Network.GameEvent.Events;
+using ACE.Server.Network.GameMessages.Messages;
+
+namespace ACE.Server.WorldObjects;
+
+/// <summary>
+/// Reverse of Scroll Writing: breaking a real spell scroll back down into Spell Dust
+/// (amount equal to the scroll's spell level) at a player-summoned Scribing Table.
+/// Invoked from Player_Inventory.GiveObjectToNPC when a scroll is given (dragged/dropped) onto
+/// a Scribing Table — the same "give object to a landblock object" pathway real quest NPCs use
+/// when they accept and consume an item (see the RemoveItemForGive/EmoteCategory.Give branch of
+/// GiveObjectToNPC), since a landblock object like the table can never be a use-with-target source.
+///
+/// The scroll is removed via TryRemoveFromInventoryWithNetworking(..., RemoveFromInventoryAction.GiveItem)
+/// rather than TryConsumeFromInventoryWithNetworking, and followed by GameEventItemServerSaysContainId —
+/// this is the exact protocol the client expects to resolve a give-object transaction it initiated.
+/// The generic "consume" removal path sends a different network message shape, which left the client
+/// waiting on an acknowledgment that never came (a stuck loading cursor).
+/// </summary>
+public static class ScribingTableService
+{
+    /// <summary>
+    /// Lazily-cached WCID of the Spell Dust weenie, found by WeenieType rather than hardcoded,
+    /// since Spell Dust's WCID is picked ad hoc in world DB content.
+    /// </summary>
+    private static uint? _spellDustWcid;
+
+    private static uint? SpellDustWcid
+    {
+        get
+        {
+            _spellDustWcid ??= DatabaseManager.World.GetFirstWeenieClassIdByType(WeenieType.SpellDust);
+            return _spellDustWcid;
+        }
+    }
+
+    /// <summary>
+    /// Default range (in the absence of a weenie-configured UseRadius) within which a summoned
+    /// Scribing Table must be to scribe/finalize a scroll or disenchant one.
+    /// </summary>
+    private const float DefaultUseRadius = 6f;
+
+    /// <summary>
+    /// Returns TRUE if the player currently has a Scribing Table summoned as their active pet and is
+    /// within range of it. Required for scribing components onto a Blank Scroll, finalizing one with
+    /// Spell Dust, and disenchanting a scroll back into Spell Dust — all Scroll Writing interactions
+    /// happen at the table, not just the scroll->dust direction.
+    /// </summary>
+    public static bool IsNearActiveTable(Player player)
+    {
+        return player.CurrentActivePet is ScribingTable table
+            && player.GetDistance(table) <= (table.UseRadius ?? DefaultUseRadius);
+    }
+
+    /// <summary>
+    /// Returns TRUE if the given item was consumed (destroyed), FALSE if it's untouched. The caller
+    /// uses this to decide whether to tell the client the item "failed to save" back into the target
+    /// container (correct only when the item still exists) — sending that for an item this method
+    /// already destroyed (and already separately notified the client about via
+    /// TryConsumeFromInventoryWithNetworking) would be a contradictory, stale message.
+    /// </summary>
+    public static bool TryConvertScrollToDust(Player player, ScribingTable table, WorldObject target)
+    {
+        if (target is not Scroll scroll)
+        {
+            player.Session.Network.EnqueueSend(
+                new GameMessageSystemChat("You can only use the Scribing Table on a scroll.", ChatMessageType.Craft)
+            );
+            return false;
+        }
+
+        if (scroll.Spell == null)
+        {
+            player.Session.Network.EnqueueSend(
+                new GameMessageSystemChat("That scroll does not have a valid spell.", ChatMessageType.Craft)
+            );
+            return false;
+        }
+
+        var level = scroll.Spell.Formula.Level;
+
+        if (level == 0)
+        {
+            player.Session.Network.EnqueueSend(
+                new GameMessageSystemChat("That scroll's spell formula is invalid.", ChatMessageType.Craft)
+            );
+            return false;
+        }
+
+        var dustWcid = SpellDustWcid;
+
+        if (dustWcid == null)
+        {
+            player.SendTransientError("Spell Dust does not exist in this world's content yet.");
+            return false;
+        }
+
+        var dustAmount = (int)level;
+        var spellName = scroll.Spell.Name;
+
+        // Same removal + acknowledgment sequence as RemoveItemForGive's whole-object branch
+        // (Player_Inventory.cs): remove with the GiveItem reason, tell the client the item is
+        // contained by the target, then destroy it.
+        if (!player.TryRemoveFromInventoryWithNetworking(scroll.Guid, out _, Player.RemoveFromInventoryAction.GiveItem))
+        {
+            player.SendTransientError("Failed to remove the scroll from your inventory.");
+            return false;
+        }
+
+        player.Session.Network.EnqueueSend(new GameEventItemServerSaysContainId(player.Session, scroll, table));
+
+        scroll.Destroy();
+
+        // Merges into an existing Spell Dust stack with room instead of always fragmenting into a
+        // separate stack, only creating a new one for any remainder.
+        if (!player.TryCreateOrMergeStackInInventoryWithNetworking(dustWcid.Value, dustAmount))
+        {
+            player.SendTransientError("Failed to add Spell Dust to your inventory.");
+            return true; // scroll was already consumed above, even though dust creation failed
+        }
+
+        player.Session.Network.EnqueueSend(
+            new GameMessageSystemChat(
+                $"You disenchant the Scroll of {spellName} into {dustAmount} Spell Dust.",
+                ChatMessageType.Craft
+            )
+        );
+
+        return true;
+    }
+}

--- a/apps/server/WorldObjects/ScrollFinalizer.cs
+++ b/apps/server/WorldObjects/ScrollFinalizer.cs
@@ -1,0 +1,220 @@
+using System;
+using ACE.Entity.Enum;
+using ACE.Server.Entity;
+using ACE.Server.Entity.Actions;
+using ACE.Server.Factories;
+using ACE.Server.Managers;
+using ACE.Server.Network.GameMessages.Messages;
+using MotionCommand = ACE.Entity.Enum.MotionCommand;
+
+namespace ACE.Server.WorldObjects;
+
+/// <summary>
+/// Finalize phase of Scroll Writing: applying Spell Dust to a scribed Blank Scroll.
+/// The scribed component order must match a real spell's formula (checked via SpellFormulaMatcher),
+/// and the player must have enough Spell Dust (spell level squared) and enough Spellcrafting skill.
+/// A wrong formula destroys the Blank Scroll outright. Insufficient dust/skill on an otherwise-correct
+/// formula is a no-cost rejection instead, since the player did nothing wrong there.
+/// </summary>
+public static class ScrollFinalizer
+{
+    public static void TryFinalizeScroll(Player player, WorldObject dustSource, WorldObject target, bool confirmed = false)
+    {
+        if (player.IsBusy)
+        {
+            player.SendUseDoneEvent(WeenieError.YoureTooBusy);
+            return;
+        }
+
+        if (!ScribingTableService.IsNearActiveTable(player))
+        {
+            player.Session.Network.EnqueueSend(
+                new GameMessageSystemChat("You must be near a summoned Scribing Table to do this.", ChatMessageType.Craft)
+            );
+            player.SendUseDoneEvent();
+            return;
+        }
+
+        if (target is not BlankScroll blankScroll)
+        {
+            player.Session.Network.EnqueueSend(
+                new GameMessageSystemChat("You can only use Scroll Dust on a Blank Scroll.", ChatMessageType.Craft)
+            );
+            player.SendUseDoneEvent();
+            return;
+        }
+
+        if (!RecipeManager.VerifyUse(player, dustSource, blankScroll, true))
+        {
+            player.SendTransientError(
+                "Either you or one of the items involved does not pass the requirements for this craft interaction."
+            );
+            player.SendUseDoneEvent();
+            return;
+        }
+
+        var scribed = blankScroll.ScribedComponents;
+
+        if (scribed.Count == 0)
+        {
+            player.Session.Network.EnqueueSend(
+                new GameMessageSystemChat("That scroll has no components scribed on it yet.", ChatMessageType.Craft)
+            );
+            player.SendUseDoneEvent();
+            return;
+        }
+
+        if (!SpellFormulaMatcher.TryMatch(scribed, out var spellId, out var spell))
+        {
+            player.TryConsumeFromInventoryWithNetworking(blankScroll, 1);
+
+            player.Session.Network.EnqueueSend(
+                new GameMessageSystemChat(
+                    "The components you have scribed do not match a known spell formula. The scroll crumbles to dust.",
+                    ChatMessageType.Craft
+                )
+            );
+            player.SendUseDoneEvent();
+            return;
+        }
+
+        if (!SpellFormulaMatcher.TryGetScrollWcid(spellId, out var scrollWcid))
+        {
+            player.Session.Network.EnqueueSend(
+                new GameMessageSystemChat(
+                    "That spell does not have a corresponding scroll available.",
+                    ChatMessageType.Craft
+                )
+            );
+            player.SendUseDoneEvent();
+            return;
+        }
+
+        var level = spell.Formula.Level;
+        var dustCost = (int)(level * level);
+
+        var bypassChecks = PropertyManager.GetBool("bypass_crafting_checks").Item;
+
+        // Required Spellcrafting skill = SpellLevel x 20 - 20 (e.g. level 1 = 0, level 5 = 80, level 8 = 140)
+        var requiredSkill = Math.Max(0, (int)level * 20 - 20);
+
+        var dustAvailable = player.GetNumInventoryItemsOfWCID(dustSource.WeenieClassId);
+
+        if (!bypassChecks && dustAvailable < dustCost)
+        {
+            player.Session.Network.EnqueueSend(
+                new GameMessageSystemChat(
+                    $"You need {dustCost} Spell Dust to finish this scroll (you have {dustAvailable}).",
+                    ChatMessageType.Craft
+                )
+            );
+            player.SendUseDoneEvent();
+            return;
+        }
+
+        var spellcraftSkill = player.GetCreatureSkill(Skill.Spellcrafting);
+
+        if (!bypassChecks && spellcraftSkill.Current < requiredSkill)
+        {
+            player.Session.Network.EnqueueSend(
+                new GameMessageSystemChat(
+                    "Your Spellcrafting is not developed enough to complete this scroll.",
+                    ChatMessageType.Craft
+                )
+            );
+            player.SendUseDoneEvent();
+            return;
+        }
+
+        var spellName = spell._spellBase?.Name ?? "Unknown Spell";
+
+        if (!confirmed)
+        {
+            var confirmationMessage =
+                $"Finalize this scroll into a Scroll of {spellName}?\n\nThis will consume the Blank Scroll and {dustCost} Spell Dust.\n\n";
+
+            if (
+                !player.ConfirmationManager.EnqueueSend(
+                    new Confirmation_CraftInteration(player.Guid, dustSource.Guid, blankScroll.Guid),
+                    confirmationMessage
+                )
+            )
+            {
+                player.SendUseDoneEvent(WeenieError.ConfirmationInProgress);
+                return;
+            }
+
+            player.SendUseDoneEvent();
+            return;
+        }
+
+        var actionChain = new ActionChain();
+
+        var animTime = 0.0f;
+
+        player.IsBusy = true;
+
+        if (player.CombatMode != CombatMode.NonCombat)
+        {
+            var stanceTime = player.SetCombatMode(CombatMode.NonCombat);
+            actionChain.AddDelaySeconds(stanceTime);
+
+            animTime += stanceTime;
+        }
+
+        animTime += player.EnqueueMotion(actionChain, MotionCommand.ClapHands);
+
+        actionChain.AddAction(
+            player,
+            () =>
+            {
+                if (!RecipeManager.VerifyUse(player, dustSource, blankScroll, true))
+                {
+                    player.SendTransientError(
+                        "Either you or one of the items involved does not pass the requirements for this craft interaction."
+                    );
+                    return;
+                }
+
+                var newScroll = WorldObjectFactory.CreateNewWorldObject(scrollWcid);
+                if (newScroll == null)
+                {
+                    player.SendTransientError("Failed to create the finished scroll.");
+                    return;
+                }
+
+                player.TryConsumeFromInventoryWithNetworking(blankScroll, 1);
+                player.TryConsumeFromInventoryWithNetworking(dustSource.WeenieClassId, dustCost);
+
+                if (!player.TryCreateInInventoryWithNetworking(newScroll))
+                {
+                    player.SendTransientError("Failed to add the finished scroll to your inventory.");
+                    newScroll.Destroy();
+                    return;
+                }
+
+                player.Session.Network.EnqueueSend(
+                    new GameMessageSystemChat($"You successfully write a Scroll of {spellName}.", ChatMessageType.Craft)
+                );
+
+                Player.TryAwardCraftingXp(player, spellcraftSkill, Skill.Spellcrafting, requiredSkill);
+
+                SpellTomeService.RecordDiscoveredFormula(player, spell);
+            }
+        );
+
+        actionChain.AddAction(
+            player,
+            () =>
+            {
+                player.IsBusy = false;
+            }
+        );
+
+        player.EnqueueMotion(actionChain, MotionCommand.Ready);
+
+        actionChain.EnqueueChain();
+
+        player.NextUseTime = DateTime.UtcNow.AddSeconds(animTime);
+    }
+}

--- a/apps/server/WorldObjects/ScrollWritingService.cs
+++ b/apps/server/WorldObjects/ScrollWritingService.cs
@@ -1,0 +1,95 @@
+using ACE.Entity.Enum;
+using ACE.Server.Entity;
+using ACE.Server.Managers;
+using ACE.Server.Network.GameMessages.Messages;
+
+namespace ACE.Server.WorldObjects;
+
+/// <summary>
+/// Scribing phase of Scroll Writing: appending spell components onto a Blank Scroll, one click at a time.
+/// Validation of the resulting formula is deferred entirely to <see cref="ScrollFinalizer"/> — any component
+/// can be scribed in any order here. Tapers are rejected outright: Scroll Writing ignores tapers entirely
+/// (see SpellFormulaMatcher), so scribing one would only ever be a wasted step.
+/// </summary>
+public static class ScrollWritingService
+{
+    public static void TryScribeComponent(Player player, BlankScroll scroll, WorldObject target)
+    {
+        if (player.IsBusy)
+        {
+            player.SendUseDoneEvent(WeenieError.YoureTooBusy);
+            return;
+        }
+
+        if (!ScribingTableService.IsNearActiveTable(player))
+        {
+            player.Session.Network.EnqueueSend(
+                new GameMessageSystemChat("You must be near a summoned Scribing Table to do this.", ChatMessageType.Craft)
+            );
+            player.SendUseDoneEvent();
+            return;
+        }
+
+        if (!RecipeManager.VerifyUse(player, scroll, target, true))
+        {
+            player.SendTransientError(
+                "Either you or one of the items involved does not pass the requirements for this craft interaction."
+            );
+            player.SendUseDoneEvent();
+            return;
+        }
+
+        if (!SpellComponent.IsValid(target.WeenieClassId))
+        {
+            player.Session.Network.EnqueueSend(
+                new GameMessageSystemChat($"The {target.NameWithMaterial} is not a spell component.", ChatMessageType.Craft)
+            );
+            player.SendUseDoneEvent();
+            return;
+        }
+
+        var componentId = SpellComponent.SpellComponentWCIDs[target.WeenieClassId];
+
+        if (SpellFormula.IsTaper(componentId))
+        {
+            player.Session.Network.EnqueueSend(
+                new GameMessageSystemChat(
+                    "Tapers are not needed for Scroll Writing.",
+                    ChatMessageType.Craft
+                )
+            );
+            player.SendUseDoneEvent();
+            return;
+        }
+
+        var maxComponents = PropertyManager.GetLong("scroll_writing_max_components").Item;
+
+        var scribed = scroll.ScribedComponents;
+
+        if (scribed.Count >= maxComponents)
+        {
+            player.Session.Network.EnqueueSend(
+                new GameMessageSystemChat(
+                    $"The {scroll.NameWithMaterial} cannot hold any more components.",
+                    ChatMessageType.Craft
+                )
+            );
+            player.SendUseDoneEvent();
+            return;
+        }
+
+        scribed.Add(componentId);
+        scroll.ScribedComponents = scribed;
+
+        player.EnqueueBroadcast(new GameMessageUpdateObject(scroll));
+
+        player.Session.Network.EnqueueSend(
+            new GameMessageSystemChat(
+                $"You scribe {target.NameWithMaterial} onto the {scroll.NameWithMaterial}. ({scribed.Count} component{(scribed.Count == 1 ? "" : "s")} scribed)",
+                ChatMessageType.Craft
+            )
+        );
+
+        player.SendUseDoneEvent();
+    }
+}

--- a/apps/server/WorldObjects/SpellDust.cs
+++ b/apps/server/WorldObjects/SpellDust.cs
@@ -1,0 +1,35 @@
+using ACE.Entity;
+using ACE.Entity.Models;
+
+namespace ACE.Server.WorldObjects;
+
+/// <summary>
+/// Reagent used to finalize a scribed Blank Scroll into a real spell scroll (Scroll Writing / Spellcrafting).
+/// </summary>
+public class SpellDust : Stackable
+{
+    /// <summary>
+    /// A new biota be created taking all of its values from weenie.
+    /// </summary>
+    public SpellDust(Weenie weenie, ObjectGuid guid)
+        : base(weenie, guid)
+    {
+        SetEphemeralValues();
+    }
+
+    /// <summary>
+    /// Restore a WorldObject from the database.
+    /// </summary>
+    public SpellDust(Biota biota)
+        : base(biota)
+    {
+        SetEphemeralValues();
+    }
+
+    private void SetEphemeralValues() { }
+
+    public override void HandleActionUseOnTarget(Player player, WorldObject target)
+    {
+        ScrollFinalizer.TryFinalizeScroll(player, this, target);
+    }
+}

--- a/apps/server/WorldObjects/SpellFormulaMatcher.cs
+++ b/apps/server/WorldObjects/SpellFormulaMatcher.cs
@@ -1,0 +1,144 @@
+using System.Collections.Generic;
+using System.Linq;
+using ACE.Database;
+using ACE.Entity.Enum;
+using ACE.Server.Entity;
+using Serilog;
+
+namespace ACE.Server.WorldObjects;
+
+/// <summary>
+/// Reverse lookup for Scroll Writing: given an ordered list of scribed spell component IDs,
+/// finds the spell (if any) whose formula matches it.
+///
+/// Tapers are deliberately excluded from matching (and from scribing, see ScrollWritingService) —
+/// taper choice/order is normally account-hash-randomized (SpellFormula.GetPlayerFormula), but
+/// Scroll Writing ignores that entirely so every player scribes the same formula for a given spell.
+///
+/// Only spells with an existing Scroll weenie in the world DB, AND whose magic school is in
+/// <see cref="AllowedSchools"/>, are considered candidates.
+/// </summary>
+public static class SpellFormulaMatcher
+{
+    private static readonly ILogger _log = Log.ForContext(typeof(SpellFormulaMatcher));
+
+    /// <summary>
+    /// The only magic schools Scroll Writing can currently produce scrolls for.
+    /// Narrow this further (or add per-spell exclusions alongside it) as needed.
+    /// </summary>
+    private static readonly HashSet<MagicSchool> AllowedSchools = new() { MagicSchool.WarMagic, MagicSchool.LifeMagic };
+
+    /// <summary>
+    /// spellId -> scroll weenie classId, built from every Scroll-type weenie with a PropertyDataId.Spell
+    /// whose spell is in an allowed magic school.
+    /// </summary>
+    private static Dictionary<uint, uint> _scrollWcidBySpellId;
+
+    private static Dictionary<uint, uint> ScrollWcidBySpellId
+    {
+        get
+        {
+            if (_scrollWcidBySpellId == null)
+            {
+                RebuildScrollMap();
+            }
+
+            return _scrollWcidBySpellId;
+        }
+    }
+
+    /// <summary>
+    /// Rebuilds the spellId -> scroll wcid cache from the world DB. Called lazily on first use;
+    /// call again after live-editing scroll weenie content to refresh without a server restart.
+    /// </summary>
+    public static void RebuildScrollMap()
+    {
+        var rawMap = DatabaseManager.World.GetScrollWeenieSpellMap();
+
+        var filtered = new Dictionary<uint, uint>();
+
+        foreach (var (spellId, scrollWcid) in rawMap)
+        {
+            var spell = new Spell(spellId, false);
+
+            if (spell._spellBase != null && AllowedSchools.Contains(spell.School))
+            {
+                filtered.Add(spellId, scrollWcid);
+            }
+        }
+
+        _scrollWcidBySpellId = filtered;
+    }
+
+    public static bool TryGetScrollWcid(uint spellId, out uint scrollWcid)
+    {
+        return ScrollWcidBySpellId.TryGetValue(spellId, out scrollWcid);
+    }
+
+    /// <summary>
+    /// Strips taper components out of a formula, leaving the account-invariant components in
+    /// their original relative order.
+    /// </summary>
+    private static List<uint> StripTapers(List<uint> components)
+    {
+        var result = new List<uint>(components.Count);
+
+        foreach (var component in components)
+        {
+            if (!SpellFormula.IsTaper(component))
+            {
+                result.Add(component);
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Attempts to match an ordered list of scribed component IDs (tapers excluded) against a known
+    /// spell's formula (also with tapers stripped). A match against either the standard formula or the
+    /// foci (scarab-only, since tapers are stripped) formula succeeds.
+    /// </summary>
+    public static bool TryMatch(List<uint> scribed, out uint spellId, out Spell spell)
+    {
+        spellId = 0;
+        spell = null;
+
+        if (scribed == null || scribed.Count == 0)
+        {
+            return false;
+        }
+
+        foreach (var candidateSpellId in ScrollWcidBySpellId.Keys)
+        {
+            var candidate = new Spell(candidateSpellId, false);
+
+            if (candidate._spellBase == null || candidate.Formula == null)
+            {
+                _log.Warning(
+                    "SpellFormulaMatcher.TryMatch: scroll map contains spellId {SpellId} with no matching dat spell",
+                    candidateSpellId
+                );
+                continue;
+            }
+
+            var canonicalFormula = StripTapers(candidate.Formula.Components);
+            if (scribed.Count == canonicalFormula.Count && scribed.SequenceEqual(canonicalFormula))
+            {
+                spellId = candidateSpellId;
+                spell = candidate;
+                return true;
+            }
+
+            var fociFormula = StripTapers(candidate.Formula.GetFociFormula());
+            if (fociFormula.Count > 0 && scribed.Count == fociFormula.Count && scribed.SequenceEqual(fociFormula))
+            {
+                spellId = candidateSpellId;
+                spell = candidate;
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/apps/server/WorldObjects/SpellTomeService.cs
+++ b/apps/server/WorldObjects/SpellTomeService.cs
@@ -1,0 +1,274 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using ACE.Entity.Enum;
+using ACE.Entity.Enum.Properties;
+using ACE.Server.Entity;
+using ACE.Server.Network.GameMessages.Messages;
+
+namespace ACE.Server.WorldObjects;
+
+/// <summary>
+/// Spell Tome (WCID 1053989): a plain Book, granted to players by an NPC (outside this file's
+/// concern). Every time the player successfully finalizes a scroll (see ScrollFinalizer) for a
+/// spell formula they haven't recorded before, that formula's core components (scarabs and tapers
+/// excluded — scarabs are the only thing that changes with spell level, so entries are level-agnostic)
+/// are added to the Tome, sorted by magic school then component order.
+///
+/// The discovery record lives on the PLAYER (a new PropertyString), not the item — so a lost/destroyed
+/// Tome can simply be re-acquired and it will sync to full history immediately (see SyncOnAcquire,
+/// called from Player_Inventory.TryCreateInInventoryWithNetworking whenever a Tome enters a player's
+/// inventory via any normal game mechanic — vendor purchase, trade, NPC/quest give). This also means a
+/// Tome traded to a different player is rebuilt for ITS new owner, matching per-player semantics rather
+/// than carrying over the previous owner's content. Book is a sealed class, so this isn't a WorldObject
+/// subclass; the Tome is identified purely by WCID.
+/// </summary>
+public static class SpellTomeService
+{
+    public const uint SpellTomeWcid = 1053989;
+
+    private sealed record DiscoveredFormula(MagicSchool School, string BaseName, List<uint> Components);
+
+    /// <summary>
+    /// Matches a trailing " I", " VI", " VIII", etc. (a level numeral AC appends to a spell's base
+    /// name) so it can be stripped — entries are level-agnostic (see class remarks), so only the base
+    /// family name is worth recording. Spells with no such suffix are left unchanged.
+    /// </summary>
+    private static readonly Regex TrailingLevelNumeral = new(@"^(.*?)\s+[IVXLCDM]+$", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Syncs a Tome to the player's current discovery record the moment it enters their inventory,
+    /// so a newly-acquired Tome (bought, given, traded, or a replacement for a lost one) is never
+    /// stale or blank while waiting for the player to discover something new. No-ops for anything
+    /// that isn't a Spell Tome.
+    /// </summary>
+    public static void SyncOnAcquire(Player player, WorldObject item)
+    {
+        if (item.WeenieClassId != SpellTomeWcid || item is not Book tome)
+        {
+            return;
+        }
+
+        RebuildTome(player, tome, SortFormulas(GetDiscoveredFormulas(player)));
+    }
+
+    /// <summary>
+    /// Records a newly-crafted spell's core formula (if not already known) against the player, and
+    /// rebuilds every Spell Tome currently in their inventory to reflect the updated, sorted list.
+    /// </summary>
+    public static void RecordDiscoveredFormula(Player player, Spell spell)
+    {
+        if (spell?.Formula?.Components == null)
+        {
+            return;
+        }
+
+        var coreComponents = StripToCoreComponents(spell.Formula.Components);
+
+        if (coreComponents.Count == 0)
+        {
+            return;
+        }
+
+        var school = spell.School;
+        var discovered = GetDiscoveredFormulas(player);
+
+        if (discovered.Any(f => f.School == school && f.Components.SequenceEqual(coreComponents)))
+        {
+            return;
+        }
+
+        discovered.Add(new DiscoveredFormula(school, GetBaseSpellName(spell.Name), coreComponents));
+        SaveDiscoveredFormulas(player, discovered);
+
+        var tomes = player.GetInventoryItemsOfWCID(SpellTomeWcid).OfType<Book>().ToList();
+        if (tomes.Count == 0)
+        {
+            return;
+        }
+
+        var sorted = SortFormulas(discovered);
+
+        foreach (var tome in tomes)
+        {
+            RebuildTome(player, tome, sorted);
+        }
+    }
+
+    /// <summary>
+    /// Strips scarabs and tapers, leaving only the level-invariant, account-invariant core components
+    /// (herb, powder, potion, talisman, etc.) in their original relative order.
+    /// </summary>
+    private static List<uint> StripToCoreComponents(List<uint> components)
+    {
+        return components.Where(c => !SpellFormula.IsScarab(c) && !SpellFormula.IsTaper(c)).ToList();
+    }
+
+    /// <summary>
+    /// Strips a trailing level numeral off a spell name, e.g. "Blood Loather VI" -> "Blood Loather".
+    /// Leaves the name unchanged if it doesn't end in one.
+    /// </summary>
+    private static string GetBaseSpellName(string spellName)
+    {
+        if (string.IsNullOrWhiteSpace(spellName))
+        {
+            return spellName;
+        }
+
+        var match = TrailingLevelNumeral.Match(spellName.Trim());
+        return match.Success ? match.Groups[1].Value : spellName;
+    }
+
+    private static List<DiscoveredFormula> SortFormulas(List<DiscoveredFormula> formulas)
+    {
+        return formulas
+            .OrderBy(f => (int)f.School)
+            .ThenBy(f => string.Join(",", f.Components.Select(c => c.ToString("D4"))))
+            .ToList();
+    }
+
+    private static string GetSchoolDisplayName(MagicSchool school)
+    {
+        return school switch
+        {
+            MagicSchool.WarMagic => "War Magic",
+            MagicSchool.LifeMagic => "Life Magic",
+            MagicSchool.PortalMagic => "Portal Magic",
+            MagicSchool.CreatureEnchantment => "Creature Enchantment",
+            MagicSchool.VoidMagic => "Void Magic",
+            _ => school.ToString()
+        };
+    }
+
+    private const string ScarabNoteText =
+        "A list of spell formulas you have discovered. The formulas recorded in this tome exclude scarabs, listing only the core spell components (herb, powder, potion, "
+        + "talisman). Select a scarab separately, based on the "
+        + "level of scroll you wish to create, and use it as the first component in the spell formula. .";
+
+    /// <summary>
+    /// Blank-line gap between the scarab note and the first entry, and between each subsequent entry
+    /// (2 newlines = 1 blank line between the last line of one block and the first line of the next).
+    /// </summary>
+    private const string EntryGap = "\n\n";
+
+    /// <summary>
+    /// Shortens component names that follow the game's own "Powdered X" / "X Talisman" naming
+    /// conventions ("Powdered Amber" -> "P. Amber", "Yew Talisman" -> "Yew T.") so more formulas fit
+    /// on one line. Names that don't match either pattern are left as-is.
+    /// </summary>
+    private static string AbbreviateComponentName(string name)
+    {
+        const string poweredPrefix = "Powdered ";
+        const string talismanSuffix = " Talisman";
+
+        if (name.StartsWith(poweredPrefix, StringComparison.Ordinal))
+        {
+            name = "P. " + name[poweredPrefix.Length..];
+        }
+
+        if (name.EndsWith(talismanSuffix, StringComparison.Ordinal))
+        {
+            name = name[..^talismanSuffix.Length] + " T.";
+        }
+
+        return name;
+    }
+
+    /// <summary>
+    /// Rebuilds a Tome from the given sorted formula list as a single combined page: the scarab note,
+    /// then every entry one line apart, rather than one entry per page. NOTE: this doesn't paginate —
+    /// if the combined text ever exceeds PropertiesBook.MaxNumCharsPerPage, it's written as-is anyway
+    /// (Book.AddPage doesn't enforce that limit server-side), so very large discovery lists may render
+    /// truncated or oddly in the client's page-reading UI. Not a concern at current formula-pool sizes.
+    /// </summary>
+    private static void RebuildTome(Player player, Book tome, List<DiscoveredFormula> sortedFormulas)
+    {
+        tome.Biota.PropertiesBookPageData.Clear();
+
+        var comps = SpellComponent.SpellComponentsTable.SpellComponents;
+
+        var blocks = new List<string> { ScarabNoteText };
+
+        foreach (var formula in sortedFormulas)
+        {
+            var componentNames = formula.Components.Select(c =>
+                AbbreviateComponentName(comps.TryGetValue(c, out var comp) ? comp.Name : "Unknown Component")
+            );
+
+            // Two lines per entry: name/school header, then the whole formula on one line.
+            blocks.Add(
+                $"{formula.BaseName} ({GetSchoolDisplayName(formula.School)})\n" + string.Join(", ", componentNames)
+            );
+        }
+
+        var pageText = string.Join(EntryGap, blocks);
+
+        tome.AddPage(player.Guid.Full, player.Name, player.Account.AccountName, true, pageText, out _);
+
+        if (tome.Biota.PropertiesBookPageData.Count == 0)
+        {
+            tome.SetProperty(PropertyInt.AppraisalPages, 0);
+        }
+
+        player.EnqueueBroadcast(new GameMessageUpdateObject(tome));
+    }
+
+    /// <summary>
+    /// Format: "{schoolInt}:{baseName}:{comp1}-{comp2}-...", semicolon-separated entries. Entries saved
+    /// before BaseName was added (2-part, no name) are silently skipped rather than crashing.
+    /// </summary>
+    private static List<DiscoveredFormula> GetDiscoveredFormulas(Player player)
+    {
+        var result = new List<DiscoveredFormula>();
+
+        var raw = player.GetProperty(PropertyString.SpellTomeDiscoveredFormulas);
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return result;
+        }
+
+        foreach (var entry in raw.Split(';', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var parts = entry.Split(':', 3);
+            if (parts.Length != 3 || !int.TryParse(parts[0], out var schoolInt))
+            {
+                continue;
+            }
+
+            var baseName = parts[1];
+
+            var components = new List<uint>();
+            foreach (var compStr in parts[2].Split('-', StringSplitOptions.RemoveEmptyEntries))
+            {
+                if (uint.TryParse(compStr, out var compId))
+                {
+                    components.Add(compId);
+                }
+            }
+
+            if (components.Count > 0)
+            {
+                result.Add(new DiscoveredFormula((MagicSchool)schoolInt, baseName, components));
+            }
+        }
+
+        return result;
+    }
+
+    private static void SaveDiscoveredFormulas(Player player, List<DiscoveredFormula> formulas)
+    {
+        if (formulas.Count == 0)
+        {
+            player.RemoveProperty(PropertyString.SpellTomeDiscoveredFormulas);
+            return;
+        }
+
+        var raw = string.Join(
+            ';',
+            formulas.Select(f => $"{(int)f.School}:{f.BaseName}:{string.Join('-', f.Components)}")
+        );
+
+        player.SetProperty(PropertyString.SpellTomeDiscoveredFormulas, raw);
+    }
+}

--- a/libs/database/WorldDatabase.cs
+++ b/libs/database/WorldDatabase.cs
@@ -226,6 +226,58 @@ public class WorldDatabase
     }
 
     /// <summary>
+    /// Returns a mapping of spellId -> scroll weenie classId, for every Scroll-type weenie
+    /// that has a PropertyDataId.Spell set. Used by Scroll Writing to look up which existing
+    /// scroll item corresponds to a spell the player has assembled the correct components for.
+    /// This is a pair of small targeted queries, not a full GetAllWeenies() load.
+    /// </summary>
+    public virtual Dictionary<uint, uint> GetScrollWeenieSpellMap()
+    {
+        using (var context = new WorldDbContext())
+        {
+            var scrollWcids = context
+                .Weenie.Where(w => w.Type == (int)WeenieType.Scroll)
+                .Select(w => w.ClassId)
+                .ToList();
+
+            var map = new Dictionary<uint, uint>();
+
+            var spellDids = context
+                .WeeniePropertiesDID.Where(p => p.Type == (ushort)PropertyDataId.Spell && scrollWcids.Contains(p.ObjectId))
+                .ToList();
+
+            foreach (var row in spellDids)
+            {
+                if (!map.TryAdd(row.Value, row.ObjectId))
+                {
+                    _log.Warning(
+                        "[DATABASE] GetScrollWeenieSpellMap: spellId {SpellId} has multiple scroll weenies; keeping wcid {Wcid}",
+                        row.Value,
+                        map[row.Value]
+                    );
+                }
+            }
+
+            return map;
+        }
+    }
+
+    /// <summary>
+    /// Returns the classId of the first weenie found with the given WeenieType, or null if none exists.
+    /// Used by Scribing Table to find the Scroll Dust weenie to spawn, without hardcoding its WCID.
+    /// </summary>
+    public virtual uint? GetFirstWeenieClassIdByType(WeenieType weenieType)
+    {
+        using (var context = new WorldDbContext())
+        {
+            return context
+                .Weenie.Where(w => w.Type == (int)weenieType)
+                .Select(w => (uint?)w.ClassId)
+                .FirstOrDefault();
+        }
+    }
+
+    /// <summary>
     /// This will populate all sub collections except the following: LandblockInstances, PointsOfInterest
     /// </summary>
     public Weenie GetWeenie(uint weenieClassId)

--- a/libs/entity/Enum/Properties/PropertyString.cs
+++ b/libs/entity/Enum/Properties/PropertyString.cs
@@ -88,6 +88,12 @@ public enum PropertyString : ushort
     PatrolPath = 54,
 
     [ServerOnly]
+    ScrollWritingComponents = 55,
+
+    [ServerOnly]
+    SpellTomeDiscoveredFormulas = 56,
+
+    [ServerOnly]
     PCAPRecordedCurrentMotionState = 8006,
 
     [ServerOnly]

--- a/libs/entity/Enum/WeenieType.cs
+++ b/libs/entity/Enum/WeenieType.cs
@@ -91,5 +91,8 @@ public enum WeenieType : uint
     TrophyEssence,
     StabilizationDevice,
     ResonanceForge,
-    Destabilizer
+    Destabilizer,
+    BlankScroll,
+    SpellDust,
+    ScribingTable
 }


### PR DESCRIPTION
Adds a player-driven scroll-writing system: Blank Scrolls can be inscribed with spell components (tapers) and finalized into a completed spell scroll via ScrollFinalizer/SpellFormulaMatcher, which matches assembled components against known spell formulas using a new WorldDatabase lookup (GetScrollWeenieSpellMap). A Scribing Table converts existing scrolls into Spell Dust (ScribingTableService, GetFirstWeenieClassIdByType) for reuse in writing. SpellTomeService tracks which formulas a player has discovered via a new PropertyString (SpellTomeDiscoveredFormulas) and syncs on item acquire.

- New WeenieTypes: BlankScroll, SpellDust, ScribingTable
- New PropertyStrings: ScrollWritingComponents, SpellTomeDiscoveredFormulas
- New PropertyManager setting: scroll_writing_max_components (default 10)
- WorldObjectFactory wired up for the three new weenie types
- Player_Inventory: new TryCreateOrMergeStackInInventoryWithNetworking helper for stacking rewards, plus ScribingTable give-object handling
- Confirmation.cs routes SpellDust confirmations to ScrollFinalizer