### PR TITLE
fix: prevent NRE crash in threat tick for non-monster creatures

### DIFF
--- a/apps/server/WorldObjects/Monster_Awareness.cs
+++ b/apps/server/WorldObjects/Monster_Awareness.cs
@@ -339,6 +339,11 @@ partial class Creature
     /// </summary>
     private void TickDownAllTargetThreatLevels()
     {
+        if (ThreatLevel == null || ThreatLevel.Count == 0)
+        {
+            return;
+        }
+
         var totalThreat = 0;
         foreach (var kvp in ThreatLevel)
         {


### PR DESCRIPTION
TickDownAllTargetThreatLevels() unconditionally iterated ThreatLevel, but that dictionary is only initialized when IsMonster is true. Non-combat Creature-typed weenies (Attackable=false, no TargetingTactic — e.g. the ON Patrol controllers/generators/supply crate) have IsMonster=false, so ThreatLevel stays null. Once such an object becomes awake and ticks, this threw a NullReferenceException and crashed the server.

Add the same null/empty guard already used elsewhere in this file for ThreatLevel, and short-circuit on an empty dictionary to avoid a division-by-zero on ThreatGainedSinceLastTick for freshly-spawned monsters with no threat entries yet.