### PR TITLE
feat: olthoi queen support

### DIFF
--- a/apps/server/Entity/AddEnchantmentResult.cs
+++ b/apps/server/Entity/AddEnchantmentResult.cs
@@ -254,7 +254,9 @@ public class AddEnchantmentResult
         SpellId.OlthoiManaDebuff,
         SpellId.OlthoiDefenseDebuff,
         SpellId.OlthoiAcidVulnerability,
-        SpellId.OlthoiHealthDebuff
+        SpellId.OlthoiHealthDebuff,
+
+        SpellId.OlthoiQueenAcidVulnerability
     };
 
     private bool IsStackableEnchantment(SpellId spellId)

--- a/apps/server/Entity/Confirmation.cs
+++ b/apps/server/Entity/Confirmation.cs
@@ -221,6 +221,9 @@ public class Confirmation_CraftInteration : Confirmation
             case WeenieType.SpellDust:
                 ScrollFinalizer.TryFinalizeScroll(player, source, target, true);
                 break;
+            case WeenieType.WeaponRelic:
+                WeaponRelic.UseObjectOnTarget(player, source, target, true);
+                break;
             default:
                 RecipeManager.UseObjectOnTarget(player, source, target, true);
                 break;

--- a/apps/server/Entity/Landblock.cs
+++ b/apps/server/Entity/Landblock.cs
@@ -2217,6 +2217,9 @@ public class Landblock : IActor
             case "Mountain Fortress":
                 dungeonLandblocks = [0x011C, 0x12FE, 0x12FD, 0x12FC, 0x12FB, 0x12FA];
                 break;
+            case "Olthoi Queen's Lair":
+                dungeonLandblocks = [0xC7B7, 0x1AFE, 0x1AFD, 0x1AFC, 0x1AFB, 0x1AFA];
+                break;
             default:
                 return null;
         }
@@ -2372,6 +2375,12 @@ public class Landblock : IActor
         { new LandblockId(0x12FC << 16 | 0xFFFF), new Position(0x12FC030F, 100.572f, -160.084f, 0.005f, 0f, 0f, 0.711837f, 0.702345f) },
         { new LandblockId(0x12FB << 16 | 0xFFFF), new Position(0x12FB030F, 100.572f, -160.084f, 0.005f, 0f, 0f, 0.711837f, 0.702345f) },
         { new LandblockId(0x12FA << 16 | 0xFFFF), new Position(0x12FA030F, 100.572f, -160.084f, 0.005f, 0f, 0f, 0.711837f, 0.702345f) },
+        { new LandblockId(0xC7B7u << 16 | 0xFFFF), new Position(0xC7B70462, -50.2814f, 7.25725f, 162.405f, 0f, 0f, -0.017697f, 0.999843f) },
+        { new LandblockId(0x1AFE << 16 | 0xFFFF), new Position(0x1AFE0462, -50.2814f, 7.25725f, 162.405f, 0f, 0f, -0.017697f, 0.999843f) },
+        { new LandblockId(0x1AFD << 16 | 0xFFFF), new Position(0x1AFD0462, -50.2814f, 7.25725f, 162.405f, 0f, 0f, -0.017697f, 0.999843f) },
+        { new LandblockId(0x1AFC << 16 | 0xFFFF), new Position(0x1AFC0462, -50.2814f, 7.25725f, 162.405f, 0f, 0f, -0.017697f, 0.999843f) },
+        { new LandblockId(0x1AFB << 16 | 0xFFFF), new Position(0x1AFB0462, -50.2814f, 7.25725f, 162.405f, 0f, 0f, -0.017697f, 0.999843f) },
+        { new LandblockId(0x1AFA << 16 | 0xFFFF), new Position(0x1AFA0462, -50.2814f, 7.25725f, 162.405f, 0f, 0f, -0.017697f, 0.999843f) },
     };
 
     public bool IsFellowshipRequired()
@@ -2397,7 +2406,8 @@ public class Landblock : IActor
             0x0139, 0x15FE, 0x15FD, 0x15FC, 0x15FB, 0x15FA, // "Mage Academy"
             0x02E9, 0x16FE, 0x16FD, 0x16FC, 0x16FB, 0x16FA, // "Lugian Mines"
             0x02E7, 0x17FE, 0x17FD, 0x17FC, 0x17FB, 0x17FA, // "Lugian Mines2"
-            0x011C, 0x12FE, 0x12FD, 0x12FC, 0x12FB, 0x12FA // "Mountain Fortress"
+            0x011C, 0x12FE, 0x12FD, 0x12FC, 0x12FB, 0x12FA, // "Mountain Fortress"
+            0xC7B7, 0x1AFE, 0x1AFD, 0x1AFC, 0x1AFB, 0x1AFA, // "Olthoi Queen's Lair"
         ];
 
     private void IncreaseMinimumEncounterSpawnDensity(List<Encounter> encounters, List<uint> generatedEncounterIdList)

--- a/apps/server/Factories/WorldObjectFactory.cs
+++ b/apps/server/Factories/WorldObjectFactory.cs
@@ -181,6 +181,8 @@ public static class WorldObjectFactory
                 return new SpellDust(weenie, guid);
             case WeenieType.ScribingTable:
                 return new ScribingTable(weenie, guid);
+            case WeenieType.WeaponRelic:
+                return new WeaponRelic(weenie, guid);
             default:
                 return new GenericObject(weenie, guid);
         }
@@ -338,6 +340,8 @@ public static class WorldObjectFactory
                 return new SpellDust(biota);
             case WeenieType.ScribingTable:
                 return new ScribingTable(biota);
+            case WeenieType.WeaponRelic:
+                return new WeaponRelic(biota);
             default:
                 return new GenericObject(biota);
         }

--- a/apps/server/Network/Structure/AppraiseInfo.cs
+++ b/apps/server/Network/Structure/AppraiseInfo.cs
@@ -858,6 +858,7 @@ public class AppraiseInfo
 
         SetCriticalStrikeUseLongText(wo);
         SetBitingStrikeUseLongText(wo);
+        SetSlayerUseLongText(wo);
 
         // "Additional Properties" ('Use' and 'LongDesc' text)
         SetWardRendingUseLongText(wo);
@@ -1922,6 +1923,26 @@ public class AppraiseInfo
         _additionalPropertiesLongDescriptionsText +=
             $"~ Biting Strike: Increases critical chance by +{ratingAmount}%, additively. " +
             $"Roll range is based on item tier ({rangeMinAtTier}% to {rangeMinAtTier + 5}%).\n";
+    }
+
+    private void SetSlayerUseLongText(WorldObject wo)
+    {
+        if (
+            !PropertiesInt.TryGetValue(PropertyInt.SlayerCreatureType, out var slayerCreatureTypeInt)
+            || !PropertiesFloat.TryGetValue(PropertyFloat.SlayerDamageBonus, out var slayerDamageBonus)
+            || !(slayerDamageBonus > 1.0)
+        )
+        {
+            return;
+        }
+
+        var slayerCreatureType = (CreatureType)slayerCreatureTypeInt;
+        var bonusPercent = Math.Round((slayerDamageBonus - 1.0) * 100, 0);
+
+        _hasExtraPropertiesText = true;
+
+        _additionalPropertiesLongDescriptionsText +=
+            $"~ {slayerCreatureType} Slayer: Deals +{bonusPercent}% damage against {slayerCreatureType} creatures.\n";
     }
 
     private void SetCriticalStrikeUseLongText(WorldObject wo)

--- a/apps/server/Physics/PhysicsObj.cs
+++ b/apps/server/Physics/PhysicsObj.cs
@@ -1256,6 +1256,20 @@ public class PhysicsObj
 
     public void MoveToPosition(Position pos, MovementParameters movementParams)
     {
+        if (MovementManager == null)
+        {
+            MovementManager = MovementManager.Create(this, WeenieObj);
+            MovementManager.EnterDefaultState();
+            if (!State.HasFlag(PhysicsState.Static))
+            {
+                if (!TransientState.HasFlag(TransientStateFlags.Active))
+                {
+                    UpdateTime = PhysicsTimer.CurrentTime;
+                }
+
+                TransientState &= ~TransientStateFlags.Active;
+            }
+        }
         var mvs = new MovementStruct();
         mvs.Position = new Position(pos);
         mvs.Type = MovementType.MoveToPosition;

--- a/apps/server/Physics/PhysicsObj.cs
+++ b/apps/server/Physics/PhysicsObj.cs
@@ -637,6 +637,15 @@ public class PhysicsObj
                 var center = Position.Frame.LocalToGlobal(pSphere.Center);
                 var lowpoint = obj.Position.Frame.LocalToGlobal(cylsphere.LowPoint);
 
+                // opt-in (PropertyBool.HotspotCollidesFromCenter): treat obj's placement as the
+                // CENTER of the CylSphere's height instead of the base, shifting the whole
+                // collision volume down by Height/2. Off by default - every other object keeps
+                // the stock base-anchored behavior.
+                if (obj.WeenieObj?.WorldObject?.GetProperty(PropertyBool.HotspotCollidesFromCenter) ?? false)
+                {
+                    lowpoint.Z -= cylsphere.Height * 0.5f;
+                }
+
                 var disp = center - lowpoint;
                 var radsum = pSphere.Radius + cylsphere.Radius - PhysicsGlobals.EPSILON;
 

--- a/apps/server/WorldObjects/Creature_Vitals.cs
+++ b/apps/server/WorldObjects/Creature_Vitals.cs
@@ -195,6 +195,18 @@ partial class Creature
 
         currentTick = diminishedMaxVital * vitalTypeBaseMod * vitalTypeArmorMod * stanceMod * enchantmentMod * augMod * relentlessStaminaMod;
 
+        // Flat, opt-in bonus added straight onto the health tick, independent of the max-health-
+        // based formula above - content-settable via SetMyFloatStat/SetFloatStat on
+        // PropertyFloat.BonusHealthRegenPerTick. Added here (not via a HeartBeat-category emote)
+        // specifically because this method runs unconditionally every ~5s for every Creature
+        // (Creature_Tick.cs Heartbeat() -> VitalHeartBeat()), regardless of IsAwake/combat state -
+        // unlike EmoteManager.HeartBeat(), which silently skips the whole HeartBeat emote category
+        // for any awake, non-patrolling Creature. Zero/unset is a no-op.
+        if (vital.Vital == PropertyAttribute2nd.MaxHealth)
+        {
+            currentTick += GetProperty(PropertyFloat.BonusHealthRegenPerTick) ?? 0;
+        }
+
         // add in partially accumulated / rounded vitals from previous tick(s)
         var totalTick = currentTick + vital.PartialRegen;
 

--- a/apps/server/WorldObjects/Hotspot.cs
+++ b/apps/server/WorldObjects/Hotspot.cs
@@ -257,6 +257,27 @@ public class Hotspot : WorldObject
         }
     }
 
+    /// <summary>
+    /// Opt-in for PhysicsObj.is_touching()'s custom collision check: treats this Hotspot's
+    /// placement position as the CENTER of its CylSphere collision height rather than the base,
+    /// shifting the whole collision volume down by Height/2. See PropertyBool.HotspotCollidesFromCenter.
+    /// </summary>
+    public bool CollidesFromCenter
+    {
+        get => GetProperty(PropertyBool.HotspotCollidesFromCenter) ?? false;
+        set
+        {
+            if (!value)
+            {
+                RemoveProperty(PropertyBool.HotspotCollidesFromCenter);
+            }
+            else
+            {
+                SetProperty(PropertyBool.HotspotCollidesFromCenter, value);
+            }
+        }
+    }
+
     private void Activate()
     {
         if (Creatures == null || CurrentLandblock == null)

--- a/apps/server/WorldObjects/Managers/EmoteManager.cs
+++ b/apps/server/WorldObjects/Managers/EmoteManager.cs
@@ -2763,6 +2763,27 @@ public class EmoteManager
                 }
                 break;
 
+            case EmoteType.JitterNextHeartbeat:
+
+                if (WorldObject != null)
+                {
+                    var jitterMin = emote.Min ?? 0;
+                    var jitterMax = emote.Max ?? jitterMin;
+
+                    var jitter = jitterMin == jitterMax ? jitterMin : ThreadSafeRandom.Next(jitterMin, jitterMax);
+
+                    WorldObject.NextHeartbeatTime = Time.GetUnixTime() + jitter;
+                }
+                break;
+
+            case EmoteType.ActivateHotspot:
+
+                if (WorldObject is Hotspot hotspot)
+                {
+                    hotspot.IsHot = true;
+                }
+                break;
+
             default:
                 _log.Debug(
                     "EmoteManager.Execute - Encountered Unhandled EmoteType {EmoteType} for {WorldObjectName} ({WorldObjectWeenieClassId})",
@@ -3580,7 +3601,15 @@ public class EmoteManager
     /// </summary>
     public void OnLocalSignal(WorldObject emitter, string message)
     {
-        ExecuteEmoteSet(EmoteCategory.ReceiveLocalSignal, message, emitter);
+        // nested:true - an incoming signal from another object is a distinct external event, not
+        // part of whatever action chain this object's own EmoteManager is currently mid-processing
+        // (e.g. a combat creature's own Taunt/WoundedTaunt/ReceiveCritical/HeartBeat reactions).
+        // Without this, "if (IsBusy && !nested) return false;" in ExecuteEmoteSet silently drops
+        // the entire incoming signal with no error and no retry whenever the receiver happens to
+        // be mid-processing anything else at that instant. HeartBeat/Taunt/WoundedTaunt/
+        // ReceiveCritical deliberately keep their existing busy-gating (unchanged) - only the
+        // incoming-signal path is affected.
+        ExecuteEmoteSet(EmoteCategory.ReceiveLocalSignal, message, emitter, true);
     }
 
     /// <summary>

--- a/apps/server/WorldObjects/Monster_Awareness.cs
+++ b/apps/server/WorldObjects/Monster_Awareness.cs
@@ -125,6 +125,64 @@ partial class Creature
     }
 
     /// <summary>
+    /// When set (seconds), this monster won't call MoveToHome() / fire Homesick the instant it
+    /// finds itself with zero valid attack targets - it waits this long first, and cancels the
+    /// wait if a target becomes visible again in the meantime. Intended for scripted encounters
+    /// where a brief target loss (e.g. a player using a short stealth effect while solo) shouldn't
+    /// be treated the same as genuinely abandoning the fight. Unset/0 preserves the original
+    /// instant behavior.
+    /// </summary>
+    public double? HomesickGracePeriod
+    {
+        get => GetProperty(PropertyFloat.HomesickGracePeriod);
+        set
+        {
+            if (value == null)
+            {
+                RemoveProperty(PropertyFloat.HomesickGracePeriod);
+            }
+            else
+            {
+                SetProperty(PropertyFloat.HomesickGracePeriod, value.Value);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Unix timestamp of when this monster first found itself with zero valid attack targets,
+    /// during the current target-loss streak. Null when it currently has a target. Only
+    /// meaningful when HomesickGracePeriod is set - see HandleNoTargetsFound().
+    /// </summary>
+    private double? _targetsLostTimestamp;
+
+    /// <summary>
+    /// Called whenever FindNextTarget() finds no valid attack targets, instead of calling
+    /// MoveToHome() directly - applies HomesickGracePeriod if set (see above), otherwise
+    /// preserves the original instant MoveToHome() behavior.
+    /// </summary>
+    private void HandleNoTargetsFound()
+    {
+        if (MonsterState == State.Return)
+        {
+            return;
+        }
+
+        var gracePeriod = HomesickGracePeriod;
+
+        if (gracePeriod is > 0)
+        {
+            _targetsLostTimestamp ??= Time.GetUnixTime();
+
+            if (Time.GetUnixTime() - _targetsLostTimestamp.Value < gracePeriod.Value)
+            {
+                return;
+            }
+        }
+
+        MoveToHome();
+    }
+
+    /// <summary>
     /// This list of possible targeting tactics for this monster
     /// </summary>
     public TargetingTactic TargetingTactic
@@ -330,11 +388,7 @@ partial class Creature
 
             if (visibleTargets.Count == 0)
             {
-                if (MonsterState != State.Return)
-                {
-                    MoveToHome();
-                }
-
+                HandleNoTargetsFound();
                 return false;
             }
 
@@ -354,10 +408,13 @@ partial class Creature
 
                 if (visibleTargets.Count == 0)
                 {
-                    MoveToHome();
+                    HandleNoTargetsFound();
                     return false;
                 }
             }
+
+            // Got here with at least one real target - clear any in-progress grace-period streak.
+            _targetsLostTimestamp = null;
 
             if (AttackTarget is Creature attackTargetCreature && GetDistance(AttackTarget) > VisualAwarenessRange)
             {

--- a/apps/server/WorldObjects/Monster_Navigation.cs
+++ b/apps/server/WorldObjects/Monster_Navigation.cs
@@ -369,7 +369,7 @@ partial class Creature
             return;
         }
 
-        if (PhysicsObj.MovementManager.MoveToManager.FailProgressCount > 0 && Timers.RunningTime > NextCancelTime)
+        if (PhysicsObj.MovementManager?.MoveToManager?.FailProgressCount > 0 && Timers.RunningTime > NextCancelTime)
         {
             CancelMoveTo();
         }

--- a/apps/server/WorldObjects/WeaponRelic.cs
+++ b/apps/server/WorldObjects/WeaponRelic.cs
@@ -1,0 +1,673 @@
+using System;
+using System.Collections.Generic;
+using ACE.Entity;
+using ACE.Entity.Enum;
+using ACE.Entity.Models;
+using ACE.Server.Entity;
+using ACE.Server.Entity.Actions;
+using ACE.Server.Factories;
+using ACE.Server.Managers;
+using ACE.Server.Network.GameMessages.Messages;
+
+namespace ACE.Server.WorldObjects;
+
+/// <summary>
+/// A generic, reusable reward item: used on a compatible weapon, it permanently transforms the
+/// target's appearance to match the relic's reward set (donor model picked per the TARGET's own
+/// weapon type, so one relic covers every lootgen weapon type without needing a separate relic per
+/// weapon type), forces the target's damage type to Bludgeon regardless of what it was, and grants
+/// a flat Slayer bonus per application (see PerApplicationSlayerBonus - no per-damage-type math
+/// needed since every weapon this relic touches ends up Bludgeon-typed) - the same native
+/// SlayerCreatureType/SlayerDamageBonus properties the loot generator itself uses for naturally-
+/// rolled Slayer weapons, so no combat-code changes were needed to make the bonus function. Can be
+/// applied up to MaxApplyCount times to the same weapon, stacking the bonus each time. No damage-
+/// type gate on the target (Acid included) - there's nothing to gate once every target ends up
+/// Bludgeon-typed regardless of what it started as.
+///
+/// A different reward (different look, different creature/bonus) needs a new weenie of this same
+/// WeenieType, plus - if it also needs a type-matched donor model per weapon type, rather than one
+/// fixed look for every target - a new entry in RelicAppearanceSets below, keyed by the new
+/// relic's own WCID.
+/// </summary>
+public class WeaponRelic : Stackable
+{
+    private const int MaxApplyCount = 5;
+
+    private readonly record struct WeaponAppearance(
+        uint Setup,
+        uint SoundTable,
+        uint? PaletteBase,
+        uint? ClothingBase,
+        uint Icon,
+        uint PhysicsTable,
+        float DefaultScale,
+        string DisplayName
+    );
+
+    /// <summary>
+    /// Per-relic-WCID sets of donor appearances, keyed by the TARGET's (ItemType, WeaponType).
+    /// Casters are keyed on ItemType alone (WeaponType.Undef) since lootgen casters don't carry a
+    /// meaningful WeaponType of their own.
+    ///
+    /// A relic WCID with no entry here falls back to a simple 1:1 copy of the relic's own
+    /// Setup/Icon/PaletteBase/Shade in ApplyRelic below, regardless of target type - that's the
+    /// right behavior for a future reward that's always the same single model.
+    ///
+    /// IMPORTANT: every value here is sourced from the official ACEmulator ACE-World-16PY-Patches
+    /// repo (github.com/ACEmulator/ACE-World-16PY-Patches, Database/Patches/9 WeenieDefaults/...),
+    /// confirmed against the actual per-item weenie SQL files there - NOT from treestats.net, whose
+    /// ace_world_patches/ace_world_base reference data turned out to not match this project's own
+    /// base.sql at all (base.sql has zero weenie_properties_d_i_d rows for any of these "Paradox-
+    /// touched Olthoi" WCIDs) and caused broken icons and invisible held weapons across the board.
+    /// </summary>
+    private static readonly Dictionary<uint, Dictionary<(ItemType ItemType, WeaponType WeaponType), WeaponAppearance>> RelicAppearanceSets =
+        new()
+        {
+            [1034443] = new() // Olthoi Queen's Carapace Shard -> retail "Paradox-touched Olthoi" weapon set
+            {
+                [(ItemType.MeleeWeapon, WeaponType.Unarmed)] = new(
+                    Setup: 0x02001712,
+                    SoundTable: 0x20000014,
+                    PaletteBase: 0x04001114,
+                    ClothingBase: 0x100006DB,
+                    Icon: 0x0600669A,
+                    PhysicsTable: 0x3400002B,
+                    DefaultScale: 1f,
+                    // The only Paradox unarmed model is shaped like a Katar - naming it that way so a
+                    // transformed Cestus/Nekode/whatever doesn't visually lie about what it is.
+                    DisplayName: "Katar"
+                ), // Katar
+                [(ItemType.MeleeWeapon, WeaponType.Sword)] = new(
+                    Setup: 0x02001714,
+                    SoundTable: 0x20000014,
+                    PaletteBase: 0x040001BF,
+                    ClothingBase: 0x1000021E,
+                    Icon: 0x06001CCA,
+                    PhysicsTable: 0x3400002B,
+                    DefaultScale: 1f,
+                    DisplayName: "Sword"
+                ), // Sword
+                [(ItemType.MeleeWeapon, WeaponType.Axe)] = new(
+                    Setup: 0x02001711,
+                    SoundTable: 0x20000014,
+                    PaletteBase: 0x04001114,
+                    ClothingBase: 0x100006DB,
+                    Icon: 0x06006699,
+                    PhysicsTable: 0x3400002B,
+                    DefaultScale: 0.75f,
+                    DisplayName: "Axe"
+                ), // Axe
+                [(ItemType.MeleeWeapon, WeaponType.Mace)] = new(
+                    Setup: 0x020019FC,
+                    SoundTable: 0x20000014,
+                    PaletteBase: null,
+                    ClothingBase: null,
+                    Icon: 0x06006D97,
+                    PhysicsTable: 0x3400002B,
+                    DefaultScale: 0.75f,
+                    DisplayName: "Mace"
+                ), // Mace
+                [(ItemType.MeleeWeapon, WeaponType.Spear)] = new(
+                    Setup: 0x02001713,
+                    SoundTable: 0x20000014,
+                    PaletteBase: 0x04001114,
+                    ClothingBase: 0x100006DB,
+                    Icon: 0x0600669B,
+                    PhysicsTable: 0x3400002B,
+                    DefaultScale: 0.9f,
+                    DisplayName: "Spear"
+                ), // Spear
+                [(ItemType.MeleeWeapon, WeaponType.Dagger)] = new(
+                    Setup: 0x020019FB,
+                    SoundTable: 0x20000014,
+                    PaletteBase: null,
+                    ClothingBase: null,
+                    Icon: 0x06006D96,
+                    PhysicsTable: 0x3400002B,
+                    DefaultScale: 0.75f,
+                    DisplayName: "Dagger"
+                ), // Dagger
+                [(ItemType.MeleeWeapon, WeaponType.Staff)] = new(
+                    Setup: 0x020019F7,
+                    SoundTable: 0x20000014,
+                    PaletteBase: null,
+                    ClothingBase: null,
+                    Icon: 0x06006D91,
+                    PhysicsTable: 0x3400002B,
+                    DefaultScale: 0.75f,
+                    DisplayName: "Staff"
+                ), // Staff
+                [(ItemType.MeleeWeapon, WeaponType.TwoHanded)] = new(
+                    Setup: 0x020019F8,
+                    SoundTable: 0x20000014,
+                    PaletteBase: null,
+                    ClothingBase: null,
+                    Icon: 0x06006D92,
+                    PhysicsTable: 0x3400002B,
+                    DefaultScale: 0.75f,
+                    DisplayName: "Great Sword"
+                ), // Great Sword
+                [(ItemType.Caster, WeaponType.Undef)] = new(
+                    Setup: 0x020019F9,
+                    SoundTable: 0x20000014,
+                    PaletteBase: null,
+                    ClothingBase: null,
+                    Icon: 0x06006D93,
+                    PhysicsTable: 0x3400002B,
+                    DefaultScale: 1.5f,
+                    DisplayName: "Wand"
+                ), // Wand
+                [(ItemType.MissileWeapon, WeaponType.Bow)] = new(
+                    Setup: 0x020019F6,
+                    SoundTable: 0x20000014,
+                    PaletteBase: null,
+                    ClothingBase: null,
+                    Icon: 0x06006D94,
+                    PhysicsTable: 0x3400002B,
+                    DefaultScale: 1f,
+                    DisplayName: "Bow"
+                ), // Bow
+                [(ItemType.MissileWeapon, WeaponType.Crossbow)] = new(
+                    Setup: 0x020019FA,
+                    SoundTable: 0x20000014,
+                    PaletteBase: null,
+                    ClothingBase: null,
+                    Icon: 0x06006D95,
+                    PhysicsTable: 0x3400002B,
+                    DefaultScale: 1f,
+                    DisplayName: "Crossbow"
+                ), // Crossbow
+                [(ItemType.MissileWeapon, WeaponType.Thrown)] = new(
+                    Setup: 0x02001710,
+                    SoundTable: 0x20000014,
+                    PaletteBase: 0x04001114,
+                    ClothingBase: 0x100006DB,
+                    Icon: 0x06006698,
+                    PhysicsTable: 0x3400002B,
+                    DefaultScale: 1f,
+                    DisplayName: "Atlatl"
+                ), // Atlatl - generic fallback for a thrown weapon TryGetAppearance can't classify by
+                   // subtype (see the Thrown handling there); NOT used for Axe/Club/Dagger/Javelin,
+                   // which get their own scaled-down look from RelicThrownAppearanceSets below.
+            },
+        };
+
+    /// <summary>
+    /// Experimental "scaled-up one-handed model" alternatives for two-handed targets, tried before
+    /// falling back to the plain Great Sword entry above (see ResolveTwoHandedAppearance). Same
+    /// Setup/Icon/Palette as the 1H Axe/Mace/Spear entries, just bigger - first pass, needs in-game
+    /// judgment on whether this actually looks better than just using the Great Sword for everything.
+    /// </summary>
+    private static readonly WeaponAppearance TwoHandedAxeLook = new(
+        Setup: 0x02001711,
+        SoundTable: 0x20000014,
+        PaletteBase: 0x04001114,
+        ClothingBase: 0x100006DB,
+        Icon: 0x06006699,
+        PhysicsTable: 0x3400002B,
+        DefaultScale: 1.2f,
+        DisplayName: "Axe"
+    );
+
+    private static readonly WeaponAppearance TwoHandedMaceLook = new(
+        Setup: 0x020019FC,
+        SoundTable: 0x20000014,
+        PaletteBase: null,
+        ClothingBase: null,
+        Icon: 0x06006D97,
+        PhysicsTable: 0x3400002B,
+        DefaultScale: 1.2f,
+        DisplayName: "Mace"
+    );
+
+    private static readonly WeaponAppearance TwoHandedSpearLook = new(
+        Setup: 0x02001713,
+        SoundTable: 0x20000014,
+        PaletteBase: 0x04001114,
+        ClothingBase: 0x100006DB,
+        Icon: 0x0600669B,
+        PhysicsTable: 0x3400002B,
+        DefaultScale: 1.3f,
+        DisplayName: "Spear"
+    );
+
+    /// <summary>
+    /// Per-relic-WCID donor appearances for Thrown weapons, keyed by the SAME subtype index
+    /// LootGenerationFactory.GetThrownWeaponsSubType returns (0=Axe, 1=Club, 2=Dagger, 3=Dart,
+    /// 4=Javelin, 5=Shuriken - see LootTables.ThrownWeaponMatrix for the authoritative order; the
+    /// doc comment on GetThrownWeaponsSubType itself has Dart/Javelin backwards, don't trust it).
+    /// Dart (3) and Shuriken (5) should never get an entry - not allowed, by design.
+    ///
+    /// Reuses the melee Axe/Mace/Dagger/Spear donor models above, just at a smaller scale for a
+    /// hand-thrown implement - first pass, may need in-game tuning.
+    /// </summary>
+    private static readonly Dictionary<uint, Dictionary<int, WeaponAppearance>> RelicThrownAppearanceSets =
+        new()
+        {
+            [1034443] = new()
+            {
+                [0] = new(
+                    Setup: 0x02001711,
+                    SoundTable: 0x20000014,
+                    PaletteBase: 0x04001114,
+                    ClothingBase: 0x100006DB,
+                    Icon: 0x06006699,
+                    PhysicsTable: 0x3400002B,
+                    DefaultScale: 0.4f,
+                    DisplayName: "Axe"
+                ), // Axe
+                [1] = new(
+                    Setup: 0x020019FC,
+                    SoundTable: 0x20000014,
+                    PaletteBase: null,
+                    ClothingBase: null,
+                    Icon: 0x06006D97,
+                    PhysicsTable: 0x3400002B,
+                    DefaultScale: 0.4f,
+                    DisplayName: "Mace"
+                ), // Club/Mace
+                [2] = new(
+                    Setup: 0x020019FB,
+                    SoundTable: 0x20000014,
+                    PaletteBase: null,
+                    ClothingBase: null,
+                    Icon: 0x06006D96,
+                    PhysicsTable: 0x3400002B,
+                    DefaultScale: 0.4f,
+                    DisplayName: "Dagger"
+                ), // Dagger
+                [4] = new(
+                    Setup: 0x02001713,
+                    SoundTable: 0x20000014,
+                    PaletteBase: 0x04001114,
+                    ClothingBase: 0x100006DB,
+                    Icon: 0x0600669B,
+                    PhysicsTable: 0x3400002B,
+                    DefaultScale: 0.45f,
+                    DisplayName: "Spear"
+                ), // Javelin/Spear
+            },
+        };
+
+    /// <summary>
+    /// A new biota be created taking all of its values from weenie.
+    /// </summary>
+    public WeaponRelic(Weenie weenie, ObjectGuid guid)
+        : base(weenie, guid)
+    {
+        SetEphemeralValues();
+    }
+
+    /// <summary>
+    /// Restore a WorldObject from the database.
+    /// </summary>
+    public WeaponRelic(Biota biota)
+        : base(biota)
+    {
+        SetEphemeralValues();
+    }
+
+    private void SetEphemeralValues() { }
+
+    public override void HandleActionUseOnTarget(Player player, WorldObject target)
+    {
+        UseObjectOnTarget(player, this, target);
+    }
+
+    public static void UseObjectOnTarget(Player player, WorldObject source, WorldObject target, bool confirmed = false)
+    {
+        if (player.IsBusy)
+        {
+            player.SendUseDoneEvent(WeenieError.YoureTooBusy);
+            return;
+        }
+
+        if (!RecipeManager.VerifyUse(player, source, target, true))
+        {
+            player.SendUseDoneEvent(WeenieError.YouDoNotPassCraftingRequirements);
+            return;
+        }
+
+        if (DestabilizedLootForge.TryBlockFurtherAlteration(player, target))
+        {
+            return;
+        }
+
+        if (target.ItemType is not (ItemType.MeleeWeapon or ItemType.MissileWeapon or ItemType.Caster))
+        {
+            player.Session.Network.EnqueueSend(
+                new GameMessageSystemChat($"The {source.Name} may only be used on a weapon.", ChatMessageType.Craft)
+            );
+            player.SendUseDoneEvent();
+            return;
+        }
+
+        // No damage-type gate (Acid included) - ApplyRelic forces every target's damage type to
+        // Bludgeon regardless of what it was, so there's nothing left to disallow on that basis.
+        var hasMatchedAppearance = TryGetAppearance(source, target, out var appearance);
+
+        if (RelicAppearanceSets.ContainsKey(source.WeenieClassId) && !hasMatchedAppearance)
+        {
+            player.Session.Network.EnqueueSend(
+                new GameMessageSystemChat(
+                    $"The {source.Name} has no matching form for that kind of weapon.",
+                    ChatMessageType.Craft
+                )
+            );
+            player.SendUseDoneEvent();
+            return;
+        }
+
+        var applyCount = target.WeaponRelicApplyCount ?? 0;
+
+        if (applyCount >= MaxApplyCount)
+        {
+            player.Session.Network.EnqueueSend(
+                new GameMessageSystemChat(
+                    $"The {target.NameWithMaterial} has already been infused the maximum number of times ({MaxApplyCount}).",
+                    ChatMessageType.Craft
+                )
+            );
+            player.SendUseDoneEvent();
+            return;
+        }
+
+        if (!confirmed)
+        {
+            var confirmationText = $"Infusing the {target.NameWithMaterial} with the {source.Name} ({applyCount + 1} of {MaxApplyCount}). This will permanently transform its appearance";
+
+            if (hasMatchedAppearance)
+            {
+                var totalBonusPercent = Math.Round((GetCumulativeSlayerBonus(applyCount + 1) - 1.0) * 100, 1);
+
+                confirmationText += $", convert its damage type to Bludgeoning, and bring its total Olthoi Slayer bonus to +{totalBonusPercent}%";
+            }
+            else
+            {
+                confirmationText += " and grant it a bonus";
+            }
+
+            confirmationText += ", consuming the relic. This cannot be undone.";
+
+            if (
+                !player.ConfirmationManager.EnqueueSend(
+                    new Confirmation_CraftInteration(player.Guid, source.Guid, target.Guid),
+                    confirmationText
+                )
+            )
+            {
+                player.SendUseDoneEvent(WeenieError.ConfirmationInProgress);
+            }
+            else
+            {
+                player.SendUseDoneEvent();
+            }
+
+            return;
+        }
+
+        var actionChain = new ActionChain();
+
+        var animTime = 0.0f;
+
+        player.IsBusy = true;
+
+        if (player.CombatMode != CombatMode.NonCombat)
+        {
+            var stanceTime = player.SetCombatMode(CombatMode.NonCombat);
+            actionChain.AddDelaySeconds(stanceTime);
+
+            animTime += stanceTime;
+        }
+
+        animTime += player.EnqueueMotion(actionChain, MotionCommand.ClapHands);
+
+        actionChain.AddAction(
+            player,
+            () =>
+            {
+                ApplyRelic(source, target);
+
+                player.EnqueueBroadcast(new GameMessageUpdateObject(target));
+                player.Session.Network.EnqueueSend(
+                    new GameMessageSystemChat(
+                        $"You infuse the {target.NameWithMaterial} with the {source.Name}.",
+                        ChatMessageType.Craft
+                    )
+                );
+                player.TryConsumeFromInventoryWithNetworking(source);
+            }
+        );
+
+        player.EnqueueMotion(actionChain, MotionCommand.Ready);
+
+        actionChain.AddAction(
+            player,
+            () =>
+            {
+                player.IsBusy = false;
+            }
+        );
+
+        actionChain.EnqueueChain();
+
+        player.NextUseTime = DateTime.UtcNow.AddSeconds(animTime);
+    }
+
+    /// <summary>
+    /// PropertyInt.WeaponType is reliably set on two-handed weapons, bows/crossbows, and thrown
+    /// weapons - but confirmed ABSENT on most one-handed melee templates (e.g. Jambiya, War Hammer
+    /// both have no WeaponType at all in retail data, despite being ordinary Dagger/Axe-skill
+    /// weapons). PropertyInt.WeaponSkill IS reliably set on essentially everything (it's what the
+    /// loot generator itself uses for weapon-shape bonus rolls), so use WeaponType when present and
+    /// fall back to translating WeaponSkill otherwise.
+    /// </summary>
+    private static WeaponType ResolveWeaponCategory(WorldObject target)
+    {
+        if (target.W_WeaponType != WeaponType.Undef)
+        {
+            return target.W_WeaponType;
+        }
+
+        return target.WeaponSkill switch
+        {
+            Skill.Axe => WeaponType.Axe,
+            Skill.Sword => WeaponType.Sword,
+            Skill.Dagger => WeaponType.Dagger,
+            Skill.Mace => WeaponType.Mace,
+            Skill.Spear => WeaponType.Spear,
+            Skill.Staff => WeaponType.Staff,
+            Skill.UnarmedCombat => WeaponType.Unarmed,
+            Skill.Bow => WeaponType.Bow,
+            Skill.Crossbow => WeaponType.Crossbow,
+            Skill.ThrownWeapon => WeaponType.Thrown,
+            _ => WeaponType.Undef,
+        };
+    }
+
+    /// <summary>
+    /// Two-handed weapons in this engine all use Skill.TwoHandedCombat regardless of shape (axe,
+    /// mace, sword, and spear-shaped 2H weapons are indistinguishable via WeaponType/WeaponSkill
+    /// alone, unlike their 1H counterparts). Experimentally picks a scaled-up 1H Axe/Mace/Spear look
+    /// based on real signals rather than guessing:
+    ///   - IsCleaving (PropertyInt.Cleaving) is the actual flag LootGenerationFactory_Melee's own
+    ///     MutateTwoHandedWeapon uses to split "swung" 2H weapons (sword/axe/mace) from "thrust" 2H
+    ///     weapons (spears) for damage-table purposes - a non-cleaving 2H weapon is a spear, full
+    ///     stop, so that's checked first and is authoritative (confirmed bug: falling back to the
+    ///     name-substring check alone meant an actual 2H spear had nowhere to go and fell all the
+    ///     way through to the Great Sword fallback).
+    ///   - Bludgeon is checked with HasFlag, not ==, since DamageType is [Flags] and a real weapon
+    ///     can have a compound value (confirmed bug: a 2H Mace with a compound damage type failed
+    ///     the old exact-match check and also fell through to Great Sword).
+    ///   - "Axe" in the name is the last, weakest signal (Slash-damage cleaving weapons are
+    ///     ambiguous between axe/sword shape with no better signal available) - falls back to the
+    ///     plain Great Sword if even that doesn't match.
+    /// </summary>
+    private static WeaponAppearance ResolveTwoHandedAppearance(WorldObject target, WeaponAppearance fallback)
+    {
+        if (!target.IsCleaving)
+        {
+            return TwoHandedSpearLook;
+        }
+
+        if (target.W_DamageType.HasFlag(DamageType.Bludgeon))
+        {
+            return TwoHandedMaceLook;
+        }
+
+        if (target.Name?.Contains("Axe", StringComparison.OrdinalIgnoreCase) == true)
+        {
+            return TwoHandedAxeLook;
+        }
+
+        return fallback;
+    }
+
+    /// <summary>
+    /// Looks up the donor appearance for this relic matching the TARGET's own weapon type.
+    /// Casters are matched on ItemType alone - lootgen casters don't carry a meaningful WeaponType.
+    /// Thrown weapons are matched on their actual subtype (axe/club/dagger/javelin only - dart and
+    /// shuriken have no matching form and correctly fail here). Two-handed weapons additionally get
+    /// routed through ResolveTwoHandedAppearance for the scaled-up Axe/Mace experiment.
+    /// </summary>
+    private static bool TryGetAppearance(WorldObject source, WorldObject target, out WeaponAppearance appearance)
+    {
+        appearance = default;
+
+        var category = ResolveWeaponCategory(target);
+
+        if (target.ItemType == ItemType.MissileWeapon && category == WeaponType.Thrown)
+        {
+            var subType = LootGenerationFactory.GetThrownWeaponsSubType(target);
+
+            if (subType is 3 or 5) // Dart, Shuriken - never allowed, regardless of relic
+            {
+                return false;
+            }
+
+            if (
+                RelicThrownAppearanceSets.TryGetValue(source.WeenieClassId, out var thrownSet)
+                && thrownSet.TryGetValue(subType, out appearance)
+            )
+            {
+                return true;
+            }
+
+            // Subtype 0/1/2/4 (Axe/Club/Dagger/Javelin) with no thrown-specific entry, or an
+            // unrecognized subtype (6 - GetThrownWeaponsSubType found no match in
+            // LootTables.ThrownWeaponMatrix, e.g. this server's actual thrown-weapon lootgen pool
+            // uses different base WCIDs than retail's hardcoded list) - fall back to the generic
+            // Atlatl look rather than hard-rejecting a legitimate (non-dart/shuriken) thrown weapon.
+            return RelicAppearanceSets.TryGetValue(source.WeenieClassId, out var atlatlSet)
+                && atlatlSet.TryGetValue((ItemType.MissileWeapon, WeaponType.Thrown), out appearance);
+        }
+
+        if (!RelicAppearanceSets.TryGetValue(source.WeenieClassId, out var appearanceSet))
+        {
+            return false;
+        }
+
+        var key = target.ItemType == ItemType.Caster ? (ItemType.Caster, WeaponType.Undef) : (target.ItemType, category);
+
+        if (!appearanceSet.TryGetValue(key, out appearance))
+        {
+            return false;
+        }
+
+        if (category == WeaponType.TwoHanded)
+        {
+            appearance = ResolveTwoHandedAppearance(target, appearance);
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Flat +5% Olthoi Slayer bonus per application. Used to scale per damage type (Bludgeon
+    /// baseline, everything else scaled by Olthoi's resist ratio to equalize effective DPS) - that's
+    /// now moot, since ApplyRelic forces every target's damage type to Bludgeon, so every weapon
+    /// this relic touches lands on this exact same rate. Kept as a named constant (not inlined)
+    /// since the reasoning - Olthoi take full, unresisted damage from Bludgeon, "weakest to blunt" -
+    /// is still the whole justification for the number even though the per-type math is gone.
+    /// </summary>
+    private const float PerApplicationSlayerBonus = 0.05f;
+
+    /// <summary>
+    /// Total SlayerDamageBonus after `applyCount` applications (1-based) - see
+    /// PerApplicationSlayerBonus for the flat per-application rate.
+    /// </summary>
+    private static float GetCumulativeSlayerBonus(int applyCount)
+    {
+        return 1.0f + applyCount * PerApplicationSlayerBonus;
+    }
+
+    private static void ApplyRelic(WorldObject source, WorldObject target)
+    {
+        var priorApplyCount = target.WeaponRelicApplyCount ?? 0;
+        var newApplyCount = priorApplyCount + 1;
+
+        // Appearance only - deliberately not touching MaterialType, so the target's other stats are
+        // untouched, only its look (and, for a type-matched relic, its scale to match the donor
+        // model) changes. ClothingBase IS copied (unlike an earlier version of this method) - the
+        // real Tailoring system copies it for weapons too, and PhysicsTable/Setup mismatches already
+        // taught us the hard way that skipping "looks armor-only" properties can break rendering.
+        // Re-applied identically on every application (1st through MaxApplyCount-th) - harmless and
+        // simpler than special-casing "only on the first use".
+        if (TryGetAppearance(source, target, out var appearance))
+        {
+            target.SetupTableId = appearance.Setup;
+            target.SoundTableId = appearance.SoundTable;
+            target.IconId = appearance.Icon;
+            target.PaletteBaseId = appearance.PaletteBase;
+            target.ClothingBase = appearance.ClothingBase;
+            target.PhysicsTableId = appearance.PhysicsTable;
+            target.ObjScale = appearance.DefaultScale;
+
+            // Every target's damage type is forced to Bludgeon, regardless of what it was (an
+            // earlier version of this method left it as the target's own - superseded by this).
+            // Since Olthoi take full, unresisted damage from Bludgeon ("weakest to blunt"), that
+            // means every weapon this relic touches now gets the exact same flat per-application
+            // Slayer rate too - see GetCumulativeSlayerBonus/PerApplicationSlayerBonus.
+            target.W_DamageType = DamageType.Bludgeon;
+            target.SlayerCreatureType = source.SlayerCreatureType;
+            target.SlayerDamageBonus = GetCumulativeSlayerBonus(newApplyCount);
+
+            // Completely replaces the original name (prefix/suffix/material and all) - per request,
+            // the transformed weapon should read as "Black Death <Type>" regardless of what it was.
+            target.Name = $"Black Death {appearance.DisplayName}";
+
+            // Replaces whatever icon overlay(s) the original weapon had (elemental glows, boosts,
+            // etc.) with just the plain Magical sparkle, regardless of the target's other mods.
+            target.UiEffects = ACE.Entity.Enum.UiEffects.Magical;
+        }
+        else
+        {
+            // No type-matched set for this relic - fall back to a simple 1:1 copy of the relic's
+            // own appearance, regardless of target type. No Slayer stacking here - a future relic
+            // without a dictionary entry just uses its own flat SlayerDamageBonus every time, same
+            // as before this feature.
+            target.SetupTableId = source.SetupTableId;
+            target.SoundTableId = source.SoundTableId;
+            target.IconId = source.IconId;
+            target.PaletteBaseId = source.PaletteBaseId;
+            target.ClothingBase = source.ClothingBase;
+            target.PhysicsTableId = source.PhysicsTableId;
+            target.Shade = source.Shade;
+            target.Shade2 = source.Shade2;
+            target.Shade3 = source.Shade3;
+            target.Shade4 = source.Shade4;
+
+            target.SlayerCreatureType = source.SlayerCreatureType;
+            target.SlayerDamageBonus = source.SlayerDamageBonus;
+        }
+
+        // Only appended once - re-applying wouldn't add anything new to say, and would just repeat
+        // the same paragraph up to 5 times.
+        if (priorApplyCount == 0)
+        {
+            target.LongDesc = string.IsNullOrEmpty(target.LongDesc) ? source.LongDesc : $"{target.LongDesc}\n\n{source.LongDesc}";
+        }
+
+        target.WeaponRelicApplyCount = newApplyCount;
+    }
+}

--- a/apps/server/WorldObjects/WorldObject_Magic.cs
+++ b/apps/server/WorldObjects/WorldObject_Magic.cs
@@ -1965,18 +1965,22 @@ partial class WorldObject
 
         if (targetCreature != null && projectileSpellType == ProjectileSpellType.Blast)
         {
+            var blastRadius = spell.Id == (uint)SpellId.OlthoiQueenAcidSpray ? 1000 : 10;
             List<Creature> nearbyTargets;
-            const int blastRadius = 10;
             nearbyTargets = this is Player ? targetCreature.GetNearbyMonsters(blastRadius) : targetCreature.GetNearbyPlayers(blastRadius);
 
             var blastTargets = new List<Creature> { targetCreature };
+
+            // Max ADDITIONAL targets beyond the primary - i.e. total targets hit caps at
+            // spell.NumProjectiles (the DB-set projectile count), not a fixed retail value.
+            var maxExtraBlastTargets = Math.Max(0, spell.NumProjectiles - 1);
 
             if (nearbyTargets != null)
             {
                 var blastCount = 0;
                 foreach (var nearbyTarget in nearbyTargets)
                 {
-                    if (blastCount == 2)
+                    if (blastCount >= maxExtraBlastTargets)
                     {
                         break;
                     }
@@ -1986,7 +1990,11 @@ partial class WorldObject
                         continue;
                     }
 
-                    var angle = targetCreature.GetAngle(nearbyTarget);
+                    // In front of the CASTER's own facing, not the primary target's facing - a
+                    // player's orientation relative to their neighbors has nothing to do with
+                    // where the caster is aiming, which was making this look like it fired in
+                    // random directions once the radius was widened for Acid Spray.
+                    var angle = (caster ?? targetCreature).GetAngle(nearbyTarget);
                     if (Math.Abs(angle) > Creature.CleaveAngle / 4.0f)
                     {
                         continue;
@@ -1995,16 +2003,6 @@ partial class WorldObject
                     blastTargets.Add(nearbyTarget);
                     blastCount++;
                 }
-            }
-
-            if (blastTargets.Count >= 3)
-            {
-                spell.SpellPowerMod = 0.67f;
-            }
-
-            if (blastTargets.Count == 2)
-            {
-                spell.SpellPowerMod = 0.75f;
             }
 
             foreach (var blastTarget in blastTargets)

--- a/apps/server/WorldObjects/WorldObject_Properties.cs
+++ b/apps/server/WorldObjects/WorldObject_Properties.cs
@@ -7283,6 +7283,22 @@ partial class WorldObject
         }
     }
 
+    public int? WeaponRelicApplyCount
+    {
+        get => GetProperty(PropertyInt.WeaponRelicApplyCount);
+        set
+        {
+            if (!value.HasValue)
+            {
+                RemoveProperty(PropertyInt.WeaponRelicApplyCount);
+            }
+            else
+            {
+                SetProperty(PropertyInt.WeaponRelicApplyCount, value.Value);
+            }
+        }
+    }
+
     public bool? BossKillXpReward
     {
         get => GetProperty(PropertyBool.BossKillXpReward);

--- a/libs/entity/Enum/EmoteType.cs
+++ b/libs/entity/Enum/EmoteType.cs
@@ -160,5 +160,34 @@ public enum EmoteType
     /// Heals the emote's own WorldObject (must be a Creature) by an amount.
     /// Amount = fixed heal amount. Min/Max = inclusive random range (overrides Amount when both are set).
     /// </summary>
-    HealSelf = 10020
+    HealSelf = 10020,
+
+    /// <summary>
+    /// Randomly reschedules the emote's own WorldObject's next HeartBeat tick, by directly
+    /// setting the in-memory NextHeartbeatTime field (WorldObject_Tick.cs) to now + a random
+    /// offset. Min/Max = inclusive random offset range in seconds.
+    ///
+    /// Exists because HeartbeatTimestamp/HeartbeatInterval alone can't desync multiple
+    /// instances of the same weenie that all get activated by the same broadcast signal at
+    /// the same moment (e.g. several identical landblock fixtures reacting to one LocalSignal)
+    /// - NextHeartbeatTime is a runtime-only field recomputed from "now" at load time (with
+    /// only a small built-in 0-5s spread) and is never re-derived from the saved
+    /// HeartbeatTimestamp property afterward, so writing that property via StampMyQuest-style
+    /// emotes has no effect on actual tick scheduling.
+    /// </summary>
+    JitterNextHeartbeat = 10021,
+
+    /// <summary>
+    /// Sets the emote's own WorldObject's IsHot property (PropertyBool.IsHot) to true, if the
+    /// WorldObject is a Hotspot.
+    ///
+    /// Exists because the built-in SetBoolStat/SetMyBoolStat emotes only operate on Player or
+    /// Creature WorldObjects respectively (see EmoteManager.cs) - a Hotspot is neither, so
+    /// there was no data-driven way to flip a Hotspot's damage on after it already exists.
+    /// Hotspot.IsHot is read fresh from the property store on every collision tick (see
+    /// Hotspot.cs Activate()), so a Hotspot can be spawned inert (no IsHot set, purely visual)
+    /// and then have this fired after a delay once its spawn-in animation has finished, without
+    /// needing to destroy/respawn the object.
+    /// </summary>
+    ActivateHotspot = 10022
 }

--- a/libs/entity/Enum/Properties/PropertyBool.cs
+++ b/libs/entity/Enum/Properties/PropertyBool.cs
@@ -314,6 +314,15 @@ public enum PropertyBool : ushort
 
     [ServerOnly]
     VendorSellsSpecialItems = 9014,
+
+    /// <summary>
+    /// Opt-in for Hotspot.OnCollideObject's custom PhysicsObj.is_touching() check: treats this
+    /// object's placement position as the CENTER of its CylSphere collision height rather than
+    /// the base, shifting the whole collision volume down by Height/2. Unset/false preserves the
+    /// stock base-anchored behavior for every other object.
+    /// </summary>
+    [ServerOnly]
+    HotspotCollidesFromCenter = 9015,
 }
 
 public static class PropertyBoolExtensions

--- a/libs/entity/Enum/Properties/PropertyFloat.cs
+++ b/libs/entity/Enum/Properties/PropertyFloat.cs
@@ -258,6 +258,12 @@ public enum PropertyFloat : ushort
     DestabVarPercent = 205,
 
     [ServerOnly]
+    HomesickGracePeriod = 206,
+
+    [ServerOnly]
+    BonusHealthRegenPerTick = 207,
+
+    [ServerOnly]
     PCAPRecordedWorkmanship = 8004,
 
     [ServerOnly]

--- a/libs/entity/Enum/Properties/PropertyInt.cs
+++ b/libs/entity/Enum/Properties/PropertyInt.cs
@@ -889,6 +889,9 @@ public enum PropertyInt : ushort
     TargetSpecificWcid = 522,
 
     [ServerOnly]
+    WeaponRelicApplyCount = 523,
+
+    [ServerOnly]
     PCAPRecordedAutonomousMovement = 8007,
 
     [ServerOnly]

--- a/libs/entity/Enum/SpellCategory.cs
+++ b/libs/entity/Enum/SpellCategory.cs
@@ -841,4 +841,5 @@ public enum SpellCategory : uint
     CookFoodLifeMagic = 843,
     CookFoodWarMagic = 844,
     CookFoodThievery = 845,
+    OlthoiQueenAcidVulnerability = 846,
 }

--- a/libs/entity/Enum/SpellId.cs
+++ b/libs/entity/Enum/SpellId.cs
@@ -6841,6 +6841,7 @@ public enum SpellId : uint
     CookFoodThievery8,
     CookFoodThievery9,
     CookFoodThievery10,
+    OlthoiQueenAcidVulnerability,
 
     NumSpells = 8192,
 

--- a/libs/entity/Enum/WeenieType.cs
+++ b/libs/entity/Enum/WeenieType.cs
@@ -94,5 +94,6 @@ public enum WeenieType : uint
     Destabilizer,
     BlankScroll,
     SpellDust,
-    ScribingTable
+    ScribingTable,
+    WeaponRelic
 }

--- a/libs/entity/Models/WeenieExtensions.cs
+++ b/libs/entity/Models/WeenieExtensions.cs
@@ -211,6 +211,7 @@ public static class WeenieExtensions
             case WeenieType.UpgradeKit:
             case WeenieType.TrophySolvent:
             case WeenieType.BezelTool:
+            case WeenieType.WeaponRelic:
 
                 return true;
         }


### PR DESCRIPTION
## Summary

Server-side engine support for the **Young Olthoi Queen** raid encounter (paired `world-db` PR). Two commits: general engine support, and a follow-up hotspot-collision opt-in.

## New content-facing hooks

- **`JitterNextHeartbeat`** emote (10021) and **`ActivateHotspot`** emote (10022) — `EmoteType.cs` / `EmoteManager.cs`. The first reseeds a WorldObject's `NextHeartbeatTime` with a random offset, needed because that field is runtime-only and never re-derived from the saved `HeartbeatTimestamp` property, so several identical fixtures activated by the same broadcast would otherwise tick in lockstep forever. The second flips a `Hotspot`'s `IsHot` on after a delay — the existing `SetBoolStat`/`SetMyBoolStat` emotes only work on `Player`/`Creature`, so there was no data-driven way to arm a Hotspot after spawn.
- **`HomesickGracePeriod`** (`PropertyFloat` 206, `Monster_Awareness.cs`) — optional delay before a monster gives up and leashes (`MoveToHome`/`Homesick`) after losing all attack targets, cancelled if a target reappears in time. Avoids false-positive resets from a brief target loss (e.g. a player's short stealth effect) being treated the same as a genuine wipe.
- **`BonusHealthRegenPerTick`** (`PropertyFloat` 207, `Creature_Vitals.cs`) — flat, content-settable addition to a creature's per-tick health regen, applied in `VitalHeartBeat()` so it runs unconditionally every ~5s regardless of combat/awake state (unlike the `HeartBeat` emote category, which the engine silently skips for any awake, non-patrolling creature).
- **`HotspotCollidesFromCenter`** (`PropertyBool` 9015, `Hotspot.cs` + `PhysicsObj.cs`) — opt-in flag that treats a Hotspot's placement as the center of its `CylSphere` collision height rather than the base, shifting the collision volume down by `Height/2`. Built for the rising acid pool, whose collision top would otherwise reach the mushroom platforms above it at higher tiers.

## Bug fixes

- **`LocalSignal` reentrancy** (`EmoteManager.cs OnLocalSignal`) — incoming signals now dispatch with `nested:true`. Previously any object whose own action chain looped back to itself via a broadcast (directly, or through another object) would silently drop that incoming signal every time, with no error, because `ExecuteEmoteSet`'s busy-gate (`if (IsBusy && !nested) return false;`) doesn't distinguish "genuinely reentrant nested dispatch" from "an unrelated external event that happens to arrive while I'm mid-processing something else." `HeartBeat`/`Taunt`/`WoundedTaunt`/`ReceiveCritical` keep their existing gating unchanged — only the incoming-signal path is affected. General engine fix, not encounter-specific.
- **Wide-radius AoE blast** (`WorldObject_Magic.cs HandleCastSpell_Projectile`) — blast radius and max extra targets were hardcoded (`10` units, `2` extra targets, fixed power falloff at 2/3 targets). Now driven by `spell.NumProjectiles` and gated only by radius, and the blast-target angle check now uses the **caster's** own facing instead of the primary target's — the old code aimed relative to the target, which looked like it fired in random directions once tested at a wider radius. Needed for the Queen's Acid Spray, an effectively room-wide AoE (`blastRadius = 1000` when `spell.Id == OlthoiQueenAcidSpray`), and fixes a latent bug that would've misfired at any radius wider than the old hardcoded value.
- **Null-safety** (`Monster_Navigation.cs Movement()`) — `PhysicsObj.MovementManager?.MoveToManager?.FailProgressCount` guarded against null.

## New raid reward system: `WeaponRelic`

New `WeenieType` (`WeenieType.cs`, `WorldObjectFactory.cs`, `Confirmation.cs`, `WeenieExtensions.cs`) backed by a new ~670-line `WeaponRelic.cs`. Used on a compatible weapon, it permanently re-skins the target to match the relic's own reward set (donor model picked per the target's *own* weapon type, so one relic WCID covers every lootgen weapon type), forces the target's damage type to Bludgeon, and grants a stacking Slayer bonus (up to 5 applications) via the same native `SlayerCreatureType`/`SlayerDamageBonus` properties the loot generator already uses — no combat-code changes needed for the bonus itself to function. Backs the raid's actual reward item on the `world-db` side (`1034443`, "Olthoi Queen Claw"). Appearance data sourced from the official ACE-World-16PY-Patches repo after the more commonly-used treestats.net reference data was confirmed not to match this project's own `base.sql`.
- `AppraiseInfo.cs` gained `SetSlayerUseLongText` so items with a Slayer bonus show it in their tooltip — needed for the relic's bonus to be visible to players.
- `PropertyInt.WeaponRelicApplyCount` (523) tracks applications per weapon.

## New spell/enchantment

`OlthoiQueenAcidVulnerability` (`SpellId.cs`, `SpellCategory.cs`) registered as a stackable Olthoi-family debuff in `AddEnchantmentResult.cs`'s enchantment-stacking list, alongside the existing Olthoi debuff spells.

## Dungeon registration

`Landblock.cs` — "Olthoi Queen's Lair" (`0xC7B7`, `0x1AFA`-`0x1AFE`) added to the existing capstone-dungeon-instance-picking list and the fellowship-required landblock list, matching how other raid dungeons rotate between 6 landblock instances per fellowship.

## Test plan

- [ ] Full Olthoi Queen encounter walkthrough (paired with the `world-db` PR) - phase transitions, acid tiers, wave/grub spawns, wipe/reset all functioning
- [ ] Acid Spray hits multiple nearby players in the correct cone relative to the Queen's facing, not scattered randomly
- [ ] Apply a Weapon Relic to weapons of several different types (melee, missile, caster) and confirm correct donor appearance + Slayer bonus per type, up to 5 stacks
- [ ] Slayer tooltip text renders correctly on a relic'd weapon
- [ ] Existing dungeons using `HeartBeat`/`Taunt`/`WoundedTaunt`/`ReceiveCritical` unaffected by the `OnLocalSignal` nested-dispatch change (regression check on the busy-gating change)
- [ ] Existing blast spells (non-Acid-Spray) unaffected by the generalized blast-radius/target-count logic
